### PR TITLE
Support dot notation with `$unset`

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/IncOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/IncOperation.java
@@ -43,7 +43,7 @@ public class IncOperation extends UpdateOperation {
   }
 
   @Override
-  public boolean updateDocument(ObjectNode doc) {
+  public boolean updateDocument(ObjectNode doc, UpdateTargetLocator targetLocator) {
     // Almost always changes, except if adding zero; need to track
     boolean modified = false;
     for (IncAction update : updates) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PopOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PopOperation.java
@@ -56,7 +56,7 @@ public class PopOperation extends UpdateOperation {
   }
 
   @Override
-  public boolean updateDocument(ObjectNode doc) {
+  public boolean updateDocument(ObjectNode doc, UpdateTargetLocator targetLocator) {
     boolean changes = false;
     for (PopAction action : actions) {
       final String path = action.path;

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PushOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PushOperation.java
@@ -125,7 +125,7 @@ public class PushOperation extends UpdateOperation {
   }
 
   @Override
-  public boolean updateDocument(ObjectNode doc) {
+  public boolean updateDocument(ObjectNode doc, UpdateTargetLocator targetLocator) {
     for (PushAction update : updates) {
       final String path = update.path;
       final JsonNode toAdd = update.value;

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/SetOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/SetOperation.java
@@ -28,7 +28,7 @@ public class SetOperation extends UpdateOperation {
   }
 
   @Override
-  public boolean updateDocument(ObjectNode doc) {
+  public boolean updateDocument(ObjectNode doc, UpdateTargetLocator targetLocator) {
     boolean modified = false;
     for (SetAction addition : additions) {
       JsonNode prev = doc.replace(addition.path, addition.value);

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UnsetOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UnsetOperation.java
@@ -1,6 +1,5 @@
 package io.stargate.sgv2.jsonapi.api.model.command.clause.update;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -27,11 +26,13 @@ public class UnsetOperation extends UpdateOperation {
   }
 
   @Override
-  public boolean updateDocument(ObjectNode doc) {
+  public boolean updateDocument(ObjectNode doc, UpdateTargetLocator targetLocator) {
     boolean modified = false;
     for (String path : paths) {
-      JsonNode prev = doc.remove(path);
-      modified |= (prev != null);
+      UpdateTarget target = targetLocator.findIfExists(doc, path);
+      if (target.removeValue() != null) {
+        modified = true;
+      }
     }
     return modified;
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateOperation.java
@@ -16,7 +16,7 @@ public abstract class UpdateOperation {
    * @param doc Document to apply operation to
    * @return True if document was modified by operation; false if not.
    */
-  public abstract boolean updateDocument(ObjectNode doc);
+  public abstract boolean updateDocument(ObjectNode doc, UpdateTargetLocator targetLocator);
 
   /**
    * Shared validation method used by {@code $set} and {@code $unset} operations to ensure they are

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateTarget.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateTarget.java
@@ -9,7 +9,31 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * update, by {@link UpdateTargetLocator}.
  */
 public record UpdateTarget(
-    String fullPath, JsonNode contextNode, JsonNode valueNode, String lastProperty, int lastIndex) {
+    /** Full path to target for error reporting purposes */
+    String fullPath,
+    /**
+     * Parent node of the value if one exists or could exist at indicated path; {@code null} if
+     * there is no complete path to parent of value node.
+     */
+    JsonNode contextNode,
+    /**
+     * Currently existing value at specified path, if any; {@code null} if not. If not {@code null}
+     * then {@code contextNode} must also be non-{@code null} and one (but not both!) of {@code
+     * lastProperty} and {@code lastIndex} must similarly exist.
+     */
+    JsonNode valueNode,
+    /**
+     * Last property name (segment) from {@code contextNode} to value that either exists or could be
+     * added as Object property. Existence means that {@code contextNode} exists and is an Object
+     * node.
+     */
+    String lastProperty,
+    /**
+     * Last Array index (non-negative) from {@code contextNode} to value that either exists or could
+     * be added as Array element; {@code -1} otherwise (context node is not Array). Existence means
+     * that {@code contextNode} exists and is an Array node.
+     */
+    int lastIndex) {
   public static UpdateTarget missingPath(String fullPath) {
     return new UpdateTarget(fullPath, null, null, null, -1);
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateTarget.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateTarget.java
@@ -1,0 +1,32 @@
+package io.stargate.sgv2.jsonapi.api.model.command.clause.update;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Definition of a target for an {@link UpdateOperation}; built from "dot path" and document to
+ * update, by {@link UpdateTargetLocator}.
+ */
+public record UpdateTarget(
+    String fullPath, JsonNode contextNode, JsonNode valueNode, String lastProperty, int lastIndex) {
+  public static UpdateTarget missingPath(String fullPath) {
+    return new UpdateTarget(fullPath, null, null, null, -1);
+  }
+
+  public static UpdateTarget pathViaArray(
+      String fullPath, JsonNode contextNode, JsonNode valueNode, int index) {
+    return new UpdateTarget(fullPath, contextNode, valueNode, null, index);
+  }
+
+  public static UpdateTarget pathViaObject(
+      String fullPath, JsonNode contextNode, JsonNode valueNode, String property) {
+    return new UpdateTarget(fullPath, contextNode, valueNode, property, -1);
+  }
+
+  public boolean hasContext() {
+    return contextNode != null;
+  }
+
+  public boolean hasValue() {
+    return valueNode != null;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateTarget.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateTarget.java
@@ -1,6 +1,8 @@
 package io.stargate.sgv2.jsonapi.api.model.command.clause.update;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Definition of a target for an {@link UpdateOperation}; built from "dot path" and document to
@@ -28,5 +30,23 @@ public record UpdateTarget(
 
   public boolean hasValue() {
     return valueNode != null;
+  }
+
+  /**
+   * Method that may be called to remove value node from its context, if there is value; value
+   * removed (if any) is returned.
+   */
+  public JsonNode removeValue() {
+    if (valueNode != null) {
+      // Either Object property or Array element, depending on context
+      if (contextNode.isObject()) {
+        ((ObjectNode) contextNode).remove(lastProperty);
+      } else {
+        // Important: to avoid changing indexes of other entries, MUST insert 'null' value
+        // (case where index is past end do not have valueNode)
+        ((ArrayNode) contextNode).setNull(lastIndex);
+      }
+    }
+    return valueNode;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateTargetLocator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateTargetLocator.java
@@ -1,0 +1,102 @@
+package io.stargate.sgv2.jsonapi.api.model.command.clause.update;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import java.util.regex.Pattern;
+import javax.enterprise.context.ApplicationScoped;
+
+/** Factory for {@link UpdateTarget} instances. */
+@ApplicationScoped
+public class UpdateTargetLocator {
+  private static final Pattern DOT = Pattern.compile(Pattern.quote("."));
+
+  private static final Pattern INDEX_SEGMENT = Pattern.compile("0|[1-9][0-9]*");
+
+  /**
+   * Method that will create target instance for given path through given document; if no such path
+   * exists, will not attempt to create path (nor report any problems).
+   *
+   * <p>Used for $unset operation.
+   *
+   * @param document Document that may contain target path
+   * @param dotPath Path that points to possibly existing target
+   * @return Target instance with optional target and context nodes
+   */
+  public UpdateTarget findIfExists(JsonNode document, String dotPath) {
+    String[] segments = splitAndVerify(dotPath);
+    JsonNode context = document;
+    final int lastSegmentIndex = segments.length - 1;
+
+    // First traverse all but the last segment
+    for (int i = 0; i < lastSegmentIndex; ++i) {
+      final String segment = segments[i];
+      // Simple logic: Object nodes traversed via property; Arrays index; others can't
+      if (context.isObject()) {
+        context = context.get(segment);
+      } else if (context.isArray()) {
+        int index = findIndexFromSegment(segment);
+        // Arrays MUST be accessed via index but here mismatch will not result
+        // in exception (as having path is optional).
+        context = (index < 0) ? null : context.get(index);
+      } else {
+        context = null;
+      }
+      if (context == null) {
+        return UpdateTarget.missingPath(dotPath);
+      }
+    }
+
+    // But the last segment is special since we now may get Value node but also need
+    // to denote how context refers to it (Object property vs Array index)
+    final String segment = segments[lastSegmentIndex];
+    if (context.isObject()) {
+      return UpdateTarget.pathViaObject(dotPath, context, context.get(segment), segment);
+    } else if (context.isArray()) {
+      int index = findIndexFromSegment(segment);
+      if (index < 0) {
+        return UpdateTarget.missingPath(dotPath);
+      }
+      return UpdateTarget.pathViaArray(dotPath, context, context.get(index), index);
+    } else {
+      return UpdateTarget.missingPath(dotPath);
+    }
+  }
+
+  /**
+   * Method that will create target instance for given path through given document; if no such path
+   * exists, will try to create path. Creation may fail with an exception for cases like path trying
+   * to create properties on Array nodes.
+   *
+   * <p>Used for update operations that add or modify values (operations other than $unset)
+   *
+   * @param document Document that is to contain target path
+   * @param dotPath Path that points to target that may exists, or is about to be added
+   * @return Target instance with optional target and context nodes
+   */
+  public UpdateTarget findOrCreate(JsonNode document, String dotPath) {
+    return null;
+  }
+
+  private String[] splitAndVerify(String dotPath) {
+    String[] result = DOT.split(dotPath);
+    for (String segment : result) {
+      if (segment.isEmpty()) {
+        throw new JsonApiException(
+            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH,
+            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH.getMessage()
+                + ": empty segment ('') in path '"
+                + dotPath
+                + "'");
+      }
+    }
+    return result;
+  }
+
+  private int findIndexFromSegment(String segment) {
+    if (INDEX_SEGMENT.matcher(segment).matches()) {
+      return Integer.parseInt(segment);
+    }
+    return -1;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateTargetLocator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateTargetLocator.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.util.regex.Pattern;
-import javax.enterprise.context.ApplicationScoped;
 
 /** Factory for {@link UpdateTarget} instances. */
-@ApplicationScoped
 public class UpdateTargetLocator {
   private static final Pattern DOT = Pattern.compile(Pattern.quote("."));
 
@@ -75,7 +73,7 @@ public class UpdateTargetLocator {
    * @return Target instance with optional target and context nodes
    */
   public UpdateTarget findOrCreate(JsonNode document, String dotPath) {
-    return null;
+    throw new UnsupportedOperationException("Not yet implemented");
   }
 
   private String[] splitAndVerify(String dotPath) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -38,6 +38,8 @@ public enum ErrorCode {
 
   UNSUPPORTED_UPDATE_OPERATION_PARAM("Unsupported update operation parameter"),
 
+  UNSUPPORTED_UPDATE_OPERATION_PATH("Invalid update operation path"),
+
   UNSUPPORTED_UPDATE_OPERATION_TARGET("Unsupported target JSON value for update operation"),
 
   UNSUPPORTED_UPDATE_FOR_DOC_ID("Cannot use operator with '_id' field");

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdater.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdater.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateOperation;
+import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateTargetLocator;
 import java.util.List;
 
 /** Updates the document read from the database with the updates came as part of the request. */
@@ -13,8 +14,9 @@ public record DocumentUpdater(List<UpdateOperation> updateOperations) {
   }
 
   public JsonNode applyUpdates(JsonNode readDocument) {
+    UpdateTargetLocator targetLocator = new UpdateTargetLocator();
     ObjectNode docToUpdate = (ObjectNode) readDocument;
-    updateOperations.forEach(u -> u.updateDocument(docToUpdate));
+    updateOperations.forEach(u -> u.updateDocument(docToUpdate, targetLocator));
     return readDocument;
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/IncOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/IncOperationTest.java
@@ -40,7 +40,7 @@ public class IncOperationTest extends UpdateOperationTestBase {
               """
                     { "integer" : 1, "fp" : 0.25, "text" : "value"  }
                     """);
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected =
           objectFromJson(
               """
@@ -64,7 +64,7 @@ public class IncOperationTest extends UpdateOperationTestBase {
               """
                     { "integer" : 1, "fp" : 0.25, "text" : "value"  }
                     """);
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected =
           objectFromJson(
               """
@@ -88,7 +88,7 @@ public class IncOperationTest extends UpdateOperationTestBase {
               """
                     { "integer" : 1, "fp" : 0.25, "text" : "value"  }
                     """);
-      assertThat(oper.updateDocument(doc)).isFalse();
+      assertThat(oper.updateDocument(doc, targetLocator)).isFalse();
       ObjectNode expected =
           objectFromJson(
               """
@@ -136,7 +136,7 @@ public class IncOperationTest extends UpdateOperationTestBase {
       Exception e =
           catchException(
               () -> {
-                oper.updateDocument(doc);
+                oper.updateDocument(doc, targetLocator);
               });
       assertThat(e)
           .isInstanceOf(JsonApiException.class)
@@ -161,7 +161,7 @@ public class IncOperationTest extends UpdateOperationTestBase {
       Exception e =
           catchException(
               () -> {
-                oper.updateDocument(doc);
+                oper.updateDocument(doc, targetLocator);
               });
       assertThat(e)
           .isInstanceOf(JsonApiException.class)

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/PopOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/PopOperationTest.java
@@ -29,7 +29,7 @@ public class PopOperationTest extends UpdateOperationTestBase {
           UpdateOperator.POP.resolveOperation(objectFromJson("{ \"array\" : -1 }"));
       assertThat(oper).isInstanceOf(PopOperation.class);
       ObjectNode doc = objectFromJson("{ \"a\" : 1, \"array\" : [ 1, 2, 3 ] }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected =
           objectFromJson(
               """
@@ -44,7 +44,7 @@ public class PopOperationTest extends UpdateOperationTestBase {
           UpdateOperator.POP.resolveOperation(objectFromJson("{ \"array\" : 1 }"));
       assertThat(oper).isInstanceOf(PopOperation.class);
       ObjectNode doc = objectFromJson("{ \"a\" : 1, \"array\" : [ 1, 2, 3 ] }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected =
           objectFromJson(
               """
@@ -60,7 +60,7 @@ public class PopOperationTest extends UpdateOperationTestBase {
       assertThat(oper).isInstanceOf(PopOperation.class);
       ObjectNode doc = objectFromJson("{ \"a\" : 1, \"array\" : [ ] }");
       ObjectNode expected = doc.deepCopy();
-      assertThat(oper.updateDocument(doc)).isFalse();
+      assertThat(oper.updateDocument(doc, targetLocator)).isFalse();
       assertThat(doc).isEqualTo(expected);
     }
 
@@ -71,7 +71,7 @@ public class PopOperationTest extends UpdateOperationTestBase {
       assertThat(oper).isInstanceOf(PopOperation.class);
       ObjectNode doc = objectFromJson("{ \"a\" : 1, \"array\" : [ ] }");
       ObjectNode expected = doc.deepCopy();
-      assertThat(oper.updateDocument(doc)).isFalse();
+      assertThat(oper.updateDocument(doc, targetLocator)).isFalse();
       assertThat(doc).isEqualTo(expected);
     }
 
@@ -83,7 +83,7 @@ public class PopOperationTest extends UpdateOperationTestBase {
       ObjectNode doc = objectFromJson("{ \"a\" : 1}");
       ObjectNode expected = doc.deepCopy();
       // No changes
-      assertThat(oper.updateDocument(doc)).isFalse();
+      assertThat(oper.updateDocument(doc, targetLocator)).isFalse();
       assertThat(doc).isEqualTo(expected);
     }
 
@@ -95,7 +95,7 @@ public class PopOperationTest extends UpdateOperationTestBase {
       ObjectNode doc = objectFromJson("{ \"a\" : 1}");
       ObjectNode expected = doc.deepCopy();
       // No changes
-      assertThat(oper.updateDocument(doc)).isFalse();
+      assertThat(oper.updateDocument(doc, targetLocator)).isFalse();
       assertThat(doc).isEqualTo(expected);
     }
   }
@@ -140,7 +140,7 @@ public class PopOperationTest extends UpdateOperationTestBase {
       Exception e =
           catchException(
               () -> {
-                oper.updateDocument(doc);
+                oper.updateDocument(doc, targetLocator);
               });
       assertThat(e)
           .isInstanceOf(JsonApiException.class)

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/PushOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/PushOperationTest.java
@@ -33,7 +33,7 @@ public class PushOperationTest extends UpdateOperationTestBase {
                                       """));
       assertThat(oper).isInstanceOf(PushOperation.class);
       ObjectNode doc = objectFromJson("{ \"a\" : 1, \"array\" : [ true ] }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected =
           objectFromJson(
               """
@@ -52,7 +52,7 @@ public class PushOperationTest extends UpdateOperationTestBase {
                                       """));
       assertThat(oper).isInstanceOf(PushOperation.class);
       ObjectNode doc = objectFromJson("{ \"a\" : 1, \"array\" : [ true ] }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected =
           objectFromJson(
               """
@@ -77,7 +77,7 @@ public class PushOperationTest extends UpdateOperationTestBase {
       Exception e =
           catchException(
               () -> {
-                oper.updateDocument(doc);
+                oper.updateDocument(doc, targetLocator);
               });
       assertThat(e)
           .isInstanceOf(JsonApiException.class)
@@ -142,7 +142,7 @@ public class PushOperationTest extends UpdateOperationTestBase {
                                       """));
       assertThat(oper).isInstanceOf(PushOperation.class);
       ObjectNode doc = objectFromJson("{ \"a\" : 1, \"array\" : [ true ] }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected =
           objectFromJson(
               """
@@ -161,7 +161,7 @@ public class PushOperationTest extends UpdateOperationTestBase {
                                         """));
       assertThat(oper).isInstanceOf(PushOperation.class);
       ObjectNode doc = objectFromJson("{ \"a\" : 1, \"array\" : [ true ] }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected =
           objectFromJson(
               """
@@ -180,7 +180,7 @@ public class PushOperationTest extends UpdateOperationTestBase {
                                       """));
       assertThat(oper).isInstanceOf(PushOperation.class);
       ObjectNode doc = objectFromJson("{ \"a\" : 1, \"array\" : [ null ] }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected =
           objectFromJson(
               """
@@ -199,7 +199,7 @@ public class PushOperationTest extends UpdateOperationTestBase {
                                       """));
       assertThat(oper).isInstanceOf(PushOperation.class);
       ObjectNode doc = objectFromJson("{ \"x\" : 1 }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected =
           objectFromJson(
               """
@@ -265,7 +265,7 @@ public class PushOperationTest extends UpdateOperationTestBase {
               objectFromJson("{ \"array\": { \"$each\" : [true, false], \"$position\" : 1 } }"));
       assertThat(oper).isInstanceOf(PushOperation.class);
       ObjectNode doc = objectFromJson("{ \"array\": [ 1, 2, 3, 4 ] }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected = objectFromJson("{ \"array\": [ 1, true, false, 2, 3, 4 ] }");
       assertThat(doc).isEqualTo(expected);
 
@@ -275,7 +275,7 @@ public class PushOperationTest extends UpdateOperationTestBase {
               objectFromJson("{ \"array\": { \"$each\" : [true, false], \"$position\" : 999 } }"));
       assertThat(oper).isInstanceOf(PushOperation.class);
       doc = objectFromJson("{ \"array\": [ 1, 2, 3, 4 ] }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       expected = objectFromJson("{ \"array\": [ 1, 2, 3, 4, true, false ] }");
       assertThat(doc).isEqualTo(expected);
     }
@@ -288,7 +288,7 @@ public class PushOperationTest extends UpdateOperationTestBase {
               objectFromJson("{ \"array\": { \"$each\" : [true, false], \"$position\" : -1 } }"));
       assertThat(oper).isInstanceOf(PushOperation.class);
       ObjectNode doc = objectFromJson("{ \"array\": [ 1, 2, 3, 4 ] }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected = objectFromJson("{ \"array\": [ 1, 2, 3, true, false, 4 ] }");
       assertThat(doc).isEqualTo(expected);
 
@@ -298,7 +298,7 @@ public class PushOperationTest extends UpdateOperationTestBase {
               objectFromJson("{ \"array\": { \"$each\" : [true, false], \"$position\" : -999 } }"));
       assertThat(oper).isInstanceOf(PushOperation.class);
       doc = objectFromJson("{ \"array\": [ 1, 2, 3, 4 ] }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       expected = objectFromJson("{ \"array\": [ true, false, 1, 2, 3, 4 ] }");
       assertThat(doc).isEqualTo(expected);
     }
@@ -310,7 +310,7 @@ public class PushOperationTest extends UpdateOperationTestBase {
               objectFromJson("{ \"newArray\": { \"$each\" : [true, false], \"$position\": 1 } }"));
       assertThat(oper).isInstanceOf(PushOperation.class);
       ObjectNode doc = objectFromJson("{ \"array\": [ 1, 2, 3 ] }");
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected =
           objectFromJson("{ \"array\": [ 1, 2, 3 ], \"newArray\": [true, false] }");
       assertThat(doc).isEqualTo(expected);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/SetOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/SetOperationTest.java
@@ -35,7 +35,7 @@ public class SetOperationTest extends UpdateOperationTestBase {
       assertThat(oper).isInstanceOf(SetOperation.class);
       // Should indicate document being modified
       ObjectNode doc = defaultTestDocABC();
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       assertThat(doc)
           .isEqualTo(
               fromJson(
@@ -55,7 +55,7 @@ public class SetOperationTest extends UpdateOperationTestBase {
       assertThat(oper).isInstanceOf(SetOperation.class);
       ObjectNode doc = defaultTestDocABC();
       // Will append the new property so there is modification
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       ObjectNode expected = defaultTestDocABC();
       expected.put("nosuchvalue", 1);
       assertThat(doc).isEqualTo(expected);
@@ -71,7 +71,7 @@ public class SetOperationTest extends UpdateOperationTestBase {
       assertThat(oper).isInstanceOf(SetOperation.class);
       ObjectNode doc = defaultTestDocABC();
       // No change, c was already set as true
-      assertThat(oper.updateDocument(doc)).isFalse();
+      assertThat(oper.updateDocument(doc, targetLocator)).isFalse();
       // And document should be the same as before
       assertThat(doc).isEqualTo(defaultTestDocABC());
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/UnsetOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/UnsetOperationTest.java
@@ -37,7 +37,7 @@ public class UnsetOperationTest extends UpdateOperationTestBase {
           .hasFieldOrPropertyWithValue("paths", Arrays.asList("a", "b"));
       // Should indicate document being modified
       ObjectNode doc = defaultTestDocABC();
-      assertThat(oper.updateDocument(doc)).isTrue();
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
       // and be left with just one property
       assertThat(doc)
           .isEqualTo(fromJson("""
@@ -59,7 +59,7 @@ public class UnsetOperationTest extends UpdateOperationTestBase {
           .hasFieldOrPropertyWithValue("paths", Arrays.asList("missing", "nosuchvalue"));
       ObjectNode doc = defaultTestDocABC();
       // No modifications
-      assertThat(oper.updateDocument(doc)).isFalse();
+      assertThat(oper.updateDocument(doc, targetLocator)).isFalse();
       // and be left with same as original (but get a new copy just to make sure)
       assertThat(doc).isEqualTo(defaultTestDocABC());
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/UnsetOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/UnsetOperationTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 public class UnsetOperationTest extends UpdateOperationTestBase {
   @Nested
   @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-  class happyPath {
+  class happyPathRoot {
     @Test
     public void testSimpleUnsetOfExisting() {
       // Remove 2 of 3 properties:
@@ -62,6 +62,129 @@ public class UnsetOperationTest extends UpdateOperationTestBase {
       assertThat(oper.updateDocument(doc, targetLocator)).isFalse();
       // and be left with same as original (but get a new copy just to make sure)
       assertThat(doc).isEqualTo(defaultTestDocABC());
+    }
+  }
+
+  @Nested
+  @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+  class happyPathNested {
+    @Test
+    public void testNestedPropertiesExist() {
+      ObjectNode doc =
+          objectFromJson(
+              """
+              {
+                "subdoc" : {
+                   "a": 3,
+                   "b": 5,
+                   "doc2" : {
+                      "a": 1,
+                      "c": 3
+                   }
+                },
+                "atomic" : 3,
+                "array" : [ 1, 2 ]
+              }
+              """);
+
+      // Try unset of lots of things; some exists, others not; ones that don't
+      // exists do not cause errors but are just ignored
+      UpdateOperation oper =
+          UpdateOperator.UNSET.resolveOperation(
+              objectFromJson(
+                  """
+                              {
+                                 "subdoc.a" : 1,
+                                 "subdoc.doc2.c" : 1,
+                                 "atomic.x" : 1,
+                                 "array.x" : 1
+                              }
+                              """));
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
+
+      ObjectNode exp =
+          objectFromJson(
+              """
+              {
+                "subdoc" : {
+                   "b": 5,
+                   "doc2" : {
+                      "a": 1
+                   }
+                },
+                "atomic" : 3,
+                "array" : [ 1, 2 ]
+              }
+              """);
+      assertThat(doc).isEqualTo(exp);
+    }
+
+    @Test
+    public void testNestedPropertiesNotExist() {
+      final ObjectNode orig =
+          objectFromJson(
+              """
+              {
+                "subdoc" : {
+                   "a": 3
+                 }
+               }
+              """);
+      ObjectNode doc = orig.deepCopy();
+
+      UpdateOperation oper =
+          UpdateOperator.UNSET.resolveOperation(objectFromJson("{\"subdoc.b\": 1, \"x.y\": 1 }"));
+      assertThat(oper.updateDocument(doc, targetLocator)).isFalse();
+      // and no modifications expected
+      assertThat(doc).isEqualTo(orig);
+    }
+
+    @Test
+    public void testNestedArrays() {
+      ObjectNode doc =
+          objectFromJson(
+              """
+              {
+                "array" : [ 1, 2, {
+                  "subdoc" : {
+                    "a" : [ true ]
+                  }
+                } ],
+                "atomic" : 3,
+                "array2" : [ 7, 13 ]
+              }
+              """);
+
+      // Try unset multiple things; as earlier, no errors results neither removal
+      // for non-existing things (ar even invalid paths wrt Array/Object)
+      UpdateOperation oper =
+          UpdateOperator.UNSET.resolveOperation(
+              objectFromJson(
+                  """
+                              {
+                                 "array.1" : 1,
+                                 "array.2.subdoc.a.0" : 1,
+                                 "atomic.1.prop" : 1,
+                                 "array2" : 1
+                              }
+                              """));
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
+
+      // Note: in Array values, placeholder nulls must be added (to retain index positions);
+      // but replacing WHOLE array is fine (no null left)
+      ObjectNode exp =
+          objectFromJson(
+              """
+              {
+                "array" : [ 1, null, {
+                  "subdoc" : {
+                    "a" : [ null ]
+                  }
+                } ],
+                "atomic" : 3
+              }
+              """);
+      assertThat(doc).isEqualTo(exp);
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/UpdateOperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/UpdateOperationTestBase.java
@@ -3,11 +3,14 @@ package io.stargate.sgv2.jsonapi.service.operation.model.command.clause.update;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateTargetLocator;
 import java.io.IOException;
 import javax.inject.Inject;
 
 abstract class UpdateOperationTestBase {
   @Inject protected ObjectMapper objectMapper;
+
+  protected final UpdateTargetLocator targetLocator = new UpdateTargetLocator();
 
   ObjectNode defaultTestDocABC() {
     return objectFromJson(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/UpdateTargetLocatorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/UpdateTargetLocatorTest.java
@@ -1,0 +1,94 @@
+package io.stargate.sgv2.jsonapi.service.operation.model.command.clause.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateTarget;
+import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateTargetLocator;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import javax.inject.Inject;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class UpdateTargetLocatorTest extends UpdateOperationTestBase {
+  @Inject protected UpdateTargetLocator targetLocator;
+
+  @Nested
+  @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+  class happyPathFindIfExists {
+    @Test
+    public void findRootPropertyPath() {
+      ObjectNode doc = objectFromJson("{\"a\" : 1 }");
+      UpdateTarget target = targetLocator.findIfExists(doc, "a");
+      assertThat(target.contextNode()).isSameAs(doc);
+      assertThat(target.valueNode()).isEqualTo(objectMapper.getNodeFactory().numberNode(1));
+
+      // But cannot proceed via atomic node
+      target = targetLocator.findIfExists(doc, "a.x");
+      assertThat(target.contextNode()).isNull();
+      assertThat(target.valueNode()).isNull();
+
+      // Can refer to missing property as well
+      target = targetLocator.findIfExists(doc, "unknown");
+      assertThat(target.contextNode()).isSameAs(doc);
+      assertThat(target.valueNode()).isNull();
+      assertThat(target.lastProperty()).isEqualTo("unknown");
+    }
+
+    @Test
+    public void findNestedPropertyPath() {
+      ObjectNode doc =
+          objectFromJson(
+              """
+                    {
+                      "b" : {
+                         "c" : true
+                      }
+                    }
+                    """);
+
+      // First: simple nested property:
+      UpdateTarget target = targetLocator.findIfExists(doc, "b.c");
+      assertThat(target.contextNode()).isSameAs(doc.get("b"));
+      assertThat(target.valueNode()).isEqualTo(fromJson("true"));
+      assertThat(target.lastProperty()).isEqualTo("c");
+
+      // But can also refer to its parent
+      target = targetLocator.findIfExists(doc, "b");
+      assertThat(target.contextNode()).isSameAs(doc);
+      assertThat(target.valueNode()).isEqualTo(objectFromJson("{\"c\":true}"));
+      assertThat(target.lastProperty()).isEqualTo("b");
+
+      // Or to missing property within existing Object:
+      target = targetLocator.findIfExists(doc, "b.unknown");
+      assertThat(target.contextNode()).isSameAs(doc.get("b"));
+      assertThat(target.valueNode()).isNull();
+      assertThat(target.lastProperty()).isEqualTo("unknown");
+    }
+  }
+
+  @Nested
+  @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+  class failForFindIfExists {
+    @Test
+    public void invalidEmptySegment() {
+      Exception e = catchException(() -> targetLocator.findIfExists(objectFromJson("{}"), "a..x"));
+      assertThat(e)
+          .isNotNull()
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH)
+          .hasMessage(
+              ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PATH.getMessage()
+                  + ": empty segment ('') in path 'a..x'");
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/UpdateTargetLocatorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/UpdateTargetLocatorTest.java
@@ -11,7 +11,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateTarget;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateTargetLocator;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
-import javax.inject.Inject;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,7 +19,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 @QuarkusTest
 @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 public class UpdateTargetLocatorTest extends UpdateOperationTestBase {
-  @Inject protected UpdateTargetLocator targetLocator;
+  protected UpdateTargetLocator targetLocator = new UpdateTargetLocator();
 
   @Nested
   @TestMethodOrder(MethodOrderer.OrderAnnotation.class)


### PR DESCRIPTION
**What this PR does**:

Adds support for dotted notation for `$unset` operation, along with tests

**Which issue(s) this PR fixes**:
Fixes #153

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
