### PR TITLE
Return deletedCount for deleteOne and deleteMany

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandStatus.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandStatus.java
@@ -7,9 +7,9 @@ public enum CommandStatus {
   /** The element has the count of document */
   @JsonProperty("counted_documents")
   COUNTED_DOCUMENT,
-  /** The element has the list of deleted ids */
-  @JsonProperty("deletedIds")
-  DELETED_IDS,
+  /** The element has the count of deleted documents */
+  @JsonProperty("deletedCount")
+  DELETED_COUNT,
   /** The element has the list of inserted ids */
   @JsonProperty("insertedIds")
   INSERTED_IDS,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperation.java
@@ -10,7 +10,6 @@ import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers;
 import io.stargate.sgv2.jsonapi.service.operation.model.ModifyOperation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadOperation;
-import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -48,7 +47,7 @@ public record DeleteOperation(
                 })
             .whilst(findResponse -> findResponse.pagingState() != null);
     AtomicInteger totalCount = new AtomicInteger(0);
-    final Uni<List<DocumentId>> ids =
+    final Uni<AtomicInteger> counter =
         findResponses
             .onItem()
             .transformToMulti(
@@ -71,9 +70,18 @@ public record DeleteOperation(
             .transformToUniAndConcatenate(
                 readDocument -> deleteDocument(queryExecutor, delete, readDocument))
             .collect()
-            .asList();
-    return ids.onItem()
-        .transform(deletedIds -> new DeleteOperationPage(deletedIds, boolenFlag.get()));
+            .in(
+                AtomicInteger::new,
+                (atomicCounter, flag) -> {
+                  if (flag) {
+                    atomicCounter.incrementAndGet();
+                  }
+                });
+
+    return counter
+        .onItem()
+        .transform(
+            deletedCounter -> new DeleteOperationPage(deletedCounter.get(), boolenFlag.get()));
   }
 
   private QueryOuterClass.Query buildDeleteQuery() {
@@ -102,7 +110,7 @@ public record DeleteOperation(
    * @param doc
    * @return
    */
-  private static Uni<DocumentId> deleteDocument(
+  private static Uni<Boolean> deleteDocument(
       QueryExecutor queryExecutor, QueryOuterClass.Query query, ReadDocument doc) {
     query = bindDeleteQuery(query, doc);
     return queryExecutor
@@ -111,9 +119,9 @@ public record DeleteOperation(
         .transformToUni(
             result -> {
               if (result.getRows(0).getValues(0).getBoolean()) {
-                return Uni.createFrom().item(doc.id());
+                return Uni.createFrom().item(true);
               } else {
-                return Uni.createFrom().nothing();
+                return Uni.createFrom().item(false);
               }
             });
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationPage.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationPage.java
@@ -2,23 +2,21 @@ package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
-import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
 /**
  * This represents the response for a delete operation. .
  *
- * @param deletedIds - document ids deleted
+ * @param deletedCount - Count of document deleted
  */
-public record DeleteOperationPage(List<DocumentId> deletedIds, boolean moreData)
+public record DeleteOperationPage(Integer deletedCount, boolean moreData)
     implements Supplier<CommandResult> {
   @Override
   public CommandResult get() {
     if (moreData)
       return new CommandResult(
-          Map.of(CommandStatus.DELETED_IDS, deletedIds, CommandStatus.MORE_DATA, true));
-    else return new CommandResult(Map.of(CommandStatus.DELETED_IDS, deletedIds));
+          Map.of(CommandStatus.DELETED_COUNT, deletedCount, CommandStatus.MORE_DATA, true));
+    else return new CommandResult(Map.of(CommandStatus.DELETED_COUNT, deletedCount));
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteManyIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteManyIntegrationTest.java
@@ -2,14 +2,13 @@ package io.stargate.sgv2.jsonapi.api.v1;
 
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
-import org.hamcrest.collection.IsCollectionWithSize;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
@@ -70,8 +69,7 @@ public class DeleteManyIntegrationTest extends CollectionResourceBaseIntegration
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.deletedIds", is(IsCollectionWithSize.hasSize(1)))
-          .body("status.deletedIds", contains("doc1"));
+          .body("status.deletedCount", is(1));
     }
 
     @Test
@@ -94,9 +92,8 @@ public class DeleteManyIntegrationTest extends CollectionResourceBaseIntegration
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.deletedIds", is(IsCollectionWithSize.hasSize(5)))
+          .body("status.deletedCount", is(5))
           .body("status.moreData", nullValue());
-      cleanUpData();
     }
 
     @Test
@@ -120,10 +117,8 @@ public class DeleteManyIntegrationTest extends CollectionResourceBaseIntegration
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.deletedIds", is(IsCollectionWithSize.hasSize(20)))
+          .body("status.deletedCount", is(20))
           .body("status.moreData", nullValue());
-      ;
-      cleanUpData();
     }
 
     @Test
@@ -147,12 +142,12 @@ public class DeleteManyIntegrationTest extends CollectionResourceBaseIntegration
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.deletedIds", is(IsCollectionWithSize.hasSize(20)))
+          .body("status.deletedCount", is(20))
           .body("status.moreData", is(true));
-      cleanUpData();
     }
 
-    private void cleanUpData() {
+    @AfterEach
+    public void cleanUpData() {
       String json =
           """
                       {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
@@ -99,11 +99,8 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
       assertThat(result)
           .satisfies(
               commandResult -> {
-                assertThat(result.status().get(CommandStatus.DELETED_IDS)).isNotNull();
-                assertThat((List<DocumentId>) result.status().get(CommandStatus.DELETED_IDS))
-                    .hasSize(1);
-                assertThat((List<DocumentId>) result.status().get(CommandStatus.DELETED_IDS))
-                    .contains(DocumentId.fromString("doc1"));
+                assertThat(result.status().get(CommandStatus.DELETED_COUNT)).isNotNull();
+                assertThat(result.status().get(CommandStatus.DELETED_COUNT)).isEqualTo(1);
               });
     }
 
@@ -150,9 +147,8 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
       assertThat(result)
           .satisfies(
               commandResult -> {
-                assertThat(result.status().get(CommandStatus.DELETED_IDS)).isNotNull();
-                assertThat((List<String>) result.status().get(CommandStatus.DELETED_IDS))
-                    .hasSize(0);
+                assertThat(result.status().get(CommandStatus.DELETED_COUNT)).isNotNull();
+                assertThat(result.status().get(CommandStatus.DELETED_COUNT)).isEqualTo(0);
               });
     }
 
@@ -214,11 +210,8 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
       assertThat(result)
           .satisfies(
               commandResult -> {
-                assertThat(result.status().get(CommandStatus.DELETED_IDS)).isNotNull();
-                assertThat((List<DocumentId>) result.status().get(CommandStatus.DELETED_IDS))
-                    .hasSize(1);
-                assertThat((List<DocumentId>) result.status().get(CommandStatus.DELETED_IDS))
-                    .contains(DocumentId.fromString("doc1"));
+                assertThat(result.status().get(CommandStatus.DELETED_COUNT)).isNotNull();
+                assertThat(result.status().get(CommandStatus.DELETED_COUNT)).isEqualTo(1);
               });
     }
 
@@ -290,11 +283,8 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
       assertThat(result)
           .satisfies(
               commandResult -> {
-                assertThat(result.status().get(CommandStatus.DELETED_IDS)).isNotNull();
-                assertThat((List<DocumentId>) result.status().get(CommandStatus.DELETED_IDS))
-                    .hasSize(2);
-                assertThat((List<DocumentId>) result.status().get(CommandStatus.DELETED_IDS))
-                    .contains(DocumentId.fromString("doc1"), DocumentId.fromString("doc2"));
+                assertThat(result.status().get(CommandStatus.DELETED_COUNT)).isNotNull();
+                assertThat(result.status().get(CommandStatus.DELETED_COUNT)).isEqualTo(2);
               });
     }
 
@@ -348,9 +338,8 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
       assertThat(result)
           .satisfies(
               commandResult -> {
-                assertThat(result.status().get(CommandStatus.DELETED_IDS)).isNotNull();
-                assertThat((List<String>) result.status().get(CommandStatus.DELETED_IDS))
-                    .hasSize(0);
+                assertThat(result.status().get(CommandStatus.DELETED_COUNT)).isNotNull();
+                assertThat(result.status().get(CommandStatus.DELETED_COUNT)).isEqualTo(0);
               });
     }
   }


### PR DESCRIPTION

**What this PR does**:
Return deletedCount instead of deletedIds for deleteOne and deleteMany

**Which issue(s) this PR fixes**:
Fixes #194 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
