### PR TITLE
Fix #210 don't use engineering notation for `BigDecimal` (as doc id)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfiguration.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfiguration.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.api.configuration;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,12 +28,13 @@ public class ObjectMapperConfiguration {
   }
 
   private ObjectMapper createMapper() {
-    // enabled:
-    // case insensitive enums, so "before" will match to "BEFORE" in an enum
     return JsonMapper.builder()
         // important for retaining number accuracy!
         .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+        // case insensitive enums, so "before" will match to "BEFORE" in an enum
         .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+        // Prevent use of Engineering Notation with trailing zeroes:
+        .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
         .build();
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
@@ -199,7 +199,8 @@ public class ShredderTest {
     // [json-api#210]: accidental use of Engineering notation with trailing zeroes
     @Test
     public void shredSimpleWithNumberIdWithTrailingZeroes() throws Exception {
-      final JsonNode inputDoc = fromJson("{\"_id\":30}");
+      final String inputJson = "{\"_id\":30}";
+      final JsonNode inputDoc = fromJson(inputJson);
 
       WritableShreddedDocument doc = shredder.shred(inputDoc);
       assertThat(doc.id()).isEqualTo(DocumentId.fromNumber(new BigDecimal(30L)));
@@ -208,8 +209,7 @@ public class ShredderTest {
 
       // Important: MUST use ObjectMapper we have configured as it has necessary
       // settings. JsonNode.toString() would use "wrong" mapper
-      assertThat(objectMapper.writeValueAsString(jsonFromShredded))
-          .isEqualTo(objectMapper.writeValueAsString(inputDoc));
+      assertThat(objectMapper.writeValueAsString(jsonFromShredded)).isEqualTo(inputJson);
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
@@ -198,18 +198,12 @@ public class ShredderTest {
 
     // [json-api#210]: accidental use of Engineering notation with trailing zeroes
     @Test
-    public void shredSimpleWithNumberIdWithTrailingZeroes() throws Exception {
+    public void shredSimpleWithNumberIdWithTrailingZeroes() {
       final String inputJson = "{\"_id\":30}";
-      final JsonNode inputDoc = fromJson(inputJson);
-
-      WritableShreddedDocument doc = shredder.shred(inputDoc);
+      WritableShreddedDocument doc = shredder.shred(fromJson(inputJson));
       assertThat(doc.id()).isEqualTo(DocumentId.fromNumber(new BigDecimal(30L)));
-
-      JsonNode jsonFromShredded = fromJson(doc.docJson());
-
-      // Important: MUST use ObjectMapper we have configured as it has necessary
-      // settings. JsonNode.toString() would use "wrong" mapper
-      assertThat(objectMapper.writeValueAsString(jsonFromShredded)).isEqualTo(inputJson);
+      // Verify that we do NOT have '{"_id":3E+1}':
+      assertThat(doc.docJson()).isEqualTo(inputJson);
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
@@ -196,6 +196,7 @@ public class ShredderTest {
       assertThat(doc.queryTextValues()).isEqualTo(Map.of(JsonPath.from("name"), "Bob"));
     }
 
+    // [json-api#210]: accidental use of Engineering notation with trailing zeroes
     @Test
     public void shredSimpleWithNumberIdWithTrailingZeroes() throws Exception {
       final JsonNode inputDoc = fromJson("{\"_id\":30}");


### PR DESCRIPTION
**What this PR does**:

Prevents serialization of `BigDecimals` (for doc id and otherwise) using "engineering notation" by forcing serialization using "plain" notation.

**Which issue(s) this PR fixes**:
Fixes #210

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
