### PR TITLE
Support dot notation with $pop update operation

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PopOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PopOperation.java
@@ -60,14 +60,18 @@ public class PopOperation extends UpdateOperation {
     boolean changes = false;
     for (PopAction action : actions) {
       final String path = action.path;
-      JsonNode node = doc.get(path);
-      ArrayNode array;
+      UpdateTarget target = targetLocator.findIfExists(doc, path);
 
-      if (node == null) { // No such property? Fine, no change
-        ;
-      } else if (node.isArray()) { // Already array? To modify unless empty
-        if (!node.isEmpty()) {
-          array = (ArrayNode) node;
+      JsonNode value = target.valueNode();
+      // If target does not match, nothing to do; not an error
+      if (value == null) {
+        continue;
+      }
+
+      // Otherwise must be an array
+      if (value.isArray()) { // Already array? To modify unless empty
+        if (!value.isEmpty()) {
+          ArrayNode array = (ArrayNode) value;
           if (action.removeFirst) {
             array.remove(0);
           } else {
@@ -79,10 +83,10 @@ public class PopOperation extends UpdateOperation {
         throw new JsonApiException(
             ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET,
             ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET.getMessage()
-                + ": $pop requires target to be Array; value at '"
+                + ": $pop requires target to be ARRAY; value at '"
                 + path
                 + "' of type "
-                + node.getNodeType());
+                + value.getNodeType());
       }
     }
     return changes;

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UnsetOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UnsetOperation.java
@@ -30,9 +30,7 @@ public class UnsetOperation extends UpdateOperation {
     boolean modified = false;
     for (String path : paths) {
       UpdateTarget target = targetLocator.findIfExists(doc, path);
-      if (target.removeValue() != null) {
-        modified = true;
-      }
+      modified |= (target.removeValue() != null);
     }
     return modified;
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndUpdateIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndUpdateIntegrationTest.java
@@ -1102,7 +1102,7 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
                         "array3": [ ]
                       }
                       """);
-      // Let's test 5 valid pop operations (with 3 changes)
+      // Let's test 6 pop operations, resulting in 3 changes
       String updateBody =
           """
                       {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndUpdateIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndUpdateIntegrationTest.java
@@ -3,7 +3,9 @@ package io.stargate.sgv2.jsonapi.api.v1;
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
@@ -1025,6 +1027,62 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
           .statusCode(200)
           .body("data.docs[0]", jsonEquals(inputDoc));
     }
+
+    @Test
+    @Order(2)
+    public void findByIdTryPopNonArray() {
+      final String inputDoc =
+          """
+                    {
+                      "_id": "update_doc_pop_non_array",
+                      "subdoc": {
+                         "value": 15
+                      }
+                    }
+                """;
+      insertDoc(inputDoc);
+      String json =
+          """
+                     {
+                        "findOneAndUpdate": {
+                          "filter" : {"_id" : "update_doc_pop_non_array"},
+                          "update" : {"$pop" : {"subdoc.value": 1 }}
+                        }
+                      }
+                     """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("errors[0].errorCode", is("UNSUPPORTED_UPDATE_OPERATION_TARGET"))
+          .body(
+              "errors[0].message",
+              is(
+                  "Unsupported target JSON value for update operation: $pop requires target to be ARRAY; value at 'subdoc.value' of type NUMBER"));
+
+      // And finally verify also that nothing was changed:
+      json =
+          """
+                  {
+                    "find": {
+                      "filter" : {"_id" : "update_doc_pop_non_array"}
+                    }
+                  }
+                  """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(inputDoc));
+    }
   }
 
   @Nested
@@ -1032,16 +1090,19 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
     @Test
     @Order(2)
     public void findByColumnAndPop() {
-      // Let's test 4 valid pop operations:
       insertDoc(
           """
                       {
                         "_id": "update_doc_pop",
                         "array1": [ 1, 2, 3 ],
                         "array2": [ 4, 5, 6 ],
+                        "subdoc" : {
+                          "array" : [ 0, 1 ]
+                        },
                         "array3": [ ]
                       }
                       """);
+      // Let's test 5 valid pop operations (with 3 changes)
       String updateBody =
           """
                       {
@@ -1052,7 +1113,9 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
                               "array1": 1,
                               "array2": -1,
                               "array3": 1,
-                              "array4": -1
+                              "array4": -1,
+                              "subdoc.array" : 1,
+                              "subdoc.x.y" : 1
                               }
                           }
                         }
@@ -1093,6 +1156,9 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
                         "_id": "update_doc_pop",
                         "array1": [ 1, 2 ],
                         "array2": [ 5, 6 ],
+                        "subdoc" : {
+                          "array" : [ 0 ]
+                        },
                         "array3": [ ]
                       }
                       """));
@@ -1347,6 +1413,8 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
         .when()
         .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
         .then()
+        // Sanity check: let's look for non-empty inserted id
+        .body("status.insertedIds[0]", not(emptyString()))
         .statusCode(200);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/PopOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/PopOperationTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 public class PopOperationTest extends UpdateOperationTestBase {
   @Nested
   @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-  class HappyPath {
+  class HappyPathRoot {
     @Test
     public void testSimplePopFirstFromExisting() {
       UpdateOperation oper =
@@ -102,6 +102,55 @@ public class PopOperationTest extends UpdateOperationTestBase {
 
   @Nested
   @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+  class HappyPathNested {
+    @Test
+    public void testNestedPopFromExisting() {
+      UpdateOperation oper =
+          UpdateOperator.POP.resolveOperation(objectFromJson("{ \"subdoc.array\" : -1 }"));
+      assertThat(oper).isInstanceOf(PopOperation.class);
+      ObjectNode doc = objectFromJson("{ \"a\" : 1, \"subdoc\" : { \"array\" : [ 1, 2, 3 ] } }");
+      assertThat(oper.updateDocument(doc, targetLocator)).isTrue();
+      ObjectNode expected =
+          objectFromJson(
+              """
+                                        { "a" : 1, "subdoc": { "array" : [ 2, 3 ] } }
+                                        """);
+      assertThat(doc).isEqualTo(expected);
+    }
+
+    @Test
+    public void testNestedPopFromEmpty() {
+      UpdateOperation oper =
+          UpdateOperator.POP.resolveOperation(objectFromJson("{ \"subdoc.array\" : 1 }"));
+      assertThat(oper).isInstanceOf(PopOperation.class);
+      ObjectNode doc = objectFromJson("{ \"subdoc\" : { \"array\" : [ ] } }");
+      ObjectNode expected = doc.deepCopy();
+      assertThat(oper.updateDocument(doc, targetLocator)).isFalse();
+      assertThat(doc).isEqualTo(expected);
+    }
+
+    @Test
+    public void testNestedPopFromNonExisting() {
+      UpdateOperation oper =
+          UpdateOperator.POP.resolveOperation(objectFromJson("{ \"subdoc.array\" : -1 }"));
+      assertThat(oper).isInstanceOf(PopOperation.class);
+      ObjectNode doc = objectFromJson("{ \"a\" : 1, \"doc\" : { } }");
+      ObjectNode expected = doc.deepCopy();
+      // No changes
+      assertThat(oper.updateDocument(doc, targetLocator)).isFalse();
+      assertThat(doc).isEqualTo(expected);
+
+      // But let's verify longer nesting too
+      oper = UpdateOperator.POP.resolveOperation(objectFromJson("{ \"a.b.c.d\" : -1 }"));
+      doc = objectFromJson("{ }");
+      // No changes here either
+      assertThat(oper.updateDocument(doc, targetLocator)).isFalse();
+      assertThat(doc).isEqualTo(objectFromJson("{ }"));
+    }
+  }
+
+  @Nested
+  @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
   class FailingCases {
     @Test
     public void nonNumberParamForPop() {
@@ -134,7 +183,7 @@ public class PopOperationTest extends UpdateOperationTestBase {
     }
 
     @Test
-    public void testPopFromNonArrayProperty() {
+    public void testPopFromNonArrayRootProperty() {
       ObjectNode doc = objectFromJson("{ \"a\": 175 }");
       UpdateOperation oper = UpdateOperator.POP.resolveOperation(objectFromJson("{ \"a\": 1 }"));
       Exception e =
@@ -147,7 +196,25 @@ public class PopOperationTest extends UpdateOperationTestBase {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET)
           .hasMessageStartingWith(
               ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET.getMessage()
-                  + ": $pop requires target to be Array; value at 'a' of type NUMBER");
+                  + ": $pop requires target to be ARRAY; value at 'a' of type NUMBER");
+    }
+
+    @Test
+    public void testPopFromNonArrayNestedProperty() {
+      ObjectNode doc = objectFromJson("{ \"subdoc\" : [ true, false ] }");
+      UpdateOperation oper =
+          UpdateOperator.POP.resolveOperation(objectFromJson("{ \"subdoc.1\": 1 }"));
+      Exception e =
+          catchException(
+              () -> {
+                oper.updateDocument(doc, targetLocator);
+              });
+      assertThat(e)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET)
+          .hasMessageStartingWith(
+              ErrorCode.UNSUPPORTED_UPDATE_OPERATION_TARGET.getMessage()
+                  + ": $pop requires target to be ARRAY; value at 'subdoc.1' of type BOOLEAN");
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/PopOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/PopOperationTest.java
@@ -113,8 +113,8 @@ public class PopOperationTest extends UpdateOperationTestBase {
       ObjectNode expected =
           objectFromJson(
               """
-                                        { "a" : 1, "subdoc": { "array" : [ 2, 3 ] } }
-                                        """);
+              { "a" : 1, "subdoc": { "array" : [ 2, 3 ] } }
+              """);
       assertThat(doc).isEqualTo(expected);
     }
 


### PR DESCRIPTION
**What this PR does**:

Changes `$pop` implementation to support dotted paths too.

**Which issue(s) this PR fixes**:
Fixes #184

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
