### PR TITLE
Changes for FindOneAndUpdateCommand and UpdateOneCommand options support

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -104,6 +104,10 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                             "update": {
                                 "$set": {"location": "New York"},
                                 "$inc": {"count": 3}
+                            },
+                            "options" : {
+                               "returnDocument" : "before",
+                               "upsert" : true
                             }
                         }
                       }
@@ -119,6 +123,9 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                           "update": {
                               "$set": {"location": "New York"},
                               "$push": {"tags": "marathon"}
+                          },
+                          "options" : {
+                              "upsert" : true
                           }
                       }
                     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndUpdateCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndUpdateCommand.java
@@ -8,6 +8,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.FilterClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateClause;
 import javax.annotation.Nullable;
 import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(
@@ -17,7 +18,14 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 public record FindOneAndUpdateCommand(
     @Valid @JsonProperty("filter") FilterClause filterClause,
     @Valid @JsonProperty("update") UpdateClause updateClause,
-    @Nullable Options options)
+    @Valid @Nullable Options options)
     implements ReadCommand, Filterable {
-  public record Options() {}
+  public record Options(
+      @Valid
+          @Nullable
+          @Pattern(
+              regexp = "(after|before)",
+              message = "returnDocument value can only be before or after")
+          String returnDocument,
+      boolean upsert) {}
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndUpdateCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndUpdateCommand.java
@@ -25,7 +25,7 @@ public record FindOneAndUpdateCommand(
           @Nullable
           @Pattern(
               regexp = "(after|before)",
-              message = "returnDocument value can only be before or after")
+              message = "returnDocument value can only be 'before' or 'after'")
           String returnDocument,
       boolean upsert) {}
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateOneCommand.java
@@ -19,5 +19,5 @@ public record UpdateOneCommand(
     @Valid @JsonProperty("update") UpdateClause updateClause,
     @Nullable Options options)
     implements ReadCommand, Filterable {
-  public record Options() {}
+  public record Options(boolean upsert) {}
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/CountOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/CountOperation.java
@@ -11,6 +11,7 @@ import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.CountOperationPage;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.ReadDocument;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -47,5 +48,10 @@ public record CountOperation(CommandContext commandContext, List<DBFilterBase> f
   @Override
   public Uni<FindResponse> getDocuments(QueryExecutor queryExecutor) {
     return Uni.createFrom().failure(new JsonApiException(ErrorCode.UNSUPPORTED_OPERATION));
+  }
+
+  @Override
+  public ReadDocument getEmptyDocuments() {
+    throw new JsonApiException(ErrorCode.UNSUPPORTED_OPERATION);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
@@ -120,7 +120,12 @@ public interface ReadOperation extends Operation {
    */
   Uni<FindResponse> getDocuments(QueryExecutor queryExecutor);
 
-  /** @return */
+  /**
+   * A operation method which can return ReadDocument with an empty document, if the filter
+   * condition has _id filter it will return document with this field added
+   *
+   * @return
+   */
   ReadDocument getEmptyDocuments();
 
   record FindResponse(List<ReadDocument> docs, String pagingState) {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
@@ -120,6 +120,9 @@ public interface ReadOperation extends Operation {
    */
   Uni<FindResponse> getDocuments(QueryExecutor queryExecutor);
 
+  /** @return */
+  ReadDocument getEmptyDocuments();
+
   record FindResponse(List<ReadDocument> docs, String pagingState) {}
 
   record CountResponse(int count) {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
@@ -35,7 +35,13 @@ public class FindOneAndUpdateCommandResolver extends FilterableResolver<FindOneA
   public Operation resolveCommand(CommandContext ctx, FindOneAndUpdateCommand command) {
     ReadOperation readOperation = resolve(ctx, command);
     DocumentUpdater documentUpdater = DocumentUpdater.construct(command.updateClause());
-    return new ReadAndUpdateOperation(ctx, readOperation, documentUpdater, true, shredder);
+    boolean returnUpdatedDocument =
+        command.options() != null
+            && command.options().returnDocument() != null
+            && command.options().returnDocument().equals("after");
+    boolean upsert = command.options() != null && command.options().upsert();
+    return new ReadAndUpdateOperation(
+        ctx, readOperation, documentUpdater, true, returnUpdatedDocument, upsert, shredder);
   }
 
   @Override

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
@@ -36,9 +36,7 @@ public class FindOneAndUpdateCommandResolver extends FilterableResolver<FindOneA
     ReadOperation readOperation = resolve(ctx, command);
     DocumentUpdater documentUpdater = DocumentUpdater.construct(command.updateClause());
     boolean returnUpdatedDocument =
-        command.options() != null
-            && command.options().returnDocument() != null
-            && command.options().returnDocument().equals("after");
+        command.options() != null && "after".equals(command.options().returnDocument());
     boolean upsert = command.options() != null && command.options().upsert();
     return new ReadAndUpdateOperation(
         ctx, readOperation, documentUpdater, true, returnUpdatedDocument, upsert, shredder);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateOneCommandResolver.java
@@ -35,7 +35,9 @@ public class UpdateOneCommandResolver extends FilterableResolver<UpdateOneComman
   public Operation resolveCommand(CommandContext ctx, UpdateOneCommand command) {
     ReadOperation readOperation = resolve(ctx, command);
     DocumentUpdater documentUpdater = DocumentUpdater.construct(command.updateClause());
-    return new ReadAndUpdateOperation(ctx, readOperation, documentUpdater, false, shredder);
+    boolean upsert = command.options() != null && command.options().upsert();
+    return new ReadAndUpdateOperation(
+        ctx, readOperation, documentUpdater, false, false, upsert, shredder);
   }
 
   @Override

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
@@ -251,14 +251,14 @@ class ObjectMapperConfigurationTest {
     public void happyPath() throws Exception {
       String json =
           """
-                    {
-                      "findOneAndUpdate": {
-                          "filter" : {"username" : "update_user5"},
-                          "update" : {"$set" : {"new_col": {"sub_doc_col" : "new_val2"}}},
-                          "options" : {}
-                        }
-                    }
-                    """;
+                          {
+                            "findOneAndUpdate": {
+                                "filter" : {"username" : "update_user5"},
+                                "update" : {"$set" : {"new_col": {"sub_doc_col" : "new_val2"}}},
+                                "options" : {}
+                              }
+                          }
+                          """;
 
       Command result = objectMapper.readValue(json, Command.class);
 
@@ -273,6 +273,38 @@ class ObjectMapperConfigurationTest {
                 assertThat(updateClause.buildOperations()).hasSize(1);
                 final FindOneAndUpdateCommand.Options options = findOneAndUpdateCommand.options();
                 assertThat(options).isNotNull();
+              });
+    }
+
+    @Test
+    public void findOneAndUpdateWithOptions() throws Exception {
+      String json =
+          """
+                          {
+                            "findOneAndUpdate": {
+                                "filter" : {"username" : "update_user5"},
+                                "update" : {"$set" : {"new_col": {"sub_doc_col" : "new_val2"}}},
+                                "options" : {"returnDocument" : "after", "upsert" : true}
+                              }
+                          }
+                          """;
+
+      Command result = objectMapper.readValue(json, Command.class);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              FindOneAndUpdateCommand.class,
+              findOneAndUpdateCommand -> {
+                FilterClause filterClause = findOneAndUpdateCommand.filterClause();
+                assertThat(filterClause).isNotNull();
+                final UpdateClause updateClause = findOneAndUpdateCommand.updateClause();
+                assertThat(updateClause).isNotNull();
+                assertThat(updateClause.buildOperations()).hasSize(1);
+                final FindOneAndUpdateCommand.Options options = findOneAndUpdateCommand.options();
+                assertThat(options).isNotNull();
+                assertThat(options.returnDocument()).isNotNull();
+                assertThat(options.returnDocument()).isEqualTo("after");
+                assertThat(options.upsert()).isTrue();
               });
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndUpdateIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndUpdateIntegrationTest.java
@@ -91,6 +91,117 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
 
     @Test
     @Order(2)
+    public void findByIdReturnDocumentAfter() {
+      String json =
+          """
+                  {
+                    "insertOne": {
+                      "document": {
+                        "_id": "afterDoc3",
+                        "username": "afterUser3",
+                        "active_user" : true
+                      }
+                    }
+                  }
+                  """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200);
+
+      json =
+          """
+                  {
+                    "findOneAndUpdate": {
+                      "filter" : {"_id" : "afterDoc3"},
+                      "update" : {"$set" : {"active_user": false}},
+                      "options" : {"returnDocument" : "after"}
+                    }
+                  }
+                  """;
+      String expected =
+          "{\"_id\":\"afterDoc3\", \"username\":\"afterUser3\", \"active_user\":false}";
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(expected))
+          .body("status.updatedIds[0]", is("afterDoc3"));
+
+      json =
+          """
+                  {
+                    "find": {
+                      "filter" : {"_id" : "afterDoc3"}
+                    }
+                  }
+                  """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(expected));
+    }
+
+    @Test
+    @Order(2)
+    public void findByIdUpsert() {
+      String json =
+          """
+                  {
+                    "findOneAndUpdate": {
+                      "filter" : {"_id" : "afterDoc4"},
+                      "update" : {"$set" : {"active_user": false}},
+                      "options" : {"returnDocument" : "after", "upsert" : true}
+                    }
+                  }
+                  """;
+      String expected = "{\"_id\":\"afterDoc4\", \"active_user\":false}";
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(expected))
+          .body("status.updatedIds[0]", is("afterDoc4"));
+
+      json =
+          """
+                  {
+                    "find": {
+                      "filter" : {"_id" : "afterDoc4"}
+                    }
+                  }
+                  """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(expected));
+    }
+
+    @Test
+    @Order(2)
     public void findByColumnAndSet() {
       String json =
           """
@@ -251,7 +362,7 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
       json =
           """
               {
-                "findOneAndUpdate": {
+                "updateOne": {
                   "filter" : {"_id" : "update_doc1"},
                   "update" : {"$set" : {"active_user": false}}
                 }
@@ -277,6 +388,50 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
                 }
               }
               """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(expected));
+    }
+
+    @Test
+    @Order(2)
+    public void findByIdUpsert() {
+      String json =
+          """
+                      {
+                        "updateOne": {
+                          "filter" : {"_id" : "afterDoc6"},
+                          "update" : {"$set" : {"active_user": false}},
+                          "options" : {"upsert" : true}
+                        }
+                      }
+                      """;
+      String expected = "{\"_id\":\"afterDoc6\", \"active_user\":false}";
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(expected))
+          .body("status.updatedIds[0]", is("afterDoc6"));
+
+      json =
+          """
+                      {
+                        "find": {
+                          "filter" : {"_id" : "afterDoc6"}
+                        }
+                      }
+                      """;
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndUpdateIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndUpdateIntegrationTest.java
@@ -412,7 +412,7 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
                         }
                       }
                       """;
-      String expected = "{\"_id\":\"afterDoc6\", \"active_user\":false}";
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -421,7 +421,6 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("data.docs[0]", jsonEquals(expected))
           .body("status.updatedIds[0]", is("afterDoc6"));
 
       json =
@@ -432,6 +431,7 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
                         }
                       }
                       """;
+      String expected = "{\"_id\":\"afterDoc6\", \"active_user\":false}";
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -1,0 +1,406 @@
+package io.stargate.sgv2.jsonapi.service.operation.model.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.stargate.bridge.grpc.TypeSpecs;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.common.bridge.AbstractValidatingStargateBridgeTest;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndUpdateCommand;
+import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
+import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers;
+import io.stargate.sgv2.jsonapi.service.operation.model.ReadOperation;
+import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
+import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
+import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
+import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
+import io.stargate.sgv2.jsonapi.service.updater.DocumentUpdater;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridgeTest {
+  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+  private CommandContext commandContext = new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);
+
+  @Inject Shredder shredder;
+  @Inject ObjectMapper objectMapper;
+  @Inject QueryExecutor queryExecutor;
+
+  @Nested
+  class ReadAndUpdateOperationsTest {
+
+    @Test
+    public void findAndUpdate() throws Exception {
+      String collectionReadCql =
+          "SELECT key, tx_id, doc_json FROM \"%s\".\"%s\" WHERE key = ? LIMIT 1"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+
+      UUID tx_id = UUID.randomUUID();
+      String doc1 =
+          """
+                            {
+                                  "_id": "doc1",
+                                  "username": "user1"
+                                }
+                            """;
+
+      String doc1Updated =
+          """
+                            {
+                                  "_id": "doc1",
+                                  "username": "user1",
+                                  "name" : "test"
+                                }
+                            """;
+      withQuery(
+              collectionReadCql,
+              Values.of(CustomValueSerializers.getDocumentIdValue(DocumentId.fromString("doc1"))))
+          .withPageSize(1)
+          .withColumnSpec(
+              List.of(
+                  QueryOuterClass.ColumnSpec.newBuilder()
+                      .setName("key")
+                      .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                      .build(),
+                  QueryOuterClass.ColumnSpec.newBuilder()
+                      .setName("tx_id")
+                      .setType(TypeSpecs.UUID)
+                      .build(),
+                  QueryOuterClass.ColumnSpec.newBuilder()
+                      .setName("doc_json")
+                      .setType(TypeSpecs.VARCHAR)
+                      .build()))
+          .returning(
+              List.of(
+                  List.of(
+                      Values.of(
+                          CustomValueSerializers.getDocumentIdValue(DocumentId.fromString("doc1"))),
+                      Values.of(tx_id),
+                      Values.of(doc1))));
+
+      String update =
+          "UPDATE %s.%s "
+              + "        SET"
+              + "            tx_id = now(),"
+              + "            doc_properties = ?,"
+              + "            exist_keys = ?,"
+              + "            sub_doc_equals = ?,"
+              + "            array_size = ?,"
+              + "            array_equals = ?,"
+              + "            array_contains = ?,"
+              + "            query_bool_values = ?,"
+              + "            query_dbl_values = ?,"
+              + "            query_text_values = ?,"
+              + "            query_null_values = ?,"
+              + "            doc_json  = ?"
+              + "        WHERE "
+              + "            key = ?"
+              + "        IF "
+              + "            tx_id = ?";
+      String collectionUpdateCql = update.formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      final JsonNode jsonNode = objectMapper.readTree(doc1Updated);
+      final WritableShreddedDocument shredDocument = shredder.shred(jsonNode);
+
+      withQuery(
+              collectionUpdateCql,
+              Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.docProperties())),
+              Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
+              Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
+              Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
+              Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
+              Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
+              Values.of(
+                  CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
+              Values.of(
+                  CustomValueSerializers.getDoubleMapValues(shredDocument.queryNumberValues())),
+              Values.of(CustomValueSerializers.getStringMapValues(shredDocument.queryTextValues())),
+              Values.of(CustomValueSerializers.getSetValue(shredDocument.queryNullValues())),
+              Values.of(shredDocument.docJson()),
+              Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument.id())),
+              Values.of(tx_id))
+          .withColumnSpec(
+              List.of(
+                  QueryOuterClass.ColumnSpec.newBuilder()
+                      .setName("applied")
+                      .setType(TypeSpecs.BOOLEAN)
+                      .build()))
+          .returning(List.of(List.of(Values.of(true))));
+
+      String updater =
+          """
+                    {
+                      "findOneAndUpdate": {
+                        "filter": {
+                          "_id": "doc1"
+                        },
+                        "update": {
+                          "$set": {
+                            "name": "test"
+                          }
+                        }
+                      }
+                    }
+                    """;
+
+      FindOneAndUpdateCommand findOneAndUpdateCommand =
+          objectMapper.readValue(updater, FindOneAndUpdateCommand.class);
+      ReadOperation readOperation =
+          new FindOperation(
+              commandContext,
+              List.of(
+                  new DBFilterBase.IDFilter(
+                      DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"))),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
+      DocumentUpdater documentUpdater =
+          DocumentUpdater.construct(findOneAndUpdateCommand.updateClause());
+      ReadAndUpdateOperation operation =
+          new ReadAndUpdateOperation(
+              commandContext, readOperation, documentUpdater, true, false, false, shredder);
+      final Uni<Supplier<CommandResult>> execute = operation.execute(queryExecutor);
+      final CommandResult commandResultSupplier =
+          execute.subscribe().asCompletionStage().get().get();
+      UniAssertSubscriber<Supplier<CommandResult>> subscriber =
+          operation.execute(queryExecutor).subscribe().withSubscriber(UniAssertSubscriber.create());
+      assertThat(commandResultSupplier)
+          .satisfies(
+              commandResult -> {
+                assertThat(commandResultSupplier.status()).isNotNull();
+                assertThat(commandResultSupplier.status().get(CommandStatus.UPDATED_IDS))
+                    .isNotNull();
+                assertThat(
+                        (List<DocumentId>)
+                            commandResultSupplier.status().get(CommandStatus.UPDATED_IDS))
+                    .contains(new DocumentId.StringId("doc1"));
+              });
+    }
+  }
+
+  @Test
+  public void findAndUpdateUpsert() throws Exception {
+    String collectionReadCql =
+        "SELECT key, tx_id, doc_json FROM \"%s\".\"%s\" WHERE key = ? LIMIT 1"
+            .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+
+    UUID tx_id = UUID.randomUUID();
+    String doc1Updated =
+        """
+                        {
+                              "_id": "doc1",
+                              "name" : "test"
+                            }
+                        """;
+    withQuery(
+            collectionReadCql,
+            Values.of(CustomValueSerializers.getDocumentIdValue(DocumentId.fromString("doc1"))))
+        .withPageSize(1)
+        .withColumnSpec(
+            List.of(
+                QueryOuterClass.ColumnSpec.newBuilder()
+                    .setName("key")
+                    .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                    .build(),
+                QueryOuterClass.ColumnSpec.newBuilder()
+                    .setName("tx_id")
+                    .setType(TypeSpecs.UUID)
+                    .build(),
+                QueryOuterClass.ColumnSpec.newBuilder()
+                    .setName("doc_json")
+                    .setType(TypeSpecs.VARCHAR)
+                    .build()))
+        .returning(List.of());
+
+    String update =
+        "UPDATE %s.%s "
+            + "        SET"
+            + "            tx_id = now(),"
+            + "            doc_properties = ?,"
+            + "            exist_keys = ?,"
+            + "            sub_doc_equals = ?,"
+            + "            array_size = ?,"
+            + "            array_equals = ?,"
+            + "            array_contains = ?,"
+            + "            query_bool_values = ?,"
+            + "            query_dbl_values = ?,"
+            + "            query_text_values = ?,"
+            + "            query_null_values = ?,"
+            + "            doc_json  = ?"
+            + "        WHERE "
+            + "            key = ?"
+            + "        IF "
+            + "            tx_id = ?";
+    String collectionUpdateCql = update.formatted(KEYSPACE_NAME, COLLECTION_NAME);
+    final JsonNode jsonNode = objectMapper.readTree(doc1Updated);
+    final WritableShreddedDocument shredDocument = shredder.shred(jsonNode);
+
+    withQuery(
+            collectionUpdateCql,
+            Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.docProperties())),
+            Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
+            Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
+            Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
+            Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
+            Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
+            Values.of(CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
+            Values.of(CustomValueSerializers.getDoubleMapValues(shredDocument.queryNumberValues())),
+            Values.of(CustomValueSerializers.getStringMapValues(shredDocument.queryTextValues())),
+            Values.of(CustomValueSerializers.getSetValue(shredDocument.queryNullValues())),
+            Values.of(shredDocument.docJson()),
+            Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument.id())),
+            Values.NULL)
+        .withColumnSpec(
+            List.of(
+                QueryOuterClass.ColumnSpec.newBuilder()
+                    .setName("applied")
+                    .setType(TypeSpecs.BOOLEAN)
+                    .build()))
+        .returning(List.of(List.of(Values.of(true))));
+
+    String updater =
+        """
+                    {
+                      "findOneAndUpdate": {
+                        "filter": {
+                          "_id": "doc1"
+                        },
+                        "update": {
+                          "$set": {
+                            "name": "test"
+                          }
+                        }
+                      }
+                    }
+                    """;
+
+    FindOneAndUpdateCommand findOneAndUpdateCommand =
+        objectMapper.readValue(updater, FindOneAndUpdateCommand.class);
+    ReadOperation readOperation =
+        new FindOperation(
+            commandContext,
+            List.of(
+                new DBFilterBase.IDFilter(
+                    DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"))),
+            null,
+            1,
+            1,
+            ReadType.DOCUMENT,
+            objectMapper);
+    DocumentUpdater documentUpdater =
+        DocumentUpdater.construct(findOneAndUpdateCommand.updateClause());
+    ReadAndUpdateOperation operation =
+        new ReadAndUpdateOperation(
+            commandContext, readOperation, documentUpdater, true, false, true, shredder);
+    final Uni<Supplier<CommandResult>> execute = operation.execute(queryExecutor);
+    final CommandResult commandResultSupplier = execute.subscribe().asCompletionStage().get().get();
+    UniAssertSubscriber<Supplier<CommandResult>> subscriber =
+        operation.execute(queryExecutor).subscribe().withSubscriber(UniAssertSubscriber.create());
+    assertThat(commandResultSupplier)
+        .satisfies(
+            commandResult -> {
+              assertThat(commandResultSupplier.status()).isNotNull();
+              assertThat(commandResultSupplier.status().get(CommandStatus.UPDATED_IDS)).isNotNull();
+              assertThat(
+                      (List<DocumentId>)
+                          commandResultSupplier.status().get(CommandStatus.UPDATED_IDS))
+                  .contains(new DocumentId.StringId("doc1"));
+            });
+  }
+
+  @Test
+  public void findAndUpdateNoData() throws Exception {
+    String collectionReadCql =
+        "SELECT key, tx_id, doc_json FROM \"%s\".\"%s\" WHERE key = ? LIMIT 1"
+            .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+
+    UUID tx_id = UUID.randomUUID();
+    withQuery(
+            collectionReadCql,
+            Values.of(CustomValueSerializers.getDocumentIdValue(DocumentId.fromString("doc1"))))
+        .withPageSize(1)
+        .withColumnSpec(
+            List.of(
+                QueryOuterClass.ColumnSpec.newBuilder()
+                    .setName("key")
+                    .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                    .build(),
+                QueryOuterClass.ColumnSpec.newBuilder()
+                    .setName("tx_id")
+                    .setType(TypeSpecs.UUID)
+                    .build(),
+                QueryOuterClass.ColumnSpec.newBuilder()
+                    .setName("doc_json")
+                    .setType(TypeSpecs.VARCHAR)
+                    .build()))
+        .returning(List.of());
+
+    String updater =
+        """
+                    {
+                      "findOneAndUpdate": {
+                        "filter": {
+                          "_id": "doc1"
+                        },
+                        "update": {
+                          "$set": {
+                            "name": "test"
+                          }
+                        }
+                      }
+                    }
+                    """;
+
+    FindOneAndUpdateCommand findOneAndUpdateCommand =
+        objectMapper.readValue(updater, FindOneAndUpdateCommand.class);
+    ReadOperation readOperation =
+        new FindOperation(
+            commandContext,
+            List.of(
+                new DBFilterBase.IDFilter(
+                    DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"))),
+            null,
+            1,
+            1,
+            ReadType.DOCUMENT,
+            objectMapper);
+    DocumentUpdater documentUpdater =
+        DocumentUpdater.construct(findOneAndUpdateCommand.updateClause());
+    ReadAndUpdateOperation operation =
+        new ReadAndUpdateOperation(
+            commandContext, readOperation, documentUpdater, true, false, false, shredder);
+    final Uni<Supplier<CommandResult>> execute = operation.execute(queryExecutor);
+    final CommandResult commandResultSupplier = execute.subscribe().asCompletionStage().get().get();
+    UniAssertSubscriber<Supplier<CommandResult>> subscriber =
+        operation.execute(queryExecutor).subscribe().withSubscriber(UniAssertSubscriber.create());
+    assertThat(commandResultSupplier)
+        .satisfies(
+            commandResult -> {
+              assertThat(commandResultSupplier.status()).isNotNull();
+              assertThat(commandResultSupplier.status().get(CommandStatus.UPDATED_IDS)).isNotNull();
+              assertThat(
+                      (List<DocumentId>)
+                          commandResultSupplier.status().get(CommandStatus.UPDATED_IDS))
+                  .hasSize(0);
+            });
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateResolverTest.java
@@ -70,7 +70,53 @@ public class FindOneAndUpdateResolverTest {
                   objectMapper.getNodeFactory().objectNode().put("location", "New York")));
       ReadAndUpdateOperation expected =
           new ReadAndUpdateOperation(
-              commandContext, readOperation, documentUpdater, true, shredder);
+              commandContext, readOperation, documentUpdater, true, false, false, shredder);
+      assertThat(operation)
+          .isInstanceOf(ReadAndUpdateOperation.class)
+          .satisfies(
+              op -> {
+                assertThat(op).isEqualTo(expected);
+              });
+    }
+
+    @Test
+    public void idFilterConditionWithOptions() throws Exception {
+      String json =
+          """
+                                {
+                                  "findOneAndUpdate": {
+                                    "filter" : {"_id" : "id"},
+                                    "update" : {"$set" : {"location" : "New York"}},
+                                    "options" : {"returnDocument" : "after", "upsert": true }
+                                  }
+                                }
+                                """;
+
+      FindOneAndUpdateCommand findOneAndUpdateCommand =
+          objectMapper.readValue(json, FindOneAndUpdateCommand.class);
+      final CommandContext commandContext = new CommandContext("namespace", "collection");
+      final Operation operation =
+          findOneAndUpdateCommandResolver.resolveCommand(commandContext, findOneAndUpdateCommand);
+      ReadOperation readOperation =
+          new FindOperation(
+              commandContext,
+              List.of(
+                  new DBFilterBase.IDFilter(
+                      DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("id"))),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
+
+      DocumentUpdater documentUpdater =
+          DocumentUpdater.construct(
+              DocumentUpdaterUtils.updateClause(
+                  UpdateOperator.SET,
+                  objectMapper.getNodeFactory().objectNode().put("location", "New York")));
+      ReadAndUpdateOperation expected =
+          new ReadAndUpdateOperation(
+              commandContext, readOperation, documentUpdater, true, true, true, shredder);
       assertThat(operation)
           .isInstanceOf(ReadAndUpdateOperation.class)
           .satisfies(
@@ -115,7 +161,7 @@ public class FindOneAndUpdateResolverTest {
                   objectMapper.getNodeFactory().objectNode().put("location", "New York")));
       ReadAndUpdateOperation expected =
           new ReadAndUpdateOperation(
-              commandContext, readOperation, documentUpdater, true, shredder);
+              commandContext, readOperation, documentUpdater, true, false, false, shredder);
       assertThat(operation)
           .isInstanceOf(ReadAndUpdateOperation.class)
           .satisfies(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateOneResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateOneResolverTest.java
@@ -69,7 +69,7 @@ public class UpdateOneResolverTest {
                   objectMapper.getNodeFactory().objectNode().put("location", "New York")));
       ReadAndUpdateOperation expected =
           new ReadAndUpdateOperation(
-              commandContext, readOperation, documentUpdater, false, shredder);
+              commandContext, readOperation, documentUpdater, false, false, false, shredder);
       assertThat(operation)
           .isInstanceOf(ReadAndUpdateOperation.class)
           .satisfies(
@@ -113,7 +113,7 @@ public class UpdateOneResolverTest {
                   objectMapper.getNodeFactory().objectNode().put("location", "New York")));
       ReadAndUpdateOperation expected =
           new ReadAndUpdateOperation(
-              commandContext, readOperation, documentUpdater, false, shredder);
+              commandContext, readOperation, documentUpdater, false, false, false, shredder);
       assertThat(operation)
           .isInstanceOf(ReadAndUpdateOperation.class)
           .satisfies(


### PR DESCRIPTION
**What this PR does**:
Changes for FindOneAndUpdateCommand and UpdateOneCommand options support

**Which issue(s) this PR fixes**:
Fixes #161 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
