### PR TITLE
relates to #178: adapt countDocuments per spec, improve tests

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -274,7 +274,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                       """
                                     {
                                       "status": {
-                                        "counted_documents": 2
+                                        "count": 2
                                       }
                                     }
                                     """),

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandStatus.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandStatus.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /** Enum with it's json property name which is returned in api response inside status */
 public enum CommandStatus {
   /** The element has the count of document */
-  @JsonProperty("counted_documents")
+  @JsonProperty("count")
   COUNTED_DOCUMENT,
   /** The element has the count of deleted documents */
   @JsonProperty("deletedCount")

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CountDocumentsCommands.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CountDocumentsCommands.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.stargate.sgv2.jsonapi.api.model.command.Filterable;
 import io.stargate.sgv2.jsonapi.api.model.command.ReadCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.FilterClause;
-import javax.annotation.Nullable;
 import javax.validation.Valid;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
@@ -13,9 +12,5 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
     description =
         "Command that returns count of documents in a collection based on the collection.")
 @JsonTypeName("countDocuments")
-public record CountDocumentsCommands(
-    @Valid @JsonProperty("filter") FilterClause filterClause, @Valid @Nullable Options options)
-    implements ReadCommand, Filterable {
-
-  public record Options() {}
-}
+public record CountDocumentsCommands(@Valid @JsonProperty("filter") FilterClause filterClause)
+    implements ReadCommand, Filterable {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
@@ -81,7 +81,7 @@ public class CollectionResource {
                         UpdateOneCommand.class
                       }),
               examples = {
-                @ExampleObject(ref = "count"),
+                @ExampleObject(ref = "countDocuments"),
                 @ExampleObject(ref = "deleteOne"),
                 @ExampleObject(ref = "deleteMany"),
                 @ExampleObject(ref = "findOne"),

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountIntegrationTest.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.api.v1;
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -22,83 +23,83 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
   @Nested
   @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
   class Count {
+
     @Test
     @Order(1)
     public void setUp() {
       String json =
           """
-                                          {
-                                            "insertOne": {
-                                              "document": {
-                                                "_id": "doc1",
-                                                "username": "user1",
-                                                "active_user" : true
-                                              }
-                                            }
-                                          }
-                                          """;
-
+          {
+            "insertOne": {
+              "document": {
+                "_id": "doc1",
+                "username": "user1",
+                "active_user" : true
+              }
+            }
+          }
+          """;
       insert(json);
+
       json =
           """
-                                          {
-                                            "insertOne": {
-                                              "document": {
-                                                "_id": "doc2",
-                                                "username": "user2",
-                                                "subdoc" : {
-                                                   "id" : "abc"
-                                                },
-                                                "array" : [
-                                                    "value1"
-                                                ]
-                                              }
-                                            }
-                                          }
-                                          """;
-
+          {
+            "insertOne": {
+              "document": {
+                "_id": "doc2",
+                "username": "user2",
+                "subdoc" : {
+                   "id" : "abc"
+                },
+                "array" : [
+                    "value1"
+                ]
+              }
+            }
+          }
+          """;
       insert(json);
+
       json =
           """
-                                              {
-                                                "insertOne": {
-                                                  "document": {
-                                                    "_id": "doc3",
-                                                    "username": "user3",
-                                                    "tags" : ["tag1", "tag2", "tag1234567890123456789012345", null, 1, true],
-                                                    "nestedArray" : [["tag1", "tag2"], ["tag1234567890123456789012345", null]]
-                                                  }
-                                                }
-                                              }
-                                              """;
-
+          {
+            "insertOne": {
+              "document": {
+                "_id": "doc3",
+                "username": "user3",
+                "tags" : ["tag1", "tag2", "tag1234567890123456789012345", null, 1, true],
+                "nestedArray" : [["tag1", "tag2"], ["tag1234567890123456789012345", null]]
+              }
+            }
+          }
+          """;
       insert(json);
+
       json =
           """
-                                      {
-                                        "insertOne": {
-                                          "document": {
-                                            "_id": "doc4",
-                                            "indexedObject" : { "0": "value_0", "1": "value_1" }
-                                          }
-                                        }
-                                      }
-                                      """;
-
+          {
+            "insertOne": {
+              "document": {
+                "_id": "doc4",
+                "indexedObject" : { "0": "value_0", "1": "value_1" }
+              }
+            }
+          }
+          """;
       insert(json);
+
       json =
           """
-                        {
-                          "insertOne": {
-                            "document": {
-                              "_id": "doc5",
-                              "username": "user5",
-                              "sub_doc" : { "a": 5, "b": { "c": "v1", "d": false } }
-                            }
-                          }
-                        }
-                        """;
-
+          {
+            "insertOne": {
+              "document": {
+                "_id": "doc5",
+                "username": "user5",
+                "sub_doc" : { "a": 5, "b": { "c": "v1", "d": false } }
+              }
+            }
+          }
+          """;
       insert(json);
     }
 
@@ -110,7 +111,8 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .when()
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
-          .statusCode(200);
+          .statusCode(200)
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -118,11 +120,12 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countNoFilter() {
       String json =
           """
-                      {
-                        "countDocuments": {
-                        }
-                      }
-                    """;
+          {
+            "countDocuments": {
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -131,7 +134,8 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(5));
+          .body("status.count", is(5))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -139,12 +143,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countByColumn() {
       String json =
           """
-                    {
-                      "countDocuments": {
-                        "filter" : {"username" : "user1"}
-                      }
-                    }
-                """;
+          {
+            "countDocuments": {
+              "filter" : {"username" : "user1"}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -153,7 +158,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -161,12 +168,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithEqComparisonOperator() {
       String json =
           """
-                                  {
-                                    "countDocuments": {
-                                      "filter" : {"username" : {"$eq" : "user1"}}
-                                    }
-                                  }
-                                  """;
+          {
+            "countDocuments": {
+              "filter" : {"username" : {"$eq" : "user1"}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -175,7 +183,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -183,12 +193,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithEqSubDoc() {
       String json =
           """
-                                      {
-                                        "countDocuments": {
-                                          "filter" : {"subdoc.id" : {"$eq" : "abc"}}
-                                        }
-                                      }
-                                      """;
+          {
+            "countDocuments": {
+              "filter" : {"subdoc.id" : {"$eq" : "abc"}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -197,7 +208,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -205,12 +218,12 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithEqSubDocWithIndex() {
       String json =
           """
-                                          {
-                                            "countDocuments": {
-                                              "filter" : {"indexedObject.1" : {"$eq" : "value_1"}}
-                                            }
-                                          }
-                                          """;
+          {
+            "countDocuments": {
+              "filter" : {"indexedObject.1" : {"$eq" : "value_1"}}
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -220,7 +233,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -228,12 +243,12 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithEqArrayElement() {
       String json =
           """
-                                      {
-                                        "countDocuments": {
-                                          "filter" : {"array.0" : {"$eq" : "value1"}}
-                                        }
-                                      }
-                                      """;
+          {
+            "countDocuments": {
+              "filter" : {"array.0" : {"$eq" : "value1"}}
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -243,7 +258,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -251,12 +268,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithExistFalseOperator() {
       String json =
           """
-                                      {
-                                        "countDocuments": {
-                                          "filter" : {"active_user" : {"$exists" : false}}
-                                        }
-                                      }
-                                      """;
+          {
+            "countDocuments": {
+              "filter" : {"active_user" : {"$exists" : false}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -273,12 +291,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithExistOperator() {
       String json =
           """
-                                          {
-                                            "countDocuments": {
-                                              "filter" : {"active_user" : {"$exists" : true}}
-                                            }
-                                          }
-                                          """;
+          {
+            "countDocuments": {
+              "filter" : {"active_user" : {"$exists" : true}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -287,7 +306,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -295,12 +316,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithAllOperator() {
       String json =
           """
-                                          {
-                                            "countDocuments": {
-                                              "filter" : {"tags" : {"$all" : ["tag1", "tag2"]}}
-                                            }
-                                          }
-                                          """;
+          {
+            "countDocuments": {
+              "filter" : {"tags" : {"$all" : ["tag1", "tag2"]}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -309,7 +331,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -317,12 +341,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithAllOperatorLongerString() {
       String json =
           """
-                                              {
-                                                "countDocuments": {
-                                                  "filter" : {"tags" : {"$all" : ["tag1", "tag1234567890123456789012345"]}}
-                                                }
-                                              }
-                                              """;
+          {
+            "countDocuments": {
+              "filter" : {"tags" : {"$all" : ["tag1", "tag1234567890123456789012345"]}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -331,7 +356,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -339,12 +366,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithAllOperatorMixedAFormatArray() {
       String json =
           """
-                                              {
-                                                "countDocuments": {
-                                                  "filter" : {"tags" : {"$all" : ["tag1", 1, true, null]}}
-                                                }
-                                              }
-                                              """;
+          {
+            "countDocuments": {
+              "filter" : {"tags" : {"$all" : ["tag1", 1, true, null]}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -353,7 +381,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -361,12 +391,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithAllOperatorNoMatch() {
       String json =
           """
-                                              {
-                                                "countDocuments": {
-                                                  "filter" : {"tags" : {"$all" : ["tag1", 2, true, null]}}
-                                                }
-                                              }
-                                              """;
+          {
+            "countDocuments": {
+              "filter" : {"tags" : {"$all" : ["tag1", 2, true, null]}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -375,20 +406,22 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(0));
+          .body("status.count", is(0))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
     @Order(2)
-    public void countWithEqSubdocumentShortcut() {
+    public void countWithEqSubDocumentShortcut() {
       String json =
           """
-                                                {
-                                                  "countDocuments": {
-                                                    "filter" : {"sub_doc" : { "a": 5, "b": { "c": "v1", "d": false } } }
-                                                  }
-                                                }
-                                                """;
+          {
+            "countDocuments": {
+              "filter" : {"sub_doc" : { "a": 5, "b": { "c": "v1", "d": false } } }
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -398,20 +431,22 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
     @Order(2)
-    public void countWithEqSubdocument() {
+    public void countWithEqSubDocument() {
       String json =
           """
-                                    {
-                                      "countDocuments": {
-                                        "filter" : {"sub_doc" : { "$eq" : { "a": 5, "b": { "c": "v1", "d": false } } } }
-                                      }
-                                    }
-                                    """;
+          {
+            "countDocuments": {
+              "filter" : {"sub_doc" : { "$eq" : { "a": 5, "b": { "c": "v1", "d": false } } } }
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -421,42 +456,22 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
-    }
-
-    @Order(2)
-    public void countWithEqSubdocumentOrderChangeNoMatch() {
-      String json =
-          """
-                                  {
-                                    "countDocuments": {
-                                      "filter" : {"sub_doc" : { "$eq" : { "a": 5, "b": { "d": false, "c": "v1" } } } }
-                                    }
-                                  }
-                                  """;
-
-      given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.counted_documents", is(0));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
     @Order(2)
-    public void countWithEqSubdocumentNoMatch() {
+    public void countWithEqSubDocumentOrderChangeNoMatch() {
       String json =
           """
-                                    {
-                                      "countDocuments": {
-                                        "filter" : {"sub_doc" : { "$eq" : { "a": 5, "b": { "c": "v1", "d": true } } } }
-                                      }
-                                    }
-                                    """;
+          {
+            "countDocuments": {
+              "filter" : {"sub_doc" : { "$eq" : { "a": 5, "b": { "d": false, "c": "v1" } } } }
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -466,7 +481,34 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(0));
+          .body("status.count", is(0))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
+    }
+
+    @Test
+    @Order(2)
+    public void countWithEqSubDocumentNoMatch() {
+      String json =
+          """
+          {
+            "countDocuments": {
+              "filter" : {"sub_doc" : { "$eq" : { "a": 5, "b": { "c": "v1", "d": true } } } }
+            }
+          }
+          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.count", is(0))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -474,12 +516,12 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithSizeOperator() {
       String json =
           """
-                                          {
-                                            "countDocuments": {
-                                              "filter" : {"tags" : {"$size" : 6}}
-                                            }
-                                          }
-                                          """;
+          {
+            "countDocuments": {
+              "filter" : {"tags" : {"$size" : 6}}
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -489,7 +531,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -497,12 +541,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithSizeOperatorNoMatch() {
       String json =
           """
-                                              {
-                                                "countDocuments": {
-                                                  "filter" : {"tags" : {"$size" : 1}}
-                                                }
-                                              }
-                                              """;
+          {
+            "countDocuments": {
+              "filter" : {"tags" : {"$size" : 1}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -511,7 +556,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(0));
+          .body("status.count", is(0))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -519,12 +566,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithEqOperatorArray() {
       String json =
           """
-                                                  {
-                                                    "countDocuments": {
-                                                      "filter" : {"tags" : {"$eq" : ["tag1", "tag2", "tag1234567890123456789012345", null, 1, true]}}
-                                                    }
-                                                  }
-                                                  """;
+          {
+            "countDocuments": {
+              "filter" : {"tags" : {"$eq" : ["tag1", "tag2", "tag1234567890123456789012345", null, 1, true]}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -533,19 +581,23 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
+    @Test
     @Order(2)
     public void countWithEqOperatorNestedArray() {
       String json =
           """
-                                                  {
-                                                    "countDocuments": {
-                                                      "filter" : {"nestedArray" : {"$eq" : [["tag1", "tag2"], ["tag1234567890123456789012345", null]]}}
-                                                    }
-                                                  }
-                                                  """;
+          {
+            "countDocuments": {
+              "filter" : {"nestedArray" : {"$eq" : [["tag1", "tag2"], ["tag1234567890123456789012345", null]]}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -554,7 +606,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -562,12 +616,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithEqOperatorArrayNoMatch() {
       String json =
           """
-                                                  {
-                                                    "countDocuments": {
-                                                      "filter" : {"tags" : {"$eq" : ["tag1", "tag2", "tag1234567890123456789012345", null, 1]}}
-                                                    }
-                                                  }
-                                                  """;
+          {
+            "countDocuments": {
+              "filter" : {"tags" : {"$eq" : ["tag1", "tag2", "tag1234567890123456789012345", null, 1]}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -576,19 +631,23 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(0));
+          .body("status.count", is(0))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
+    @Test
     @Order(2)
     public void countWithEqOperatorNestedArrayNoMatch() {
       String json =
           """
-                                                  {
-                                                    "countDocuments": {
-                                                      "filter" : {"nestedArray" : {"$eq" : [["tag1", "tag2"], ["tag1234567890123456789012345", null], ["abc"]]}}
-                                                    }
-                                                  }
-                                                  """;
+          {
+            "countDocuments": {
+              "filter" : {"nestedArray" : {"$eq" : [["tag1", "tag2"], ["tag1234567890123456789012345", null], ["abc"]]}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -597,7 +656,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(0));
+          .body("status.count", is(0))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
@@ -605,12 +666,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countWithNEComparisonOperator() {
       String json =
           """
-                                      {
-                                        "countDocuments": {
-                                          "filter" : {"username" : {"$ne" : "user1"}}
-                                        }
-                                      }
-                                      """;
+          {
+            "countDocuments": {
+              "filter" : {"username" : {"$ne" : "user1"}}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -627,12 +689,13 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
     public void countByBooleanColumn() {
       String json =
           """
-                                                {
-                                                  "countDocuments": {
-                                                    "filter" : {"active_user" : true}
-                                                  }
-                                                }
-                                                """;
+          {
+            "countDocuments": {
+              "filter" : {"active_user" : true}
+            }
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -641,7 +704,9 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.counted_documents", is(1));
+          .body("status.count", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CountDocumentsCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CountDocumentsCommandResolverTest.java
@@ -1,0 +1,82 @@
+package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.Mock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.CountDocumentsCommands;
+import io.stargate.sgv2.jsonapi.service.operation.model.CountOperation;
+import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase.MapFilterBase.Operator;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+class CountDocumentsCommandResolverTest {
+
+  @Inject ObjectMapper objectMapper;
+  @Inject CountDocumentsCommandResolver resolver;
+
+  @Nested
+  class ResolveCommand {
+
+    @Mock CommandContext context;
+
+    @Test
+    public void noFilter() throws Exception {
+      String json =
+          """
+            {
+              "countDocuments": {
+              }
+            }
+            """;
+
+      CountDocumentsCommands command = objectMapper.readValue(json, CountDocumentsCommands.class);
+      Operation result = resolver.resolveCommand(context, command);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              CountOperation.class,
+              op -> {
+                assertThat(op.commandContext()).isEqualTo(context);
+                assertThat(op.filters()).isEmpty();
+              });
+    }
+
+    @Test
+    public void withFilter() throws Exception {
+      String json =
+          """
+            {
+              "countDocuments": {
+                "filter": {
+                    "name": "Aaron"
+                }
+              }
+            }
+            """;
+
+      CountDocumentsCommands command = objectMapper.readValue(json, CountDocumentsCommands.class);
+      Operation result = resolver.resolveCommand(context, command);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              CountOperation.class,
+              op -> {
+                DBFilterBase.TextFilter expected =
+                    new DBFilterBase.TextFilter("name", Operator.EQ, "Aaron");
+
+                assertThat(op.commandContext()).isEqualTo(context);
+                assertThat(op.filters()).singleElement().isEqualTo(expected);
+              });
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does**:

Adaptation to spec for the `countDocuments`, including test improvements.

* [x] adapted status to `count` as per spec, from `counted_documents` (@kathirsvn fyi)
* [x] removed option class from command as per spec no options exists
* improved tests:
   * [x] added resolver test
   * [ ] added error case in operation tests
   * [x] several fixes for the integration tests:
      * assert no errors & data
      * few tests were missing `@Test` annotation
      * improved readability
      * [x] remove test order - not needed
* [x] fixed swagger examples


**Which issue(s) this PR fixes**:
Relates to #178.
