### PR TITLE
Fix #106: shred atomic values into "array_contains" too

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/JsonPath.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/JsonPath.java
@@ -140,9 +140,7 @@ public final class JsonPath implements Comparable<JsonPath> {
       this.inArray = inArray;
     }
 
-    /**
-     * Factory method used to construct a builder for elements of an Array value
-     */
+    /** Factory method used to construct a builder for elements of an Array value */
     public Builder nestedArrayBuilder() {
       // Must not be called unless we are pointing to a property or element:
       if (childPath == null) {
@@ -151,9 +149,7 @@ public final class JsonPath implements Comparable<JsonPath> {
       return new Builder(childPath, true);
     }
 
-    /**
-     * Factory method used to construct a builder for properties of an Object value
-     */
+    /** Factory method used to construct a builder for properties of an Object value */
     public Builder nestedObjectBuilder() {
       // Must not be called unless we are pointing to a property or element:
       if (childPath == null) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/JsonPath.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/JsonPath.java
@@ -140,6 +140,9 @@ public final class JsonPath implements Comparable<JsonPath> {
       this.inArray = inArray;
     }
 
+    /**
+     * Factory method used to construct a builder for elements of an Array value
+     */
     public Builder nestedArrayBuilder() {
       // Must not be called unless we are pointing to a property or element:
       if (childPath == null) {
@@ -148,6 +151,9 @@ public final class JsonPath implements Comparable<JsonPath> {
       return new Builder(childPath, true);
     }
 
+    /**
+     * Factory method used to construct a builder for properties of an Object value
+     */
     public Builder nestedObjectBuilder() {
       // Must not be called unless we are pointing to a property or element:
       if (childPath == null) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/ShredListener.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/ShredListener.java
@@ -9,9 +9,9 @@ import java.math.BigDecimal;
  * processing. Callbacks are called in document order when traversing the input document.
  */
 public interface ShredListener {
-  void shredObject(JsonPath.Builder pathBuilder, ObjectNode obj);
+  void shredObject(JsonPath path, ObjectNode obj);
 
-  void shredArray(JsonPath.Builder pathBuilder, ArrayNode arr);
+  void shredArray(JsonPath path, ArrayNode arr);
 
   void shredText(JsonPath path, String text);
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -126,11 +126,11 @@ public class Shredder {
     if (value.isObject()) {
       ObjectNode ob = (ObjectNode) value;
       callback.shredObject(pathBuilder, ob);
-      traverseObject(ob, callback, pathBuilder.nestedValueBuilder());
+      traverseObject(ob, callback, pathBuilder.nestedObjectBuilder());
     } else if (value.isArray()) {
       ArrayNode arr = (ArrayNode) value;
       callback.shredArray(pathBuilder, arr);
-      traverseArray(arr, callback, pathBuilder.nestedValueBuilder());
+      traverseArray(arr, callback, pathBuilder.nestedArrayBuilder());
     } else if (value.isTextual()) {
       callback.shredText(pathBuilder.build(), value.textValue());
     } else if (value.isNumber()) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -123,22 +123,23 @@ public class Shredder {
   }
 
   private void traverseValue(JsonNode value, ShredListener callback, JsonPath.Builder pathBuilder) {
+    final JsonPath path = pathBuilder.build();
     if (value.isObject()) {
       ObjectNode ob = (ObjectNode) value;
-      callback.shredObject(pathBuilder, ob);
+      callback.shredObject(path, ob);
       traverseObject(ob, callback, pathBuilder.nestedObjectBuilder());
     } else if (value.isArray()) {
       ArrayNode arr = (ArrayNode) value;
-      callback.shredArray(pathBuilder, arr);
+      callback.shredArray(path, arr);
       traverseArray(arr, callback, pathBuilder.nestedArrayBuilder());
     } else if (value.isTextual()) {
-      callback.shredText(pathBuilder.build(), value.textValue());
+      callback.shredText(path, value.textValue());
     } else if (value.isNumber()) {
-      callback.shredNumber(pathBuilder.build(), value.decimalValue());
+      callback.shredNumber(path, value.decimalValue());
     } else if (value.isBoolean()) {
-      callback.shredBoolean(pathBuilder.build(), value.booleanValue());
+      callback.shredBoolean(path, value.booleanValue());
     } else if (value.isNull()) {
-      callback.shredNull(pathBuilder.build());
+      callback.shredNull(path);
     } else {
       throw new JsonApiException(
           ErrorCode.SHRED_UNRECOGNIZED_NODE_TYPE,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/WritableShreddedDocument.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/WritableShreddedDocument.java
@@ -110,8 +110,7 @@ public record WritableShreddedDocument(
      */
 
     @Override
-    public void shredObject(JsonPath.Builder pathBuilder, ObjectNode obj) {
-      final JsonPath path = pathBuilder.build();
+    public void shredObject(JsonPath path, ObjectNode obj) {
       addKey(path);
 
       if (subDocEquals == null) {
@@ -121,8 +120,7 @@ public record WritableShreddedDocument(
     }
 
     @Override
-    public void shredArray(JsonPath.Builder pathBuilder, ArrayNode arr) {
-      final JsonPath path = pathBuilder.build();
+    public void shredArray(JsonPath path, ArrayNode arr) {
       addKey(path);
       if (arraySize == null) { // all initialized the first time one needed
         arraySize = new HashMap<>();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/JsonPathTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/JsonPathTest.java
@@ -13,6 +13,7 @@ public class JsonPathTest {
     @Test
     public void rootPropertyPathViaBuilder() {
       JsonPath.Builder b = JsonPath.rootBuilder();
+      assertThat(b).hasFieldOrPropertyWithValue("inArray", false);
 
       // Special case first: should not be used for anything but if it is,
       // has to result in "empty" (
@@ -20,6 +21,7 @@ public class JsonPathTest {
 
       // But more importantly can handle Object paths
       b.property("a");
+      assertThat(b).hasFieldOrPropertyWithValue("inArray", false);
       assertThat(b.build().toString()).isEqualTo("a");
       b.property("b2");
       assertThat(b.build().toString()).isEqualTo("b2");
@@ -30,41 +32,34 @@ public class JsonPathTest {
     }
 
     @Test
-    public void rootArrayPathViaBuilder() {
-      JsonPath.Builder b = JsonPath.rootBuilder();
-      b.index(0);
-      assertThat(b.build().toString()).isEqualTo("0");
-      b.index(1);
-      assertThat(b.build().toString()).isEqualTo("1");
-      b.index(999);
-      assertThat(b.build().toString()).isEqualTo("999");
-    }
-
-    @Test
     public void nestedPropertyPathViaBuilder() {
       JsonPath.Builder b = JsonPath.rootBuilder();
       b.property("props");
-      JsonPath.Builder b2 = b.nestedValueBuilder();
-
+      assertThat(b).hasFieldOrPropertyWithValue("inArray", false);
+      JsonPath.Builder b2 = b.nestedObjectBuilder();
+      assertThat(b2).hasFieldOrPropertyWithValue("inArray", false);
       assertThat(b2.property("propX").build().toString()).isEqualTo("props.propX");
-      assertThat(b2.index(12).build().toString()).isEqualTo("props.12");
+
+      JsonPath.Builder b3 = b.nestedArrayBuilder().index(12);
+      assertThat(b3).hasFieldOrPropertyWithValue("inArray", true);
+      assertThat(b3.build().toString()).isEqualTo("props.12");
       assertThat(b2.property("with.dot").build().toString()).isEqualTo("props.with.dot");
     }
 
     @Test
-    public void nestedIndexPathViaBuilder() {
+    public void nestedArrayPathViaBuilder() {
       JsonPath.Builder b = JsonPath.rootBuilder();
       b.property("arrays");
-      JsonPath.Builder b2 = b.nestedValueBuilder().index(5).nestedValueBuilder();
+      JsonPath.Builder b2 = b.nestedArrayBuilder().index(5).nestedArrayBuilder();
       assertThat(b2.build().toString()).isEqualTo("arrays.5");
       assertThat(b2.index(9).build().toString()).isEqualTo("arrays.5.9");
 
       // Builders are stateful so 'b3' has its last configuration that we can use:
-      JsonPath.Builder b3 = b2.nestedValueBuilder().property("leaf").nestedValueBuilder();
+      JsonPath.Builder b3 = b2.nestedObjectBuilder().property("leaf");
       assertThat(b3.build().toString()).isEqualTo("arrays.5.9.leaf");
 
       b.property("arr[0]");
-      b2 = b.nestedValueBuilder().index(3).nestedValueBuilder();
+      b2 = b.nestedArrayBuilder().index(3);
       assertThat(b2.build().toString()).isEqualTo("arr[0].3");
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
@@ -52,8 +52,8 @@ public class ShredderTest {
               JsonPath.from("_id"),
               JsonPath.from("name"),
               JsonPath.from("values"),
-              JsonPath.from("values.0"),
-              JsonPath.from("values.1"),
+              JsonPath.from("values.0", true),
+              JsonPath.from("values.1", true),
               JsonPath.from("[extra.stuff]"),
               JsonPath.from("nullable"));
 
@@ -65,7 +65,12 @@ public class ShredderTest {
           .hasSize(1)
           .containsEntry(JsonPath.from("values"), Integer.valueOf(2));
       assertThat(doc.arrayEquals()).hasSize(1);
-      assertThat(doc.arrayContains()).hasSize(2);
+
+      // We have 2 from array, plus 3 main level properties (_id excluded)
+      assertThat(doc.arrayContains()).hasSize(5);
+      assertThat(doc.arrayContains())
+          .containsExactlyInAnyOrder(
+              "name SBob", "values N1", "values N2", "[extra.stuff] B1", "nullable Z");
 
       // Also, the document should be the same, including _id:
       JsonNode jsonFromShredded = objectMapper.readTree(doc.docJson());
@@ -78,8 +83,8 @@ public class ShredderTest {
       assertThat(doc.queryBoolValues())
           .isEqualTo(Collections.singletonMap(JsonPath.from("[extra.stuff]"), Boolean.TRUE));
       Map<JsonPath, BigDecimal> expNums = new LinkedHashMap<>();
-      expNums.put(JsonPath.from("values.0"), BigDecimal.valueOf(1));
-      expNums.put(JsonPath.from("values.1"), BigDecimal.valueOf(2));
+      expNums.put(JsonPath.from("values.0", true), BigDecimal.valueOf(1));
+      expNums.put(JsonPath.from("values.1", true), BigDecimal.valueOf(2));
       assertThat(doc.queryNumberValues()).isEqualTo(expNums);
       assertThat(doc.queryTextValues())
           .isEqualTo(Map.of(JsonPath.from("_id"), "abc", JsonPath.from("name"), "Bob"));
@@ -107,7 +112,8 @@ public class ShredderTest {
       assertThat(doc.existKeys()).isEqualTo(new HashSet<>(expPaths));
       assertThat(doc.arraySize()).isEmpty();
       assertThat(doc.arrayEquals()).isEmpty();
-      assertThat(doc.arrayContains()).isEmpty();
+      // 2 non-doc-id main-level properties with hashes:
+      assertThat(doc.arrayContains()).containsExactlyInAnyOrder("age N39", "name SChuck");
       assertThat(doc.subDocEquals()).hasSize(0);
 
       // Also, the document should be the same, including _id added:
@@ -143,6 +149,12 @@ public class ShredderTest {
       JsonNode jsonFromShredded = objectMapper.readTree(doc.docJson());
       assertThat(jsonFromShredded).isEqualTo(inputDoc);
 
+      assertThat(doc.arraySize()).isEmpty();
+      assertThat(doc.arrayEquals()).isEmpty();
+      // 1 non-doc-id main-level property
+      assertThat(doc.arrayContains()).containsExactlyInAnyOrder("name SBob");
+      assertThat(doc.subDocEquals()).hasSize(0);
+
       assertThat(doc.queryBoolValues()).isEqualTo(Map.of(JsonPath.from("_id"), Boolean.TRUE));
       assertThat(doc.queryNullValues()).isEmpty();
       assertThat(doc.queryNumberValues()).isEmpty();
@@ -163,6 +175,12 @@ public class ShredderTest {
 
       JsonNode jsonFromShredded = objectMapper.readTree(doc.docJson());
       assertThat(jsonFromShredded).isEqualTo(inputDoc);
+
+      assertThat(doc.arraySize()).isEmpty();
+      assertThat(doc.arrayEquals()).isEmpty();
+      // 1 non-doc-id main-level property
+      assertThat(doc.arrayContains()).containsExactlyInAnyOrder("name SBob");
+      assertThat(doc.subDocEquals()).hasSize(0);
 
       assertThat(doc.queryBoolValues()).isEmpty();
       assertThat(doc.queryNullValues()).isEmpty();


### PR DESCRIPTION
PR that adds atomic values outside of arrays (root-level, in sub-documents) into `array_contains`.

Scope of changes a bit bigger due to need to start keeping track of whether given value is a direct element of an array or not, requiring changes to `JsonPath` and `JsonPath.Builder`.
