### PR TITLE
relates to #178: insert commands per spec, added oerdered/unordered, better tests

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -196,24 +196,29 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                       """
                                     {
                                       "insertMany": {
-                                        "documents": [{
-                                          "_id": "1",
-                                          "location": "London",
-                                          "race": {
-                                            "competitors": 100,
-                                            "start_date": "2022-08-15"
-                                          },
-                                          "tags" : [ "eu" ]
-                                        },
-                                        {
-                                          "_id": "2",
-                                          "location": "New York",
-                                          "race": {
-                                            "competitors": 150,
-                                            "start_date": "2022-09-15"
-                                          },
-                                          "tags": [ "us" ]
-                                        }]
+                                        "documents": [
+                                            {
+                                              "_id": "1",
+                                              "location": "London",
+                                              "race": {
+                                                "competitors": 100,
+                                                "start_date": "2022-08-15"
+                                              },
+                                              "tags" : [ "eu" ]
+                                            },
+                                            {
+                                              "_id": "2",
+                                              "location": "New York",
+                                              "race": {
+                                                "competitors": 150,
+                                                "start_date": "2022-09-15"
+                                              },
+                                              "tags": [ "us" ]
+                                            }
+                                        ],
+                                        "options": {
+                                            "ordered": true
+                                        }
                                       }
                                     }
                                     """),
