### PR TITLE
closes #56: remove WebApplicationException from the error responses

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/exception/WebApplicationExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/exception/WebApplicationExceptionMapper.java
@@ -1,0 +1,18 @@
+package io.stargate.sgv2.jsonapi.api.exception;
+
+import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.exception.mappers.ThrowableCommandResultSupplier;
+import javax.ws.rs.WebApplicationException;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+/** Tries to omit the `WebApplicationException` and just report the cause. */
+public class WebApplicationExceptionMapper {
+
+  @ServerExceptionMapper
+  public RestResponse<CommandResult> genericExceptionMapper(WebApplicationException e) {
+    Throwable toReport = null != e.getCause() ? e.getCause() : e;
+    CommandResult commandResult = new ThrowableCommandResultSupplier(toReport).get();
+    return RestResponse.ok(commandResult);
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
@@ -60,9 +60,7 @@ class CollectionResourceIntegrationTest extends CqlEnabledIntegrationTestBase {
           .then()
           .statusCode(200)
           .body("errors[0].message", is(not(blankString())))
-          .body("errors[0].exceptionClass", is("WebApplicationException"))
-          .body("errors[1].message", is(not(blankString())))
-          .body("errors[1].exceptionClass", is("JsonParseException"));
+          .body("errors[0].exceptionClass", is("JsonParseException"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResourceIntegrationTest.java
@@ -90,18 +90,18 @@ class GeneralResourceIntegrationTest extends CqlEnabledIntegrationTestBase {
     public final void withReplicationFactor() {
       String json =
           """
-              {
-                "createNamespace": {
-                  "name": "%s",
-                  "options": {
-                    "replication": {
-                      "class": "SimpleStrategy",
-                      "replication_factor": 2
-                    }
-                  }
+          {
+            "createNamespace": {
+              "name": "%s",
+              "options": {
+                "replication": {
+                  "class": "SimpleStrategy",
+                  "replication_factor": 2
                 }
               }
-              """
+            }
+          }
+          """
               .formatted(DB_NAME);
 
       given()
@@ -119,11 +119,11 @@ class GeneralResourceIntegrationTest extends CqlEnabledIntegrationTestBase {
     public void invalidCommand() {
       String json =
           """
-              {
-                "createNamespace": {
-                }
-              }
-              """;
+          {
+            "createNamespace": {
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -167,20 +167,18 @@ class GeneralResourceIntegrationTest extends CqlEnabledIntegrationTestBase {
           .then()
           .statusCode(200)
           .body("errors[0].message", is(not(blankString())))
-          .body("errors[0].exceptionClass", is("WebApplicationException"))
-          .body("errors[1].message", is(not(blankString())))
-          .body("errors[1].exceptionClass", is("JsonParseException"));
+          .body("errors[0].exceptionClass", is("JsonParseException"));
     }
 
     @Test
     public void unknownCommand() {
       String json =
           """
-                  {
-                    "unknownCommand": {
-                    }
-                  }
-                  """;
+          {
+            "unknownCommand": {
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResourceIntegrationTest.java
@@ -85,9 +85,7 @@ class NamespaceResourceIntegrationTest extends CqlEnabledIntegrationTestBase {
           .then()
           .statusCode(200)
           .body("errors[0].message", is(not(blankString())))
-          .body("errors[0].exceptionClass", is("WebApplicationException"))
-          .body("errors[1].message", is(not(blankString())))
-          .body("errors[1].exceptionClass", is("JsonParseException"));
+          .body("errors[0].exceptionClass", is("JsonParseException"));
     }
 
     @Test


### PR DESCRIPTION
I tried to simulate any further deserialization exceptions, but was not able to (see https://github.com/stargate/jsonapi/issues/56#issuecomment-1431518067). Thus I simply removed `WebApplicationException` from the responses as requested by @maheshrajamani.