### PR TITLE
Fix #204: Remove "doc_properties" column, "docProperties" shredded doc field

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -38,7 +38,6 @@ public record CreateCollectionOperation(CommandContext commandContext, String na
             + "    key                 tuple<tinyint,text>,"
             + "    tx_id               timeuuid, "
             + "    doc_json            text,"
-            + "    doc_properties      map<text, int>,"
             + "    exist_keys          set<text>,"
             + "    sub_doc_equals      map<text, text>,"
             + "    array_size          map<text, int>,"
@@ -56,13 +55,6 @@ public record CreateCollectionOperation(CommandContext commandContext, String na
 
   protected List<QueryOuterClass.Query> getIndexStatements(String keyspace, String table) {
     List<QueryOuterClass.Query> statements = new ArrayList<>(10);
-
-    String propertyIndex =
-        "CREATE CUSTOM INDEX IF NOT EXISTS %s_doc_properties ON %s.%s (entries(doc_properties)) USING 'StorageAttachedIndex'";
-    statements.add(
-        QueryOuterClass.Query.newBuilder()
-            .setCql(String.format(propertyIndex, table, keyspace, table))
-            .build());
 
     String existKeys =
         "CREATE CUSTOM INDEX IF NOT EXISTS %s_exists_keys ON %s.%s (exist_keys) USING 'StorageAttachedIndex'";

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
@@ -60,9 +60,9 @@ public record InsertOperation(
   private QueryOuterClass.Query buildInsertQuery() {
     String insert =
         "INSERT INTO %s.%s"
-            + "            (key, tx_id, doc_json, doc_properties, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values)"
+            + "            (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values)"
             + "        VALUES"
-            + "            (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
+            + "            (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
     return QueryOuterClass.Query.newBuilder()
         .setCql(String.format(insert, commandContext.namespace(), commandContext.collection()))
         .build();
@@ -75,7 +75,6 @@ public record InsertOperation(
         QueryOuterClass.Values.newBuilder()
             .addValues(Values.of(CustomValueSerializers.getDocumentIdValue(doc.id())))
             .addValues(Values.of(doc.docJson()))
-            .addValues(Values.of(CustomValueSerializers.getIntegerMapValues(doc.docProperties())))
             .addValues(Values.of(CustomValueSerializers.getSetValue(doc.existKeys())))
             .addValues(Values.of(CustomValueSerializers.getStringMapValues(doc.subDocEquals())))
             .addValues(Values.of(CustomValueSerializers.getIntegerMapValues(doc.arraySize())))

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
@@ -152,7 +152,6 @@ public record ReadAndUpdateOperation(
         "UPDATE %s.%s "
             + "        SET"
             + "            tx_id = now(),"
-            + "            doc_properties = ?,"
             + "            exist_keys = ?,"
             + "            sub_doc_equals = ?,"
             + "            array_size = ?,"
@@ -177,7 +176,6 @@ public record ReadAndUpdateOperation(
     // respect the order in the DocsApiConstants.ALL_COLUMNS_NAMES
     QueryOuterClass.Values.Builder values =
         QueryOuterClass.Values.newBuilder()
-            .addValues(Values.of(CustomValueSerializers.getIntegerMapValues(doc.docProperties())))
             .addValues(Values.of(CustomValueSerializers.getSetValue(doc.existKeys())))
             .addValues(Values.of(CustomValueSerializers.getStringMapValues(doc.subDocEquals())))
             .addValues(Values.of(CustomValueSerializers.getIntegerMapValues(doc.arraySize())))

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/WritableShreddedDocument.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/WritableShreddedDocument.java
@@ -18,8 +18,6 @@ public record WritableShreddedDocument(
     /** Optional transaction id used for optimistic locking */
     UUID txID,
     String docJson,
-    /** !!! TODO: what purpose does this field serve? */
-    Map<JsonPath, Integer> docProperties,
     Set<JsonPath> existKeys,
     Map<JsonPath, String> subDocEquals,
     Map<JsonPath, Integer> arraySize,
@@ -48,8 +46,6 @@ public record WritableShreddedDocument(
     private final UUID txID;
 
     private final String docJson;
-
-    private Map<JsonPath, Integer> properties;
 
     private final Set<JsonPath> existKeys;
 
@@ -83,7 +79,6 @@ public record WritableShreddedDocument(
           id,
           txID,
           docJson,
-          _nonNull(properties),
           existKeys,
           _nonNull(subDocEquals),
           _nonNull(arraySize),

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
@@ -56,7 +56,6 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
             + "    key                 tuple<tinyint,text>,"
             + "    tx_id               timeuuid, "
             + "    doc_json            text,"
-            + "    doc_properties      map<text, int>,"
             + "    exist_keys          set<text>,"
             + "    sub_doc_equals      map<text, text>,"
             + "    array_size          map<text, int>,"
@@ -68,9 +67,6 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
             + "    query_null_values   set<text>,     "
             + "    PRIMARY KEY (key))";
     queries.add(create.formatted(namespace, collection));
-    queries.add(
-        "CREATE CUSTOM INDEX IF NOT EXISTS %s_doc_properties ON %s.%s (entries(doc_properties)) USING 'StorageAttachedIndex'"
-            .formatted(collection, namespace, collection));
     queries.add(
         "CREATE CUSTOM INDEX IF NOT EXISTS %s_exists_keys ON %s.%s (exist_keys) USING 'StorageAttachedIndex'"
             .formatted(collection, namespace, collection));

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
@@ -60,9 +60,9 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                     """;
       String insert =
           "INSERT INTO %s.%s"
-              + "            (key, tx_id, doc_json, doc_properties, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values)"
+              + "            (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values)"
               + "        VALUES"
-              + "            (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
+              + "            (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
       String collectionInsertCql = insert.formatted(KEYSPACE_NAME, COLLECTION_NAME);
       final JsonNode jsonNode = objectMapper.readTree(doc1);
       final WritableShreddedDocument shredDocument = shredder.shred(jsonNode);
@@ -72,8 +72,6 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   collectionInsertCql,
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument.id())),
                   Values.of(shredDocument.docJson()),
-                  Values.of(
-                      CustomValueSerializers.getIntegerMapValues(shredDocument.docProperties())),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
                   Values.of(
                       CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
@@ -134,9 +132,9 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                       """;
     String insert =
         "INSERT INTO %s.%s"
-            + "            (key, tx_id, doc_json, doc_properties, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values)"
+            + "            (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values)"
             + "        VALUES"
-            + "            (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
+            + "            (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
     String collectionInsertCql = insert.formatted(KEYSPACE_NAME, COLLECTION_NAME);
     final JsonNode jsonNode = objectMapper.readTree(doc1);
     final WritableShreddedDocument shredDocument = shredder.shred(jsonNode);
@@ -146,8 +144,6 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                 collectionInsertCql,
                 Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument.id())),
                 Values.of(shredDocument.docJson()),
-                Values.of(
-                    CustomValueSerializers.getIntegerMapValues(shredDocument.docProperties())),
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
                 Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -100,7 +100,6 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           "UPDATE %s.%s "
               + "        SET"
               + "            tx_id = now(),"
-              + "            doc_properties = ?,"
               + "            exist_keys = ?,"
               + "            sub_doc_equals = ?,"
               + "            array_size = ?,"
@@ -121,7 +120,6 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
 
       withQuery(
               collectionUpdateCql,
-              Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.docProperties())),
               Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
               Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
               Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
@@ -233,7 +231,6 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
         "UPDATE %s.%s "
             + "        SET"
             + "            tx_id = now(),"
-            + "            doc_properties = ?,"
             + "            exist_keys = ?,"
             + "            sub_doc_equals = ?,"
             + "            array_size = ?,"
@@ -254,7 +251,6 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
 
     withQuery(
             collectionUpdateCql,
-            Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.docProperties())),
             Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
             Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
             Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
@@ -480,7 +476,6 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
         "UPDATE %s.%s "
             + "        SET"
             + "            tx_id = now(),"
-            + "            doc_properties = ?,"
             + "            exist_keys = ?,"
             + "            sub_doc_equals = ?,"
             + "            array_size = ?,"
@@ -501,7 +496,6 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
 
     withQuery(
             collectionUpdateCql,
-            Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.docProperties())),
             Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
             Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
             Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
@@ -527,7 +521,6 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
 
     withQuery(
             collectionUpdateCql,
-            Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.docProperties())),
             Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
             Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
             Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
@@ -635,7 +628,6 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
         "UPDATE %s.%s "
             + "        SET"
             + "            tx_id = now(),"
-            + "            doc_properties = ?,"
             + "            exist_keys = ?,"
             + "            sub_doc_equals = ?,"
             + "            array_size = ?,"
@@ -656,7 +648,6 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
 
     withQuery(
             collectionUpdateCql,
-            Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.docProperties())),
             Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
             Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
             Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),


### PR DESCRIPTION
**What this PR does**:

Removes unused column/field "document properties".

**Which issue(s) this PR fixes**:
Fixes #204

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
