### PR TITLE
workflow for updating stargate version

### DIFF
--- a/.github/workflows/update-parent-version.yaml
+++ b/.github/workflows/update-parent-version.yaml
@@ -1,0 +1,48 @@
+# @author Ivan Senic
+name: Update parent version
+
+# runs on
+# * stargate v2 release event
+# * manual trigger
+on:
+  repository_dispatch:
+    types: [ stargate-v2-release ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Stargate version to update, for example `v2.0.9`.'
+        required: true
+        type: string
+
+jobs:
+
+  main:
+    name: Main
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v3
+
+      # update version
+      # use input or the event payload value
+      - name: Update version
+        id: update
+        run: |
+          VERSION=${{ inputs.version != null && inputs.version || github.event.client_payload.version }}
+          echo "Resolved version to update to $VERSION"
+          ./scripts/bump_stargate.sh $VERSION"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      # commit and create pr
+      - name: Create pull-request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Use Stargate ${{ steps.update.outputs.version }}
+          branch: create-pull-request/update-stargate
+          branch-suffix: short-commit-hash
+          base: main
+          title: Use Stargate ${{ steps.update.outputs.version }}
+          body: |
+            Automated changes that try to update Stargate version.

--- a/.github/workflows/update-parent-version.yaml
+++ b/.github/workflows/update-parent-version.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           VERSION=${{ inputs.version != null && inputs.version || github.event.client_payload.version }}
           echo "Resolved version to update to $VERSION"
-          ./scripts/bump_stargate.sh $VERSION"
+          ./scripts/bump_stargate.sh ${VERSION}
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       # commit and create pr

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>sgv2-jsonapi</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <properties>
-    <stargate.version>${parent.version}</stargate.version>
+    <stargate.version>${project.parent.version}</stargate.version>
     <failsafe.useModulePath>false</failsafe.useModulePath>
     <!-- Quarkus version override due to the https://github.com/quarkusio/quarkus/issues/30744 -->
     <!-- Remove when updating to 2.0.9 -->

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>sgv2-jsonapi</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <properties>
-    <stargate.version>2.0.8</stargate.version>
+    <stargate.version>${parent.version}</stargate.version>
     <failsafe.useModulePath>false</failsafe.useModulePath>
     <!-- Quarkus version override due to the https://github.com/quarkusio/quarkus/issues/30744 -->
     <!-- Remove when updating to 2.0.9 -->

--- a/scripts/bump_stargate.sh
+++ b/scripts/bump_stargate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -z ${1+x} ]; then
+   echo "stargate version is a required argument"
+   exit 1
+fi
+
+STARGATE_VERSION=$1
+if [[ "$STARGATE_VERSION" =~ ^v[1-9]\.[0-9]+ ]]; then
+   STARGATE_VERSION_NUMBER=$(echo ${STARGATE_VERSION} | cut -c 2-)
+else
+   echo "stargate version ('$STARGATE_VERSION') must start with prefix 'v' followed by a number, dot, another number (f.ex 'v2.0.9')"
+   exit 1
+fi
+
+# Note: brackets around version needed for parent (version "range") but not for child modules
+./mvnw -B versions:update-parent -DparentVersion="[${STARGATE_VERSION_NUMBER}]" -DgenerateBackupPoms=false -DallowSnapshots=true


### PR DESCRIPTION
**What this PR does**:
Adds workflow for updating Stargate version based on the input or the release event. Please test the `bump_stargate.sh v2.0.7` or something like that.

**Which issue(s) this PR fixes**:
Internal.
