### PR TITLE
Add support for dot-notation path for $push update operator

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndUpdateIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindAndUpdateIntegrationTest.java
@@ -1239,7 +1239,7 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
                   {
                     "updateOne": {
                       "filter" : {"_id" : "update_doc_push"},
-                      "update" : {"$push" : {"array": 13 }}
+                      "update" : {"$push" : {"array": 13, "subdoc.array": true }}
                     }
                   }
                   """;
@@ -1255,7 +1255,8 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
           .body("status.modifiedCount", is(1));
       ;
 
-      String expected = "{\"_id\":\"update_doc_push\", \"array\": [2, 13]}";
+      String expected =
+          "{\"_id\":\"update_doc_push\", \"array\": [2, 13], \"subdoc\" : { \"array\" : [ true ] }}";
       json =
           """
                       {
@@ -1282,7 +1283,7 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
           """
                   {
                     "_id": "update_doc_push_each",
-                    "array": [ 1 ]
+                    "nested" : { "array": [ 1 ] }
                   }
                   """);
       String json =
@@ -1292,7 +1293,7 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
                       "filter" : {"_id" : "update_doc_push_each"},
                       "update" : {
                           "$push" : {
-                             "array": { "$each" : [ 2, 3 ] },
+                             "nested.array": { "$each" : [ 2, 3 ] },
                              "newArray": { "$each" : [ true ] }
                           }
                        }
@@ -1314,7 +1315,7 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
       String expected =
           """
             { "_id":"update_doc_push_each",
-              "array": [1, 2, 3],
+              "nested" : { "array": [1, 2, 3] },
               "newArray": [true] }
             """;
       json =
@@ -1354,7 +1355,7 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
                           "update" : {
                               "$push" : {
                                  "array": { "$each" : [ 4, 5 ], "$position" : 2 },
-                                 "newArray": { "$each" : [ 1, 2, 3 ], "$position" : -999 }
+                                 "nested.values": { "$each" : [ 1, 2, 3 ], "$position" : -999 }
                               }
                            }
                         }
@@ -1375,7 +1376,10 @@ public class FindAndUpdateIntegrationTest extends CollectionResourceBaseIntegrat
           """
                 { "_id":"update_doc_push_each_position",
                   "array": [1, 2, 4, 5, 3],
-                  "newArray": [1, 2, 3] }
+                  "nested": {
+                    "values" : [1, 2, 3]
+                  }
+                }
                 """;
       json =
           """


### PR DESCRIPTION
**What this PR does**:

Adds support for "dot-path" (nested docs, arrays) for `$push` operator

**Which issue(s) this PR fixes**:
Fixes #185
**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
