### PR TITLE
add failure mode test for countDocuments

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
@@ -168,7 +168,7 @@ public class CountOperationTest extends AbstractValidatingStargateBridgeTest {
 
     @Test
     public void error() {
-      // failures are propaged down
+      // failures are propagated down
       RuntimeException failure = new RuntimeException("Ivan fails the test.");
 
       String collectionReadCql =


### PR DESCRIPTION
**What this PR does**:
Ensure count operation propagate received errors, as per spec.
