### PR TITLE
Remove 'pageSize' from the options of find command

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -89,7 +89,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                       {
                         "find": {
                              "filter": {"location": "London", "race.competitors" : {"$eq" : 100}},
-                             "options": {"limit" : 1000, "pageSize": 25, "pagingState" : "Next paging state got from previous page call"}
+                             "options": {"limit" : 1000, "pagingState" : "Next paging state got from previous page call"}
                         }
                       }
                       """),

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
@@ -31,11 +31,5 @@ public record FindCommand(
               description = "Next page state for pagination.",
               type = SchemaType.STRING,
               implementation = String.class)
-          String pagingState,
-      @Valid
-          @Schema(
-              description = "Number of document needed per page.",
-              type = SchemaType.INTEGER,
-              implementation = Integer.class)
-          Integer pageSize) {}
+          String pagingState) {}
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolver.java
@@ -41,10 +41,7 @@ public class FindCommandResolver extends FilterableResolver<FindCommand>
         command.options() != null && command.options().limit() != null
             ? command.options().limit()
             : documentConfig.maxLimit();
-    int pageSize =
-        command.options() != null && command.options().pageSize() != null
-            ? command.options().pageSize()
-            : documentConfig.defaultPageSize();
+    int pageSize = documentConfig.defaultPageSize();
     String pagingState = command.options() != null ? command.options().pagingState() : null;
     return new FilteringOptions(limit, pagingState, pageSize, ReadType.DOCUMENT);
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
@@ -192,7 +192,7 @@ class ObjectMapperConfigurationTest {
                       "find": {
                         "filter" : {"username" : "user1"},
                         "options" : {
-                          "pageSize" : 1
+                          "limit" : 1
                         }
                       }
                     }
@@ -208,7 +208,7 @@ class ObjectMapperConfigurationTest {
                 assertThat(filterClause).isNotNull();
                 final FindCommand.Options options = find.options();
                 assertThat(options).isNotNull();
-                assertThat(options.pageSize()).isEqualTo(1);
+                assertThat(options.limit()).isEqualTo(1);
               });
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -4,7 +4,6 @@ import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -148,7 +147,7 @@ public class FindIntegrationTest extends CollectionResourceBaseIntegrationTest {
                                   {
                                     "find": {
                                       "options" : {
-                                        "pageSize" : 1
+                                        "limit" : 1
                                       }
                                     }
                                   }
@@ -161,8 +160,7 @@ public class FindIntegrationTest extends CollectionResourceBaseIntegrationTest {
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("data.count", is(1))
-          .body("data.nextPageState", is(notNullValue()));
+          .body("data.count", is(1));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
@@ -101,7 +101,6 @@ public class FindCommandResolverTest {
                 "find": {
                   "options" : {
                     "limit" : 10,
-                    "pageSize" : 5,
                     "pagingState" : "dlavjhvbavkjbna"
                   }
                 }
@@ -114,7 +113,13 @@ public class FindCommandResolverTest {
           findCommandResolver.resolveCommand(commandContext, findOneCommand);
       FindOperation expected =
           new FindOperation(
-              commandContext, List.of(), "dlavjhvbavkjbna", 10, 5, ReadType.DOCUMENT, objectMapper);
+              commandContext,
+              List.of(),
+              "dlavjhvbavkjbna",
+              10,
+              documentConfig.defaultPageSize(),
+              ReadType.DOCUMENT,
+              objectMapper);
       assertThat(operation)
           .isInstanceOf(FindOperation.class)
           .satisfies(


### PR DESCRIPTION
**What this PR does**:
Remove 'pageSize' from the options of find command
**Which issue(s) this PR fixes**:
Fixes #162 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