@@ -269,7 +274,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                             """),
               @ExampleObject(
                   name = "resultCount",
-                  summary = "countDocuments command result",
+                  summary = "`countDocuments` command result",
                   value =
                       """
                                     {
@@ -369,7 +374,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                               """),
               @ExampleObject(
                   name = "resultInsert",
-                  summary = "Insert command result",
+                  summary = "`insertOne` & `insertMany` command result",
                   value =
                       """
                       {

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
@@ -6,6 +6,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.Command;
 import io.stargate.sgv2.jsonapi.api.model.command.ModifyCommand;
 import java.util.List;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -20,6 +21,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @JsonTypeName("insertMany")
 public record InsertManyCommand(
     @NotNull
+        @NotEmpty
         @Schema(
             description = "JSON document to insert.",
             implementation = Object.class,

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
@@ -13,7 +13,8 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 /**
  * Representation of the insertMany API {@link Command}.
  *
- * @param document The document to insert.
+ * @param documents The document to insert.
+ * @param options Options for this command.
  */
 @Schema(description = "Command that inserts multiple JSON document to a collection.")
 @JsonTypeName("insertMany")
@@ -26,5 +27,12 @@ public record InsertManyCommand(
         List<JsonNode> documents,
     @Nullable Options options)
     implements ModifyCommand {
-  public record Options() {}
+
+  @Schema(name = "InsertManyCommand.Options", description = "Options for inserting many documents.")
+  public record Options(
+      @Schema(
+              description =
+                  "When `true` the server will insert the documents in sequential order, otherwise when `false` the server is free to re-order the inserts and parallelize them for performance. See specifications for more info on failure modes.",
+              defaultValue = "true")
+          Boolean ordered) {}
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertOneCommand.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.stargate.sgv2.jsonapi.api.model.command.Command;
 import io.stargate.sgv2.jsonapi.api.model.command.ModifyCommand;
-import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -22,8 +21,5 @@ public record InsertOneCommand(
             description = "JSON document to insert.",
             implementation = Object.class,
             type = SchemaType.OBJECT)
-        JsonNode document,
-    @Nullable Options options)
-    implements ModifyCommand {
-  public record Options() {}
-}
+        JsonNode document)
+    implements ModifyCommand {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
@@ -103,14 +103,14 @@ public class CollectionResource {
                   schema = @Schema(implementation = CommandResult.class),
                   examples = {
                     @ExampleObject(ref = "resultCount"),
+                    @ExampleObject(ref = "resultDeleteOne"),
+                    @ExampleObject(ref = "resultDeleteMany"),
                     @ExampleObject(ref = "resultRead"),
                     @ExampleObject(ref = "resultFindOneAndUpdate"),
                     @ExampleObject(ref = "resultInsert"),
-                    @ExampleObject(ref = "resultError"),
-                    @ExampleObject(ref = "resultDeleteOne"),
-                    @ExampleObject(ref = "resultDeleteMany"),
                     @ExampleObject(ref = "resultUpdateMany"),
                     @ExampleObject(ref = "resultUpdateOne"),
+                    @ExampleObject(ref = "resultError"),
                   })))
   @POST
   public Uni<RestResponse<CommandResult>> postCommand(

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -8,7 +8,7 @@ public enum ErrorCode {
 
   CONCURRENCY_FAILURE("Unable to complete transaction due to concurrent transactions"),
 
-  DOCUMENT_ALREADY_EXISTS("Document already exists with the id"),
+  DOCUMENT_ALREADY_EXISTS("Document already exists with the given _id"),
 
   DOCUMENT_UNPARSEABLE("Unable to parse the document"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/JsonApiException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/JsonApiException.java
@@ -58,4 +58,8 @@ public class JsonApiException extends RuntimeException implements Supplier<Comma
       return new CommandResult(List.of(error, causeError));
     }
   }
+
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.tuples.Tuple2;
 import io.stargate.bridge.grpc.Values;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
@@ -13,50 +14,138 @@ import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers
 import io.stargate.sgv2.jsonapi.service.operation.model.ModifyOperation;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
-/** Operation that inserts one or more documents. */
+/**
+ * Operation that inserts one or more documents.
+ *
+ * @param commandContext Context that defines namespace and database.
+ * @param documents Documents to insert.
+ * @param ordered If insert should be ordered.
+ */
 public record InsertOperation(
-    CommandContext commandContext, List<WritableShreddedDocument> documents)
+    CommandContext commandContext, List<WritableShreddedDocument> documents, boolean ordered)
     implements ModifyOperation {
 
   public InsertOperation(CommandContext commandContext, WritableShreddedDocument document) {
-    this(commandContext, List.of(document));
+    this(commandContext, List.of(document), true);
   }
 
   /** {@inheritDoc} */
   @Override
   public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
-    QueryOuterClass.Query query = buildInsertQuery();
-    final Uni<List<DocumentId>> ids =
-        Multi.createFrom()
-            .items(documents.stream())
-            .onItem()
-            .transformToUniAndConcatenate(doc -> insertDocument(queryExecutor, query, doc))
-            .collect()
-            .asList();
-    return ids.onItem().transform(insertedIds -> new InsertOperationPage(insertedIds, documents));
+    if (ordered) {
+      return insertOrdered(queryExecutor);
+    } else {
+      return insertUnordered(queryExecutor);
+    }
   }
 
+  // implementation for the ordered insert
+  private Uni<Supplier<CommandResult>> insertOrdered(QueryExecutor queryExecutor) {
+    // build query once
+    QueryOuterClass.Query query = buildInsertQuery();
+
+    return Multi.createFrom()
+        .iterable(documents)
+
+        // concatenate to respect ordered
+        .onItem()
+        .transformToUniAndConcatenate(
+            doc ->
+                insertDocument(queryExecutor, query, doc)
+
+                    // if we fail to insert propagate the FailFastInsertException
+                    .onFailure()
+                    .transform(t -> new FailFastInsertException(doc.id(), t)))
+
+        // if no failures reduce to the op page
+        .collect()
+        .in(InsertOperationPage::new, (agg, in) -> agg.aggregate(in, null))
+
+        // use object identity to resolve to Supplier<CommandResult>
+        .map(i -> i)
+
+        // in case upstream propagated FailFastInsertException
+        // ensure to construct correctly the information about inserted documents
+        .onFailure(FailFastInsertException.class)
+        .recoverWithItem(
+            e -> {
+              // safe to cast, asserted class in onFailure
+              FailFastInsertException failFastInsertException = (FailFastInsertException) e;
+              DocumentId failedId = failFastInsertException.documentId;
+
+              // collect inserted, since it's sequential iterate until failed id
+              List<DocumentId> insertedId = new ArrayList<>();
+              for (WritableShreddedDocument document : documents()) {
+                if (Objects.equals(document.id(), failedId)) {
+                  break;
+                }
+                insertedId.add(document.id());
+              }
+
+              return new InsertOperationPage(
+                  insertedId,
+                  Collections.singletonMap(failedId, failFastInsertException.getCause()));
+            })
+
+        // use object identity to resolve to Supplier<CommandResult>
+        .map(i -> i);
+  }
+
+  // implementation for the unordered insert
+  private Uni<Supplier<CommandResult>> insertUnordered(QueryExecutor queryExecutor) {
+    // build query once
+    QueryOuterClass.Query query = buildInsertQuery();
+
+    return Multi.createFrom()
+        .iterable(documents)
+
+        // merge to make it parallel
+        .onItem()
+        .transformToUniAndMerge(
+            doc ->
+                insertDocument(queryExecutor, query, doc)
+
+                    // handle errors fail silent mode
+                    .onItemOrFailure()
+                    .transform((id, t) -> Tuple2.of(doc, t)))
+
+        // then reduce here
+        .collect()
+        .in(InsertOperationPage::new, (agg, in) -> agg.aggregate(in.getItem1().id(), in.getItem2()))
+
+        // use object identity to resolve to Supplier<CommandResult>
+        .map(i -> i);
+  }
+
+  // inserts a single document
   private static Uni<DocumentId> insertDocument(
       QueryExecutor queryExecutor, QueryOuterClass.Query query, WritableShreddedDocument doc) {
-    query = bindInsertValues(query, doc);
+    // bind and execute
+    QueryOuterClass.Query bindedQuery = bindInsertValues(query, doc);
+
     return queryExecutor
-        .executeWrite(query)
+        .executeWrite(bindedQuery)
+
+        // ensure document was written, if no applied continue with error
         .onItem()
-        .transform(
+        .transformToUni(
             result -> {
               if (result.getRows(0).getValues(0).getBoolean()) {
-                return doc.id();
+                return Uni.createFrom().item(doc.id());
               } else {
-                throw new JsonApiException(
-                    ErrorCode.DOCUMENT_ALREADY_EXISTS,
-                    String.format("Document already exists with the _id: %s", doc.id()));
+                Exception failure = new JsonApiException(ErrorCode.DOCUMENT_ALREADY_EXISTS);
+                return Uni.createFrom().failure(failure);
               }
             });
   }
 
+  // utility for building the insert query
   private QueryOuterClass.Query buildInsertQuery() {
     String insert =
         "INSERT INTO %s.%s"
@@ -68,6 +157,7 @@ public record InsertOperation(
         .build();
   }
 
+  // utility for query binding
   private static QueryOuterClass.Query bindInsertValues(
       QueryOuterClass.Query builtQuery, WritableShreddedDocument doc) {
     // respect the order in the DocsApiConstants.ALL_COLUMNS_NAMES
@@ -86,5 +176,16 @@ public record InsertOperation(
             .addValues(Values.of(CustomValueSerializers.getStringMapValues(doc.queryTextValues())))
             .addValues(Values.of(CustomValueSerializers.getSetValue(doc.queryNullValues())));
     return QueryOuterClass.Query.newBuilder(builtQuery).setValues(values).build();
+  }
+
+  // simple exception to propagate fail fast
+  private static class FailFastInsertException extends Exception {
+
+    private final DocumentId documentId;
+
+    public FailFastInsertException(DocumentId documentId, Throwable cause) {
+      super(cause);
+      this.documentId = documentId;
+    }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
@@ -146,9 +146,10 @@ public record InsertOperation(
   private QueryOuterClass.Query buildInsertQuery() {
     String insert =
         "INSERT INTO %s.%s"
-            + "            (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values)"
-            + "        VALUES"
-            + "            (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
+            + " (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values)"
+            + " VALUES"
+            + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
+
     return QueryOuterClass.Query.newBuilder()
         .setCql(String.format(insert, commandContext.namespace(), commandContext.collection()))
         .build();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
@@ -50,14 +50,14 @@ public record InsertOperation(
     return Multi.createFrom()
         .iterable(documents)
 
-        // concatenate to respect ordered and do not prefetch items
+        // concatenate to respect ordered
         .onItem()
         .transformToUni(
             doc ->
                 insertDocument(queryExecutor, query, doc)
 
                     // wrap item and failure
-                    // no prefetch, the collection can decide how to react on failure
+                    // the collection can decide how to react on failure
                     .onItemOrFailure()
                     .transform((id, t) -> Tuple2.of(doc, t)))
         .concatenate(false)

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
@@ -65,9 +65,6 @@ public record InsertOperation(
         .collect()
         .in(InsertOperationPage::new, (agg, in) -> agg.aggregate(in, null))
 
-        // use object identity to resolve to Supplier<CommandResult>
-        .map(i -> i)
-
         // in case upstream propagated FailFastInsertException
         // ensure to construct correctly the information about inserted documents
         .onFailure(FailFastInsertException.class)

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationPage.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationPage.java
@@ -2,21 +2,73 @@ package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
 /**
- * The internal to modification operation results, what were the ID's of the docs we changed and
- * what change.
+ * The internal to insert operation results, keeping ids of successfully and not-successfully
+ * inserted documents.
+ *
+ * <p>Can serve as an aggregator, using the {@link #aggregate(WritableShreddedDocument, Throwable)}
+ * function.
+ *
+ * @param insertedIds Documents IDs that we successfully inserted.
+ * @param failedIds Document IDs that failed to be inserted.
  */
 public record InsertOperationPage(
-    List<DocumentId> insertedIds, List<WritableShreddedDocument> insertedDocs)
+    List<DocumentId> insertedIds, Map<DocumentId, Throwable> failedIds)
     implements Supplier<CommandResult> {
+
+  /** No-arg constructor, usually used for aggregation. */
+  public InsertOperationPage() {
+    this(new ArrayList<>(), new HashMap<>());
+  }
+
+  /** {@inheritDoc} */
   @Override
   public CommandResult get() {
+    // if we have errors, transform
+    if (null != failedIds && !failedIds().isEmpty()) {
+
+      List<CommandResult.Error> errors = new ArrayList<>(failedIds.size());
+      failedIds.forEach((documentId, throwable) -> errors.add(getError(documentId, throwable)));
+
+      return new CommandResult(null, Map.of(CommandStatus.INSERTED_IDS, insertedIds), errors);
+    }
+
+    // id no errors, just inserted ids
     return new CommandResult(Map.of(CommandStatus.INSERTED_IDS, insertedIds));
+  }
+
+  private static CommandResult.Error getError(DocumentId documentId, Throwable throwable) {
+    String message =
+        "Failed to insert document with _id %s: %s".formatted(documentId, throwable.getMessage());
+
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("exceptionClass", throwable.getClass().getSimpleName());
+    if (throwable instanceof JsonApiException jae) {
+      fields.put("errorCode", jae.getErrorCode().name());
+    }
+    return new CommandResult.Error(message, fields);
+  }
+
+  /**
+   * Aggregates the result of the insert operation into this object.
+   *
+   * @param id ID of the document that was inserted written.
+   * @param failure If not null, means an error occurred during the write.
+   */
+  public void aggregate(DocumentId id, Throwable failure) {
+    if (null != failure) {
+      failedIds.put(id, failure);
+    } else {
+      insertedIds.add(id);
+    }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertManyCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertManyCommandResolver.java
@@ -8,7 +8,6 @@ import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -31,7 +30,12 @@ public class InsertManyCommandResolver implements CommandResolver<InsertManyComm
   @Override
   public Operation resolveCommand(CommandContext ctx, InsertManyCommand command) {
     final List<WritableShreddedDocument> shreddedDocuments =
-        command.documents().stream().map(doc -> shredder.shred(doc)).collect(Collectors.toList());
-    return new InsertOperation(ctx, shreddedDocuments);
+        command.documents().stream().map(shredder::shred).toList();
+
+    // resolve ordered
+    InsertManyCommand.Options options = command.options();
+    boolean ordered = null == options || !Boolean.FALSE.equals(options.ordered());
+
+    return new InsertOperation(ctx, shreddedDocuments, ordered);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
@@ -137,8 +137,7 @@ class ObjectMapperConfigurationTest {
                 "some": {
                   "data": true
                 }
-              },
-              "options" :{}
+              }
             }
           }
           """;

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommandTest.java
@@ -1,0 +1,66 @@
+package io.stargate.sgv2.jsonapi.api.model.command.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+class InsertManyCommandTest {
+
+  @Inject ObjectMapper objectMapper;
+
+  @Inject Validator validator;
+
+  @Nested
+  class Validation {
+
+    @Test
+    public void noDocuments() throws Exception {
+      String json =
+          """
+                    {
+                      "insertMany": {
+                      }
+                    }
+                    """;
+
+      InsertManyCommand command = objectMapper.readValue(json, InsertManyCommand.class);
+      Set<ConstraintViolation<InsertManyCommand>> result = validator.validate(command);
+
+      assertThat(result)
+          .isNotEmpty()
+          .extracting(ConstraintViolation::getMessage)
+          .contains("must not be null");
+    }
+
+    @Test
+    public void documentsArrayEmpty() throws Exception {
+      String json =
+          """
+                    {
+                      "insertMany": {
+                        "documents": []
+                      }
+                    }
+                    """;
+
+      InsertManyCommand command = objectMapper.readValue(json, InsertManyCommand.class);
+      Set<ConstraintViolation<InsertManyCommand>> result = validator.validate(command);
+
+      assertThat(result)
+          .isNotEmpty()
+          .extracting(ConstraintViolation::getMessage)
+          .contains("must not be empty");
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommandTest.java
@@ -28,11 +28,11 @@ class InsertManyCommandTest {
     public void noDocuments() throws Exception {
       String json =
           """
-                    {
-                      "insertMany": {
-                      }
-                    }
-                    """;
+          {
+            "insertMany": {
+            }
+          }
+          """;
 
       InsertManyCommand command = objectMapper.readValue(json, InsertManyCommand.class);
       Set<ConstraintViolation<InsertManyCommand>> result = validator.validate(command);
@@ -47,12 +47,12 @@ class InsertManyCommandTest {
     public void documentsArrayEmpty() throws Exception {
       String json =
           """
-                    {
-                      "insertMany": {
-                        "documents": []
-                      }
-                    }
-                    """;
+          {
+            "insertMany": {
+              "documents": []
+            }
+          }
+          """;
 
       InsertManyCommand command = objectMapper.readValue(json, InsertManyCommand.class);
       Set<ConstraintViolation<InsertManyCommand>> result = validator.validate(command);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertOneCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertOneCommandTest.java
@@ -29,11 +29,11 @@ class InsertOneCommandTest {
     public void noDocument() throws Exception {
       String json =
           """
-                    {
-                      "insertOne": {
-                      }
-                    }
-                    """;
+          {
+            "insertOne": {
+            }
+          }
+          """;
 
       InsertOneCommand command = objectMapper.readValue(json, InsertOneCommand.class);
       Set<ConstraintViolation<InsertOneCommand>> result = validator.validate(command);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertOneCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertOneCommandTest.java
@@ -1,0 +1,47 @@
+package io.stargate.sgv2.jsonapi.api.model.command.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+class InsertOneCommandTest {
+
+  @Inject ObjectMapper objectMapper;
+
+  @Inject Validator validator;
+
+  @Nested
+  class Validation {
+
+    @Test
+    public void noDocument() throws Exception {
+      String json =
+          """
+                    {
+                      "insertOne": {
+                      }
+                    }
+                    """;
+
+      InsertOneCommand command = objectMapper.readValue(json, InsertOneCommand.class);
+      Set<ConstraintViolation<InsertOneCommand>> result = validator.validate(command);
+
+      assertThat(result)
+          .isNotEmpty()
+          .extracting(ConstraintViolation::getMessage)
+          .contains("must not be null");
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -397,7 +397,7 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
     }
 
     @Test
-    public void orderedDuplicateIdsNoNamespace() {
+    public void orderedDuplicateDocumentNoNamespace() {
       String json =
           """
           {
@@ -409,7 +409,7 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
                 },
                 {
                   "_id": "doc4",
-                  "username": "user4_duplicate"
+                  "username": "user4"
                 },
                 {
                   "_id": "doc5",

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -5,14 +5,20 @@ import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.Matchers.blankString;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -20,21 +26,42 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(DseTestResource.class)
 public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest {
 
+  @AfterEach
+  public void cleanUpData() {
+    String json =
+        """
+            {
+              "deleteMany": {
+              }
+            }
+            """;
+
+    given()
+        .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+        .then()
+        .statusCode(200);
+  }
+
   @Nested
   class InsertOne {
+
     @Test
     public void insertDocument() {
       String json =
           """
-                    {
-                      "insertOne": {
-                        "document": {
-                          "_id": "doc3",
-                          "username": "user3"
-                        }
-                      }
-                    }
-                    """;
+          {
+            "insertOne": {
+              "document": {
+                "_id": "doc3",
+                "username": "user3"
+              }
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -44,7 +71,9 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.insertedIds[0]", is("doc3"));
+          .body("status.insertedIds[0]", is("doc3"))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
 
       json =
           """
@@ -54,7 +83,14 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
             }
           }
           """;
-      String expected = "{\"_id\":\"doc3\", \"username\":\"user3\"}";
+      String expected =
+          """
+          {
+            "_id":"doc3",
+            "username":"user3"
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -63,22 +99,23 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("data.docs[0]", jsonEquals(expected));
+          .body("data.docs[0]", jsonEquals(expected))
+          .body("errors", is(nullValue()));
     }
 
     @Test
     public void insertDocumentWithNumberId() {
       String json =
           """
-                        {
-                          "insertOne": {
-                            "document": {
-                              "_id": 4,
-                              "username": "user4"
-                            }
-                          }
-                        }
-                        """;
+          {
+            "insertOne": {
+              "document": {
+                "_id": 4,
+                "username": "user4"
+              }
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -88,17 +125,26 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.insertedIds[0]", is(4));
+          .body("status.insertedIds[0]", is(4))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
 
       json =
           """
-              {
-                "find": {
-                  "filter" : {"_id" : 4}
-                }
-              }
-              """;
-      String expected = "{\"_id\": 4, \"username\":\"user4\"}";
+          {
+            "find": {
+              "filter" : {"_id" : 4}
+            }
+          }
+          """;
+      String expected =
+          """
+          {
+            "_id": 4,
+            "username":"user4"
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -107,22 +153,23 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("data.docs[0]", jsonEquals(expected));
+          .body("data.docs[0]", jsonEquals(expected))
+          .body("errors", is(nullValue()));
     }
 
     @Test
     public void insertDuplicateDocument() {
       String json =
           """
-                            {
-                              "insertOne": {
-                                "document": {
-                                  "_id": "duplicate",
-                                  "username": "user4"
-                                }
-                              }
-                            }
-                            """;
+          {
+            "insertOne": {
+              "document": {
+                "_id": "duplicate",
+                "username": "user4"
+              }
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -132,19 +179,21 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.insertedIds[0]", is("duplicate"));
+          .body("status.insertedIds[0]", is("duplicate"))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
 
       json =
           """
-                    {
-                      "insertOne": {
-                        "document": {
-                          "_id": "duplicate",
-                          "username": "different_user_name"
-                        }
-                      }
-                    }
-                    """;
+          {
+            "insertOne": {
+              "document": {
+                "_id": "duplicate",
+                "username": "different_user_name"
+              }
+            }
+          }
+          """;
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -153,17 +202,29 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("errors[0].message", is("Document already exists with the _id: duplicate"));
+          .body("status.insertedIds", jsonEquals("[]"))
+          .body(
+              "errors[0].message",
+              is(
+                  "Failed to insert document with _id duplicate: Document already exists with the given _id"))
+          .body("errors[0].errorCode", is("DOCUMENT_ALREADY_EXISTS"));
 
       json =
           """
-                  {
-                    "find": {
-                      "filter" : {"_id" : "duplicate"}
-                    }
-                  }
-                  """;
-      String expected = "{\"_id\": \"duplicate\", \"username\":\"user4\"}";
+          {
+            "find": {
+              "filter" : {"_id" : "duplicate"}
+            }
+          }
+          """;
+      String expected =
+          """
+              {
+                "_id": "duplicate",
+                "username":"user4"
+              }
+              """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -179,13 +240,13 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
     public void emptyDocument() {
       String json =
           """
-                    {
-                      "insertOne": {
-                        "document": {
-                        }
-                      }
-                    }
-                    """;
+          {
+            "insertOne": {
+              "document": {
+              }
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -194,18 +255,21 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
           .when()
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
-          .statusCode(200);
+          .statusCode(200)
+          .body("status.insertedIds[0]", is(notNullValue()))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
 
     @Test
     public void notValidDocumentMissing() {
       String json =
           """
-                    {
-                      "insertOne": {
-                      }
-                    }
-                    """;
+          {
+            "insertOne": {
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -222,43 +286,301 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
 
   @Nested
   class InsertMany {
+
     @Test
-    public void insertDocument() {
+    public void ordered() {
       String json =
           """
-                    {
-                      "insertMany": {
-                        "documents": [{
-                          "_id": "doc4",
-                          "username": "user4"
-                        },
-                        {
-                          "_id": "doc5",
-                          "username": "user5"
-                        }]
-                      }
-                    }
-                    """;
-
-      given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.insertedIds", contains("doc4", "doc5"));
-
-      json =
-          """
+          {
+            "insertMany": {
+              "documents": [
                 {
-                  "find": {
-                    "filter" : {"_id" : "doc4"}
-                  }
+                  "_id": "doc4",
+                  "username": "user4"
+                },
+                {
+                  "_id": "doc5",
+                  "username": "user5"
                 }
-                """;
-      String expected = "{\"_id\":\"doc4\", \"username\":\"user4\"}";
+              ]
+            }
+          }
+          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.insertedIds", contains("doc4", "doc5"))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
+
+      json =
+          """
+          {
+            "countDocuments": {
+            }
+          }
+          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.count", is(2))
+          .body("errors", is(nullValue()));
+    }
+
+    @Test
+    public void orderedDuplicateIds() {
+      String json =
+          """
+          {
+            "insertMany": {
+              "documents": [
+                {
+                  "_id": "doc4",
+                  "username": "user4"
+                },
+                {
+                  "_id": "doc4",
+                  "username": "user4_duplicate"
+                },
+                {
+                  "_id": "doc5",
+                  "username": "user5"
+                }
+              ]
+            }
+          }
+          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.insertedIds", contains("doc4"))
+          .body("data", is(nullValue()))
+          .body("errors[0].message", startsWith("Failed to insert document with _id doc4"))
+          .body("errors[0].errorCode", is("DOCUMENT_ALREADY_EXISTS"));
+
+      json =
+          """
+          {
+            "countDocuments": {
+            }
+          }
+          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.count", is(1))
+          .body("errors", is(nullValue()));
+    }
+
+    @Test
+    public void unordered() {
+      String json =
+          """
+          {
+            "insertMany": {
+              "documents": [
+                {
+                  "_id": "doc4",
+                  "username": "user4"
+                },
+                {
+                  "_id": "doc5",
+                  "username": "user5"
+                }
+              ],
+              "options": { "ordered": false }
+            }
+          }
+          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.insertedIds", containsInAnyOrder("doc4", "doc5"))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
+
+      json =
+          """
+          {
+            "countDocuments": {
+            }
+          }
+          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.count", is(2))
+          .body("errors", is(nullValue()));
+    }
+
+    @Test
+    public void unorderedDuplicateIds() {
+      String json =
+          """
+          {
+            "insertMany": {
+              "documents": [
+                {
+                  "_id": "doc4",
+                  "username": "user4"
+                },
+                {
+                  "_id": "doc4",
+                  "username": "user4"
+                },
+                {
+                  "_id": "doc5",
+                  "username": "user5"
+                }
+              ],
+              "options": { "ordered": false }
+            }
+          }
+          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.insertedIds", containsInAnyOrder("doc4", "doc5"))
+          .body("data", is(nullValue()))
+          .body("errors[0].message", startsWith("Failed to insert document with _id doc4"))
+          .body("errors[0].errorCode", is("DOCUMENT_ALREADY_EXISTS"));
+
+      json =
+          """
+          {
+            "countDocuments": {
+            }
+          }
+          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.count", is(2))
+          .body("errors", is(nullValue()));
+    }
+
+    @Test
+    public void withDifferentTypes() {
+      String json =
+          """
+          {
+            "insertMany": {
+              "documents": [
+                {
+                  "_id": "5",
+                  "username": "user_id_5"
+                },
+                {
+                  "_id": 5,
+                  "username": "user_id_5_number"
+                }
+              ]
+            }
+          }
+          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.insertedIds", contains("5", 5))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
+
+      json =
+          """
+          {
+            "find": {
+              "filter" : {"_id" : "5"}
+            }
+          }
+          """;
+      String expected =
+          """
+          {
+            "_id": "5",
+            "username":"user_id_5"
+          }
+          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(expected));
+
+      json =
+          """
+          {
+            "find": {
+              "filter" : {"_id" : 5}
+            }
+          }
+          """;
+      expected =
+          """
+          {
+            "_id": 5,
+            "username":"user_id_5_number"
+          }
+          """;
+
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -271,22 +593,18 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
     }
 
     @Test
-    public void insertDocumentWithDifferentTypes() {
+    public void emptyDocuments() {
       String json =
           """
-                        {
-                          "insertMany": {
-                            "documents": [{
-                              "_id": "5",
-                              "username": "user_id_5"
-                            },
-                            {
-                              "_id": 5,
-                              "username": "user_id_5_number"
-                            }]
-                          }
-                        }
-                        """;
+          {
+            "insertMany": {
+              "documents": [
+                {},
+                {}
+              ]
+            }
+          }
+          """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -296,67 +614,9 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("status.insertedIds", contains("5", 5));
-
-      json =
-          """
-                    {
-                      "find": {
-                        "filter" : {"_id" : "5"}
-                      }
-                    }
-                    """;
-      String expected = "{\"_id\":\"5\", \"username\":\"user_id_5\"}";
-      given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
-          .then()
-          .statusCode(200)
-          .body("data.docs[0]", jsonEquals(expected));
-
-      json =
-          """
-                    {
-                      "find": {
-                        "filter" : {"_id" : 5}
-                      }
-                    }
-                    """;
-      expected = "{\"_id\":5, \"username\":\"user_id_5_number\"}";
-      given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
-          .then()
-          .statusCode(200)
-          .body("data.docs[0]", jsonEquals(expected));
-    }
-
-    @Test
-    public void emptyDocument() {
-      String json =
-          """
-                    {
-                      "insertMany": {
-                        "documents": [{
-                        }]
-                      }
-                    }
-                    """;
-
-      given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
-          .then()
-          .statusCode(200);
+          .body("status.insertedIds", hasSize(2))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -28,13 +28,12 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
 
   @AfterEach
   public void cleanUpData() {
-    String json =
-        """
-            {
-              "deleteMany": {
-              }
-            }
-            """;
+    String json = """
+        {
+          "deleteMany": {
+          }
+        }
+        """;
 
     given()
         .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.bridge.grpc.TypeSpecs;
 import io.stargate.bridge.grpc.Values;
@@ -22,7 +21,6 @@ import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 import javax.inject.Inject;
@@ -35,41 +33,44 @@ import org.junit.jupiter.api.Test;
 public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
   private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
   private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
-  private CommandContext commandContext = new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);
+  private static final CommandContext COMMAND_CONTEXT =
+      new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);
 
   @Inject Shredder shredder;
   @Inject ObjectMapper objectMapper;
   @Inject QueryExecutor queryExecutor;
 
   @Nested
-  class InsertOperationsTest {
+  class Execute {
+
+    static final String INSERT_CQL =
+        "INSERT INTO %s.%s"
+            + " (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values)"
+            + " VALUES"
+            + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
 
     @Test
     public void insertOne() throws Exception {
-      String doc1 =
+      String document =
           """
-                    {
-                          "_id": "doc1",
-                          "text": "user1",
-                          "number" : 10,
-                          "boolean": true,
-                          "nullval" : null,
-                          "array" : ["a", "b"],
-                          "sub_doc" : {"col": "val"}
-                        }
-                    """;
-      String insert =
-          "INSERT INTO %s.%s"
-              + "            (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values)"
-              + "        VALUES"
-              + "            (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
-      String collectionInsertCql = insert.formatted(KEYSPACE_NAME, COLLECTION_NAME);
-      final JsonNode jsonNode = objectMapper.readTree(doc1);
-      final WritableShreddedDocument shredDocument = shredder.shred(jsonNode);
+          {
+            "_id": "doc1",
+            "text": "user1",
+            "number" : 10,
+            "boolean": true,
+            "nullval" : null,
+            "array" : ["a", "b"],
+            "sub_doc" : {"col": "val"}
+          }
+          """;
 
-      ValidatingStargateBridge.QueryAssert candidatesAssert =
+      JsonNode jsonNode = objectMapper.readTree(document);
+      WritableShreddedDocument shredDocument = shredder.shred(jsonNode);
+
+      String insertCql = INSERT_CQL.formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert insertAssert =
           withQuery(
-                  collectionInsertCql,
+                  insertCql,
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument.id())),
                   Values.of(shredDocument.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
@@ -94,99 +95,784 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                           .build()))
               .returning(List.of(List.of(Values.of(true))));
 
-      InsertOperation operation = new InsertOperation(commandContext, shredDocument);
-      final Uni<Supplier<CommandResult>> execute = operation.execute(queryExecutor);
-      final CommandResult commandResultSupplier =
-          execute.subscribe().asCompletionStage().get().get();
+      InsertOperation operation = new InsertOperation(COMMAND_CONTEXT, shredDocument);
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
 
-      UniAssertSubscriber<Supplier<CommandResult>> subscriber =
-          operation.execute(queryExecutor).subscribe().withSubscriber(UniAssertSubscriber.create());
+      // assert query execution
+      insertAssert.assertExecuteCount().isOne();
 
-      assertThat(commandResultSupplier)
+      // then result
+      CommandResult result = execute.get();
+      assertThat(result.status())
+          .hasSize(1)
+          .containsEntry(CommandStatus.INSERTED_IDS, List.of(new DocumentId.StringId("doc1")));
+      assertThat(result.errors()).isNull();
+    }
+
+    @Test
+    public void insertDuplicate() throws Exception {
+      String doc1 =
+          """
+          {
+            "_id": "doc1",
+            "text": "user1",
+            "number" : 10,
+            "boolean": true,
+            "nullval" : null,
+            "array" : ["a", "b"],
+            "sub_doc" : {"col": "val"}
+          }
+          """;
+
+      final JsonNode jsonNode = objectMapper.readTree(doc1);
+      final WritableShreddedDocument shredDocument = shredder.shred(jsonNode);
+
+      String insertCql = INSERT_CQL.formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert insertAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument.id())),
+                  Values.of(shredDocument.docJson()),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
+                  Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
+                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
+                  Values.of(
+                      CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
+                  Values.of(
+                      CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
+                  Values.of(
+                      CustomValueSerializers.getDoubleMapValues(shredDocument.queryNumberValues())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument.queryTextValues())),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument.queryNullValues())))
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("applied")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build()))
+              .returning(List.of(List.of(Values.of(false))));
+
+      InsertOperation operation = new InsertOperation(COMMAND_CONTEXT, shredDocument);
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
+
+      // assert query execution
+      insertAssert.assertExecuteCount().isOne();
+
+      // then result
+      CommandResult result = execute.get();
+      assertThat(result.status()).hasSize(1).containsEntry(CommandStatus.INSERTED_IDS, List.of());
+      assertThat(result.errors())
+          .singleElement()
           .satisfies(
-              commandResult -> {
-                assertThat(commandResultSupplier.status()).isNotNull();
-                assertThat(commandResultSupplier.status().get(CommandStatus.INSERTED_IDS))
-                    .isNotNull();
-                assertThat(
-                        (List<DocumentId>)
-                            commandResultSupplier.status().get(CommandStatus.INSERTED_IDS))
-                    .contains(new DocumentId.StringId("doc1"));
+              error -> {
+                assertThat(error.message())
+                    .isEqualTo(
+                        "Failed to insert document with _id doc1: Document already exists with the given _id");
+                assertThat(error.fields())
+                    .containsEntry("exceptionClass", "JsonApiException")
+                    .containsEntry("errorCode", "DOCUMENT_ALREADY_EXISTS");
               });
     }
-  }
 
-  @Test
-  public void insertDuplicate() throws Exception {
-    String doc1 =
-        """
-                      {
-                            "_id": "doc1",
-                            "text": "user1",
-                            "number" : 10,
-                            "boolean": true,
-                            "nullval" : null,
-                            "array" : ["a", "b"],
-                            "sub_doc" : {"col": "val"}
-                          }
-                      """;
-    String insert =
-        "INSERT INTO %s.%s"
-            + "            (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values)"
-            + "        VALUES"
-            + "            (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
-    String collectionInsertCql = insert.formatted(KEYSPACE_NAME, COLLECTION_NAME);
-    final JsonNode jsonNode = objectMapper.readTree(doc1);
-    final WritableShreddedDocument shredDocument = shredder.shred(jsonNode);
+    @Test
+    public void insertManyOrdered() throws Exception {
+      String document1 =
+          """
+          {
+            "_id": "doc1",
+            "text": "user1",
+            "number" : 10,
+            "boolean": true,
+            "nullval" : null,
+            "array" : ["a", "b"],
+            "sub_doc" : {"col": "val"}
+          }
+          """;
+      String document2 =
+          """
+          {
+            "_id": "doc2",
+            "text": "user2",
+            "number" : 11,
+            "boolean": false,
+            "nullval" : null,
+            "array" : ["c", "d"],
+            "sub_doc" : {"col": "lav"}
+          }
+          """;
 
-    ValidatingStargateBridge.QueryAssert candidatesAssert =
-        withQuery(
-                collectionInsertCql,
-                Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument.id())),
-                Values.of(shredDocument.docJson()),
-                Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
-                Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
-                Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
-                Values.of(
-                    CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
-                Values.of(
-                    CustomValueSerializers.getDoubleMapValues(shredDocument.queryNumberValues())),
-                Values.of(
-                    CustomValueSerializers.getStringMapValues(shredDocument.queryTextValues())),
-                Values.of(CustomValueSerializers.getSetValue(shredDocument.queryNullValues())))
-            .withColumnSpec(
-                List.of(
-                    QueryOuterClass.ColumnSpec.newBuilder()
-                        .setName("applied")
-                        .setType(TypeSpecs.BOOLEAN)
-                        .build()))
-            .returning(List.of(List.of(Values.of(false))));
+      JsonNode jsonNode1 = objectMapper.readTree(document1);
+      WritableShreddedDocument shredDocument1 = shredder.shred(jsonNode1);
 
-    InsertOperation operation = new InsertOperation(commandContext, shredDocument);
-    Supplier<CommandResult> execute =
-        operation
-            .execute(queryExecutor)
-            .subscribe()
-            .withSubscriber(UniAssertSubscriber.create())
-            .awaitItem()
-            .getItem();
+      JsonNode jsonNode2 = objectMapper.readTree(document2);
+      WritableShreddedDocument shredDocument2 = shredder.shred(jsonNode2);
 
-    CommandResult result = execute.get();
-    assertThat(result.status())
-        .hasSize(1)
-        .containsEntry(CommandStatus.INSERTED_IDS, Collections.emptyList());
-    assertThat(result.errors())
-        .singleElement()
-        .satisfies(
-            error -> {
-              assertThat(error.message())
-                  .isEqualTo(
-                      "Failed to insert document with _id doc1: Document already exists with the given _id");
-              assertThat(error.fields())
-                  .containsEntry("exceptionClass", "JsonApiException")
-                  .containsEntry("errorCode", "DOCUMENT_ALREADY_EXISTS");
-            });
+      String insertCql = INSERT_CQL.formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert insertFirstAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument1.id())),
+                  Values.of(shredDocument1.docJson()),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument1.existKeys())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.subDocEquals())),
+                  Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument1.arraySize())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.arrayEquals())),
+                  Values.of(
+                      CustomValueSerializers.getStringSetValue(shredDocument1.arrayContains())),
+                  Values.of(
+                      CustomValueSerializers.getBooleanMapValues(shredDocument1.queryBoolValues())),
+                  Values.of(
+                      CustomValueSerializers.getDoubleMapValues(
+                          shredDocument1.queryNumberValues())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.queryTextValues())),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument1.queryNullValues())))
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("applied")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build()))
+              .returning(List.of(List.of(Values.of(true))));
+      ValidatingStargateBridge.QueryAssert insertSecondAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument2.id())),
+                  Values.of(shredDocument2.docJson()),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument2.existKeys())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.subDocEquals())),
+                  Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument2.arraySize())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.arrayEquals())),
+                  Values.of(
+                      CustomValueSerializers.getStringSetValue(shredDocument2.arrayContains())),
+                  Values.of(
+                      CustomValueSerializers.getBooleanMapValues(shredDocument2.queryBoolValues())),
+                  Values.of(
+                      CustomValueSerializers.getDoubleMapValues(
+                          shredDocument2.queryNumberValues())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.queryTextValues())),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument2.queryNullValues())))
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("applied")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build()))
+              .returning(List.of(List.of(Values.of(true))));
+
+      InsertOperation operation =
+          new InsertOperation(COMMAND_CONTEXT, List.of(shredDocument1, shredDocument2), true);
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
+
+      // assert query execution
+      insertFirstAssert.assertExecuteCount().isOne();
+      insertSecondAssert.assertExecuteCount().isOne();
+
+      // then result
+      CommandResult result = execute.get();
+      assertThat(result.status())
+          .hasSize(1)
+          .containsEntry(
+              CommandStatus.INSERTED_IDS,
+              List.of(new DocumentId.StringId("doc1"), new DocumentId.StringId("doc2")));
+      assertThat(result.errors()).isNull();
+    }
+
+    @Test
+    public void insertManyUnordered() throws Exception {
+      String document1 =
+          """
+          {
+            "_id": "doc1",
+            "text": "user1",
+            "number" : 10,
+            "boolean": true,
+            "nullval" : null,
+            "array" : ["a", "b"],
+            "sub_doc" : {"col": "val"}
+          }
+          """;
+      String document2 =
+          """
+          {
+            "_id": "doc2",
+            "text": "user2",
+            "number" : 11,
+            "boolean": false,
+            "nullval" : null,
+            "array" : ["c", "d"],
+            "sub_doc" : {"col": "lav"}
+          }
+          """;
+
+      JsonNode jsonNode1 = objectMapper.readTree(document1);
+      WritableShreddedDocument shredDocument1 = shredder.shred(jsonNode1);
+
+      JsonNode jsonNode2 = objectMapper.readTree(document2);
+      WritableShreddedDocument shredDocument2 = shredder.shred(jsonNode2);
+
+      String insertCql = INSERT_CQL.formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert insertFirstAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument1.id())),
+                  Values.of(shredDocument1.docJson()),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument1.existKeys())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.subDocEquals())),
+                  Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument1.arraySize())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.arrayEquals())),
+                  Values.of(
+                      CustomValueSerializers.getStringSetValue(shredDocument1.arrayContains())),
+                  Values.of(
+                      CustomValueSerializers.getBooleanMapValues(shredDocument1.queryBoolValues())),
+                  Values.of(
+                      CustomValueSerializers.getDoubleMapValues(
+                          shredDocument1.queryNumberValues())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.queryTextValues())),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument1.queryNullValues())))
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("applied")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build()))
+              .returning(List.of(List.of(Values.of(true))));
+      ValidatingStargateBridge.QueryAssert insertSecondAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument2.id())),
+                  Values.of(shredDocument2.docJson()),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument2.existKeys())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.subDocEquals())),
+                  Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument2.arraySize())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.arrayEquals())),
+                  Values.of(
+                      CustomValueSerializers.getStringSetValue(shredDocument2.arrayContains())),
+                  Values.of(
+                      CustomValueSerializers.getBooleanMapValues(shredDocument2.queryBoolValues())),
+                  Values.of(
+                      CustomValueSerializers.getDoubleMapValues(
+                          shredDocument2.queryNumberValues())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.queryTextValues())),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument2.queryNullValues())))
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("applied")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build()))
+              .returning(List.of(List.of(Values.of(true))));
+
+      InsertOperation operation =
+          new InsertOperation(COMMAND_CONTEXT, List.of(shredDocument1, shredDocument2), false);
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
+
+      // assert query execution
+      insertFirstAssert.assertExecuteCount().isOne();
+      insertSecondAssert.assertExecuteCount().isOne();
+
+      // then result
+      CommandResult result = execute.get();
+      assertThat(result.status()).hasSize(1);
+      assertThat(result.status().get(CommandStatus.INSERTED_IDS))
+          .asList()
+          .containsExactlyInAnyOrder(
+              new DocumentId.StringId("doc1"), new DocumentId.StringId("doc2"));
+      assertThat(result.errors()).isNull();
+    }
+
+    // failure modes
+
+    @Test
+    public void failureOrdered() throws Exception {
+      // unordered first query fail
+      String document1 =
+          """
+          {
+            "_id": "doc1",
+            "text": "user1",
+            "number" : 10,
+            "boolean": true,
+            "nullval" : null,
+            "array" : ["a", "b"],
+            "sub_doc" : {"col": "val"}
+          }
+          """;
+      String document2 =
+          """
+          {
+            "_id": "doc2",
+            "text": "user2",
+            "number" : 11,
+            "boolean": false,
+            "nullval" : null,
+            "array" : ["c", "d"],
+            "sub_doc" : {"col": "lav"}
+          }
+          """;
+
+      JsonNode jsonNode1 = objectMapper.readTree(document1);
+      WritableShreddedDocument shredDocument1 = shredder.shred(jsonNode1);
+
+      JsonNode jsonNode2 = objectMapper.readTree(document2);
+      WritableShreddedDocument shredDocument2 = shredder.shred(jsonNode2);
+
+      String insertCql = INSERT_CQL.formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert insertFirstAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument1.id())),
+                  Values.of(shredDocument1.docJson()),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument1.existKeys())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.subDocEquals())),
+                  Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument1.arraySize())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.arrayEquals())),
+                  Values.of(
+                      CustomValueSerializers.getStringSetValue(shredDocument1.arrayContains())),
+                  Values.of(
+                      CustomValueSerializers.getBooleanMapValues(shredDocument1.queryBoolValues())),
+                  Values.of(
+                      CustomValueSerializers.getDoubleMapValues(
+                          shredDocument1.queryNumberValues())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.queryTextValues())),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument1.queryNullValues())))
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("applied")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build()))
+              .returningFailure(new RuntimeException("Ivan breaks the test."));
+
+      InsertOperation operation =
+          new InsertOperation(COMMAND_CONTEXT, List.of(shredDocument1, shredDocument2), true);
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
+
+      // assert query execution
+      // second query never executed
+      insertFirstAssert.assertExecuteCount().isOne();
+
+      // then result
+      CommandResult result = execute.get();
+      assertThat(result.status()).hasSize(1).containsEntry(CommandStatus.INSERTED_IDS, List.of());
+      assertThat(result.errors())
+          .singleElement()
+          .satisfies(
+              error -> {
+                assertThat(error.message())
+                    .isEqualTo("Failed to insert document with _id doc1: Ivan breaks the test.");
+                assertThat(error.fields()).containsEntry("exceptionClass", "RuntimeException");
+              });
+    }
+
+    @Test
+    public void failureOrderedLastFails() throws Exception {
+      // unordered first query OK, second fail
+      String document1 =
+          """
+          {
+            "_id": "doc1",
+            "text": "user1",
+            "number" : 10,
+            "boolean": true,
+            "nullval" : null,
+            "array" : ["a", "b"],
+            "sub_doc" : {"col": "val"}
+          }
+          """;
+      String document2 =
+          """
+          {
+            "_id": "doc2",
+            "text": "user2",
+            "number" : 11,
+            "boolean": false,
+            "nullval" : null,
+            "array" : ["c", "d"],
+            "sub_doc" : {"col": "lav"}
+          }
+          """;
+
+      JsonNode jsonNode1 = objectMapper.readTree(document1);
+      WritableShreddedDocument shredDocument1 = shredder.shred(jsonNode1);
+
+      JsonNode jsonNode2 = objectMapper.readTree(document2);
+      WritableShreddedDocument shredDocument2 = shredder.shred(jsonNode2);
+
+      String insertCql = INSERT_CQL.formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert insertFirstAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument1.id())),
+                  Values.of(shredDocument1.docJson()),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument1.existKeys())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.subDocEquals())),
+                  Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument1.arraySize())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.arrayEquals())),
+                  Values.of(
+                      CustomValueSerializers.getStringSetValue(shredDocument1.arrayContains())),
+                  Values.of(
+                      CustomValueSerializers.getBooleanMapValues(shredDocument1.queryBoolValues())),
+                  Values.of(
+                      CustomValueSerializers.getDoubleMapValues(
+                          shredDocument1.queryNumberValues())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.queryTextValues())),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument1.queryNullValues())))
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("applied")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build()))
+              .returning(List.of(List.of(Values.of(true))));
+      ValidatingStargateBridge.QueryAssert insertSecondAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument2.id())),
+                  Values.of(shredDocument2.docJson()),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument2.existKeys())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.subDocEquals())),
+                  Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument2.arraySize())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.arrayEquals())),
+                  Values.of(
+                      CustomValueSerializers.getStringSetValue(shredDocument2.arrayContains())),
+                  Values.of(
+                      CustomValueSerializers.getBooleanMapValues(shredDocument2.queryBoolValues())),
+                  Values.of(
+                      CustomValueSerializers.getDoubleMapValues(
+                          shredDocument2.queryNumberValues())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.queryTextValues())),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument2.queryNullValues())))
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("applied")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build()))
+              .returningFailure(new RuntimeException("Ivan really breaks the test."));
+
+      InsertOperation operation =
+          new InsertOperation(COMMAND_CONTEXT, List.of(shredDocument1, shredDocument2), true);
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
+
+      // assert query execution
+      // second query never executed
+      insertFirstAssert.assertExecuteCount().isOne();
+      insertSecondAssert.assertExecuteCount().isOne();
+
+      // then result contains both insert and error
+      CommandResult result = execute.get();
+      assertThat(result.status())
+          .hasSize(1)
+          .containsEntry(CommandStatus.INSERTED_IDS, List.of(new DocumentId.StringId("doc1")));
+      assertThat(result.errors())
+          .singleElement()
+          .satisfies(
+              error -> {
+                assertThat(error.message())
+                    .isEqualTo(
+                        "Failed to insert document with _id doc2: Ivan really breaks the test.");
+                assertThat(error.fields()).containsEntry("exceptionClass", "RuntimeException");
+              });
+    }
+
+    @Test
+    public void failureUnorderedPartial() throws Exception {
+      // unordered one query fail
+      String document1 =
+          """
+          {
+            "_id": "doc1",
+            "text": "user1",
+            "number" : 10,
+            "boolean": true,
+            "nullval" : null,
+            "array" : ["a", "b"],
+            "sub_doc" : {"col": "val"}
+          }
+          """;
+      String document2 =
+          """
+          {
+            "_id": "doc2",
+            "text": "user2",
+            "number" : 11,
+            "boolean": false,
+            "nullval" : null,
+            "array" : ["c", "d"],
+            "sub_doc" : {"col": "lav"}
+          }
+          """;
+
+      JsonNode jsonNode1 = objectMapper.readTree(document1);
+      WritableShreddedDocument shredDocument1 = shredder.shred(jsonNode1);
+
+      JsonNode jsonNode2 = objectMapper.readTree(document2);
+      WritableShreddedDocument shredDocument2 = shredder.shred(jsonNode2);
+
+      String insertCql = INSERT_CQL.formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert insertFirstAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument1.id())),
+                  Values.of(shredDocument1.docJson()),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument1.existKeys())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.subDocEquals())),
+                  Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument1.arraySize())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.arrayEquals())),
+                  Values.of(
+                      CustomValueSerializers.getStringSetValue(shredDocument1.arrayContains())),
+                  Values.of(
+                      CustomValueSerializers.getBooleanMapValues(shredDocument1.queryBoolValues())),
+                  Values.of(
+                      CustomValueSerializers.getDoubleMapValues(
+                          shredDocument1.queryNumberValues())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.queryTextValues())),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument1.queryNullValues())))
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("applied")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build()))
+              .returningFailure(new RuntimeException("Ivan breaks the test."));
+      ValidatingStargateBridge.QueryAssert insertSecondAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument2.id())),
+                  Values.of(shredDocument2.docJson()),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument2.existKeys())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.subDocEquals())),
+                  Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument2.arraySize())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.arrayEquals())),
+                  Values.of(
+                      CustomValueSerializers.getStringSetValue(shredDocument2.arrayContains())),
+                  Values.of(
+                      CustomValueSerializers.getBooleanMapValues(shredDocument2.queryBoolValues())),
+                  Values.of(
+                      CustomValueSerializers.getDoubleMapValues(
+                          shredDocument2.queryNumberValues())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.queryTextValues())),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument2.queryNullValues())))
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("applied")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build()))
+              .returning(List.of(List.of(Values.of(true))));
+
+      InsertOperation operation =
+          new InsertOperation(COMMAND_CONTEXT, List.of(shredDocument1, shredDocument2), false);
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
+
+      // assert query execution
+      // second query never executed
+      insertFirstAssert.assertExecuteCount().isOne();
+      insertSecondAssert.assertExecuteCount().isOne();
+
+      // then result has both insert id and errors
+      CommandResult result = execute.get();
+      assertThat(result.status())
+          .hasSize(1)
+          .containsEntry(CommandStatus.INSERTED_IDS, List.of(new DocumentId.StringId("doc2")));
+      assertThat(result.errors())
+          .singleElement()
+          .satisfies(
+              error -> {
+                assertThat(error.message())
+                    .isEqualTo("Failed to insert document with _id doc1: Ivan breaks the test.");
+                assertThat(error.fields()).containsEntry("exceptionClass", "RuntimeException");
+              });
+    }
+
+    @Test
+    public void failureUnorderedAll() throws Exception {
+      // unordered both queries fail
+      String document1 =
+          """
+          {
+            "_id": "doc1",
+            "text": "user1",
+            "number" : 10,
+            "boolean": true,
+            "nullval" : null,
+            "array" : ["a", "b"],
+            "sub_doc" : {"col": "val"}
+          }
+          """;
+      String document2 =
+          """
+          {
+            "_id": "doc2",
+            "text": "user2",
+            "number" : 11,
+            "boolean": false,
+            "nullval" : null,
+            "array" : ["c", "d"],
+            "sub_doc" : {"col": "lav"}
+          }
+          """;
+
+      JsonNode jsonNode1 = objectMapper.readTree(document1);
+      WritableShreddedDocument shredDocument1 = shredder.shred(jsonNode1);
+
+      JsonNode jsonNode2 = objectMapper.readTree(document2);
+      WritableShreddedDocument shredDocument2 = shredder.shred(jsonNode2);
+
+      String insertCql = INSERT_CQL.formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert insertFirstAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument1.id())),
+                  Values.of(shredDocument1.docJson()),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument1.existKeys())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.subDocEquals())),
+                  Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument1.arraySize())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.arrayEquals())),
+                  Values.of(
+                      CustomValueSerializers.getStringSetValue(shredDocument1.arrayContains())),
+                  Values.of(
+                      CustomValueSerializers.getBooleanMapValues(shredDocument1.queryBoolValues())),
+                  Values.of(
+                      CustomValueSerializers.getDoubleMapValues(
+                          shredDocument1.queryNumberValues())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument1.queryTextValues())),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument1.queryNullValues())))
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("applied")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build()))
+              .returningFailure(new RuntimeException("Ivan breaks the test."));
+      ValidatingStargateBridge.QueryAssert insertSecondAssert =
+          withQuery(
+                  insertCql,
+                  Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument2.id())),
+                  Values.of(shredDocument2.docJson()),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument2.existKeys())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.subDocEquals())),
+                  Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument2.arraySize())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.arrayEquals())),
+                  Values.of(
+                      CustomValueSerializers.getStringSetValue(shredDocument2.arrayContains())),
+                  Values.of(
+                      CustomValueSerializers.getBooleanMapValues(shredDocument2.queryBoolValues())),
+                  Values.of(
+                      CustomValueSerializers.getDoubleMapValues(
+                          shredDocument2.queryNumberValues())),
+                  Values.of(
+                      CustomValueSerializers.getStringMapValues(shredDocument2.queryTextValues())),
+                  Values.of(CustomValueSerializers.getSetValue(shredDocument2.queryNullValues())))
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("applied")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build()))
+              .returningFailure(new RuntimeException("Ivan really breaks the test."));
+
+      InsertOperation operation =
+          new InsertOperation(COMMAND_CONTEXT, List.of(shredDocument1, shredDocument2), false);
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
+
+      // assert query execution
+      // second query never executed
+      insertFirstAssert.assertExecuteCount().isOne();
+      insertSecondAssert.assertExecuteCount().isOne();
+
+      // then result has 2 errors
+      CommandResult result = execute.get();
+      assertThat(result.status()).hasSize(1).containsEntry(CommandStatus.INSERTED_IDS, List.of());
+      assertThat(result.errors())
+          .hasSize(2)
+          .extracting(CommandResult.Error::message)
+          .containsExactlyInAnyOrder(
+              "Failed to insert document with _id doc1: Ivan breaks the test.",
+              "Failed to insert document with _id doc2: Ivan really breaks the test.");
+    }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertManyCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertManyCommandResolverTest.java
@@ -1,19 +1,21 @@
 package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.Mock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.InsertManyCommand;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.InsertOperation;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
-import java.util.List;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,48 +23,152 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
 public class InsertManyCommandResolverTest {
+
   @Inject ObjectMapper objectMapper;
   @Inject Shredder shredder;
-  @Inject InsertManyCommandResolver insertManyCommandResolver;
+  @Inject InsertManyCommandResolver resolver;
 
   @Nested
-  class InsertManyResolveCommand {
+  class ResolveCommand {
+
+    @Mock CommandContext commandContext;
 
     @Test
-    public void idFilterCondition() throws Exception {
+    public void happyPath() throws Exception {
       String json =
           """
-            {
-              "insertMany": {
-                "documents": [
-                  {
-                    "_id": "1",
-                    "location": "London"
-                  },
-                  {
-                    "_id": "2",
-                    "location": "New York"
-                  }
-                ]
-              }
+          {
+            "insertMany": {
+              "documents": [
+                {
+                  "_id": "1",
+                  "location": "London"
+                },
+                {
+                  "_id": "2",
+                  "location": "New York"
+                }
+              ]
             }
+          }
           """;
 
-      InsertManyCommand insertManyCommand = objectMapper.readValue(json, InsertManyCommand.class);
-      final CommandContext commandContext = new CommandContext("namespace", "collection");
-      final Operation operation =
-          insertManyCommandResolver.resolveCommand(commandContext, insertManyCommand);
-      List<WritableShreddedDocument> shreddedDocuments =
-          insertManyCommand.documents().stream()
-              .map(doc -> shredder.shred(doc))
-              .collect(Collectors.toList());
-      InsertOperation expected = new InsertOperation(commandContext, shreddedDocuments);
-      assertThat(operation)
-          .isInstanceOf(InsertOperation.class)
-          .satisfies(
+      InsertManyCommand command = objectMapper.readValue(json, InsertManyCommand.class);
+      Operation result = resolver.resolveCommand(commandContext, command);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              InsertOperation.class,
               op -> {
-                assertThat(op).isEqualTo(expected);
+                WritableShreddedDocument first = shredder.shred(command.documents().get(0));
+                WritableShreddedDocument second = shredder.shred(command.documents().get(1));
+
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.ordered()).isTrue();
+                assertThat(op.documents()).containsExactly(first, second);
               });
+    }
+
+    @Test
+    public void optionsEmpty() throws Exception {
+      String json =
+          """
+          {
+            "insertMany": {
+              "documents": [
+                {
+                  "_id": "1",
+                  "location": "London"
+                },
+                {
+                  "_id": "2",
+                  "location": "New York"
+                }
+              ],
+              "options": {
+              }
+            }
+          }
+          """;
+
+      InsertManyCommand command = objectMapper.readValue(json, InsertManyCommand.class);
+      Operation result = resolver.resolveCommand(commandContext, command);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              InsertOperation.class,
+              op -> {
+                WritableShreddedDocument first = shredder.shred(command.documents().get(0));
+                WritableShreddedDocument second = shredder.shred(command.documents().get(1));
+
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.ordered()).isTrue();
+                assertThat(op.documents()).containsExactly(first, second);
+              });
+    }
+
+    @Test
+    public void optionsNotOrdered() throws Exception {
+      String json =
+          """
+          {
+            "insertMany": {
+              "documents": [
+                {
+                  "_id": "1",
+                  "location": "London"
+                },
+                {
+                  "_id": "2",
+                  "location": "New York"
+                }
+              ],
+              "options": {
+                "ordered": false
+              }
+            }
+          }
+          """;
+
+      InsertManyCommand command = objectMapper.readValue(json, InsertManyCommand.class);
+      Operation result = resolver.resolveCommand(commandContext, command);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              InsertOperation.class,
+              op -> {
+                WritableShreddedDocument first = shredder.shred(command.documents().get(0));
+                WritableShreddedDocument second = shredder.shred(command.documents().get(1));
+
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.ordered()).isFalse();
+                assertThat(op.documents()).containsExactly(first, second);
+              });
+    }
+
+    @Test
+    public void shredderFailure() throws Exception {
+      String json =
+          """
+          {
+            "insertMany": {
+              "documents": [
+                {
+                  "_id": "1",
+                  "location": "London"
+                },
+                "primitive"
+              ]
+            }
+          }
+          """;
+
+      InsertManyCommand command = objectMapper.readValue(json, InsertManyCommand.class);
+      Throwable failure = catchThrowable(() -> resolver.resolveCommand(commandContext, command));
+
+      assertThat(failure)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_DOCUMENT_TYPE);
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertOneCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertOneCommandResolverTest.java
@@ -1,0 +1,84 @@
+package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.Mock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.InsertOneCommand;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.InsertOperation;
+import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
+import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+class InsertOneCommandResolverTest {
+
+  @Inject ObjectMapper objectMapper;
+  @Inject InsertOneCommandResolver resolver;
+  @Inject Shredder shredder;
+
+  @Nested
+  class ResolveCommand {
+
+    @Mock CommandContext commandContext;
+
+    @Test
+    public void happyPath() throws Exception {
+      String json =
+          """
+          {
+            "insertOne": {
+              "document" : {
+                "_id": "1"
+              }
+            }
+          }
+          """;
+
+      InsertOneCommand command = objectMapper.readValue(json, InsertOneCommand.class);
+      Operation result = resolver.resolveCommand(commandContext, command);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              InsertOperation.class,
+              op -> {
+                WritableShreddedDocument expected = shredder.shred(command.document());
+
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.ordered()).isTrue();
+                assertThat(op.documents()).singleElement().isEqualTo(expected);
+              });
+    }
+
+    @Test
+    public void shredderFailure() throws Exception {
+      String json =
+          """
+          {
+            "insertOne": {
+              "document" : null
+            }
+          }
+          """;
+
+      InsertOneCommand command = objectMapper.readValue(json, InsertOneCommand.class);
+      Throwable failure = catchThrowable(() -> resolver.resolveCommand(commandContext, command));
+
+      assertThat(failure)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_DOCUMENT_TYPE);
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does**:

Adaptation to spec for the `insertOne` & `insertMany`, including test improvements.

* [x] removed option class from `insertOne`  command as per spec no options exists
* [x] added `ordered` option for the `insertMany`
* [x] implemented ordered/unordered insertion
* [x] implemented fail fast for order version
* [x] implemented fail silently for unordered
* improved tests:
   * [x] extended operation tests to ensure all failure modes are tested
   * [x] created/updated tests for command resolvers 
   * [x] created tests for commands validation 
   * [x] several fixes for the integration tests:
      * add unordered tests
      * simulate possible failure modes (using duplicated entries in insert many)
      * assert no errors & data
      * improved readability
* [x] fixed swagger examples


**Which issue(s) this PR fixes**:
Relates to #178.

