### PR TITLE
Support dot-notation with $inc update operator

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PopOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/PopOperation.java
@@ -23,7 +23,8 @@ public class PopOperation extends UpdateOperation {
     List<PopAction> actions = new ArrayList<>();
     while (fieldIter.hasNext()) {
       Map.Entry<String, JsonNode> entry = fieldIter.next();
-      final String name = entry.getKey();
+      final String path = validateUpdatePath(UpdateOperator.POP, entry.getKey());
+
       final JsonNode arg = entry.getValue();
 
       // Argument must be -1 (remove first) or 1 (remove last)
@@ -50,7 +51,7 @@ public class PopOperation extends UpdateOperation {
                   + ": $pop requires argument of -1 or 1, instead got: "
                   + arg.intValue());
       }
-      actions.add(new PopAction(name, first));
+      actions.add(new PopAction(path, first));
     }
     return new PopOperation(actions);
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/SetOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/SetOperation.java
@@ -21,7 +21,7 @@ public class SetOperation extends UpdateOperation {
     var it = args.fields();
     while (it.hasNext()) {
       var entry = it.next();
-      String path = validateSetPath(UpdateOperator.SET, entry.getKey());
+      String path = validateUpdatePath(UpdateOperator.SET, entry.getKey());
       additions.add(new SetAction(path, entry.getValue()));
     }
     return new SetOperation(additions);

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UnsetOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UnsetOperation.java
@@ -20,7 +20,7 @@ public class UnsetOperation extends UpdateOperation {
     Iterator<String> it = args.fieldNames();
     List<String> fieldNames = new ArrayList<>();
     while (it.hasNext()) {
-      fieldNames.add(validateSetPath(UpdateOperator.UNSET, it.next()));
+      fieldNames.add(validateUpdatePath(UpdateOperator.UNSET, it.next()));
     }
     return new UnsetOperation(fieldNames);
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateOperation.java
@@ -19,11 +19,11 @@ public abstract class UpdateOperation {
   public abstract boolean updateDocument(ObjectNode doc, UpdateTargetLocator targetLocator);
 
   /**
-   * Shared validation method used by {@code $set} and {@code $unset} operations to ensure they are
-   * not used to modify paths that are not allowed (specifically Document's primary id, {@code
-   * _id}).
+   * Shared validation method used by mutating operations (like {@code $set}, {@code $unset}, {@code
+   * inc}, {@code pop}) to ensure they are not used to modify paths that are not allowed:
+   * specifically Document's primary id, {@code _id}.
    */
-  protected static String validateSetPath(UpdateOperator oper, String path) {
+  protected static String validateUpdatePath(UpdateOperator oper, String path) {
     if (DocumentConstants.Fields.DOC_ID.equals(path)) {
       throw new JsonApiException(
           ErrorCode.UNSUPPORTED_UPDATE_FOR_DOC_ID,

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/PopOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/command/clause/update/PopOperationTest.java
@@ -183,6 +183,19 @@ public class PopOperationTest extends UpdateOperationTestBase {
     }
 
     @Test
+    public void testPopOfDocId() {
+      Exception e =
+          catchException(
+              () -> {
+                UpdateOperator.POP.resolveOperation(objectFromJson("{ \"_id\" : 1 }"));
+              });
+      assertThat(e)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_FOR_DOC_ID)
+          .hasMessageStartingWith(ErrorCode.UNSUPPORTED_UPDATE_FOR_DOC_ID.getMessage() + ": $pop");
+    }
+
+    @Test
     public void testPopFromNonArrayRootProperty() {
       ObjectNode doc = objectFromJson("{ \"a\": 175 }");
       UpdateOperation oper = UpdateOperator.POP.resolveOperation(objectFromJson("{ \"a\": 1 }"));


### PR DESCRIPTION
**What this PR does**:

Supports dot-notation (nested paths) for `$inc` operator (currently only works on root-level properties).

**Which issue(s) this PR fixes**:
Fixes #183

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
