### PR TITLE
run CI on pull request only on code-related changes

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -2,13 +2,19 @@
 name: Continuous Integration
 
 # runs on
-# * pushes and pull requests on the "main"
+# * pushes and pull requests on the "main" (pull request only for specific paths)
 # * manual trigger
 on:
   push:
     branches: [ "main" ]
+
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'src/**'
+      - 'pom.xml'
+      - '.github/workflows/continuous-integration.yaml'
+
   workflow_dispatch:
 
 


### PR DESCRIPTION
**What this PR does**:
Noticed in https://github.com/stargate/jsonapi/pull/179 that the main CI runs even if no source code changes are made. Fixing that to run only:
* if `src` had changes
* if `pom.xml` had changes (deps updates)
* workflow changed itself

