### PR TITLE
Fix #240: surround String-valued DocumentId in single quotes

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/serializer/CustomValueSerializers.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/serializer/CustomValueSerializers.java
@@ -64,7 +64,7 @@ public class CustomValueSerializers {
   public static List<QueryOuterClass.Value> getDocumentIdValue(DocumentId documentId) {
     // Temporary implementation until we convert it to Tuple in DB
     List<QueryOuterClass.Value> tupleValues =
-        List.of(Values.of(documentId.typeId()), Values.of(documentId.toString()));
+        List.of(Values.of(documentId.typeId()), Values.of(documentId.asDBKey()));
     return tupleValues;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocumentId.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocumentId.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 public interface DocumentId {
   int typeId();
 
+  /** Method called by JSON serializer to get value to include in JSON output. */
   @JsonValue
   Object value();
 
@@ -35,6 +36,14 @@ public interface DocumentId {
   }
 
   JsonNode asJson(JsonNodeFactory nodeFactory);
+
+  /**
+   * Accessor used to get canonical String representation of the id to be stored in database. Does
+   * NOT contain type prefix or suffic.
+   *
+   * @return Canonical String representation of the id
+   */
+  String asDBKey();
 
   static DocumentId fromJson(JsonNode node) {
     switch (node.getNodeType()) {
@@ -128,6 +137,11 @@ public interface DocumentId {
     }
 
     @Override
+    public String asDBKey() {
+      return key();
+    }
+
+    @Override
     public String toString() {
       // Enclose in single-quotes to indicate it is String value (not to overlap
       // with Number, Boolean, null values), indicate start/end
@@ -150,6 +164,11 @@ public interface DocumentId {
     @Override
     public JsonNode asJson(JsonNodeFactory nodeFactory) {
       return nodeFactory.numberNode(key);
+    }
+
+    @Override
+    public String asDBKey() {
+      return String.valueOf(key);
     }
 
     @Override
@@ -182,6 +201,11 @@ public interface DocumentId {
     }
 
     @Override
+    public String asDBKey() {
+      return String.valueOf(key);
+    }
+
+    @Override
     public String toString() {
       return String.valueOf(key);
     }
@@ -203,6 +227,11 @@ public interface DocumentId {
     @Override
     public JsonNode asJson(JsonNodeFactory nodeFactory) {
       return nodeFactory.nullNode();
+    }
+
+    @Override
+    public String asDBKey() {
+      return "null";
     }
 
     @Override

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocumentId.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocumentId.java
@@ -129,7 +129,10 @@ public interface DocumentId {
 
     @Override
     public String toString() {
-      return key;
+      // Enclose in single-quotes to indicate it is String value (not to overlap
+      // with Number, Boolean, null values), indicate start/end
+      // TODO: Consider escaping of quotes within value?
+      return "'" + key + "'";
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -206,7 +206,7 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
           .body(
               "errors[0].message",
               is(
-                  "Failed to insert document with _id duplicate: Document already exists with the given _id"))
+                  "Failed to insert document with _id 'duplicate': Document already exists with the given _id"))
           .body("errors[0].errorCode", is("DOCUMENT_ALREADY_EXISTS"));
 
       json =
@@ -373,7 +373,7 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
           .statusCode(200)
           .body("status.insertedIds", contains("doc4"))
           .body("data", is(nullValue()))
-          .body("errors[0].message", startsWith("Failed to insert document with _id doc4"))
+          .body("errors[0].message", startsWith("Failed to insert document with _id 'doc4'"))
           .body("errors[0].errorCode", is("DOCUMENT_ALREADY_EXISTS"));
 
       json =
@@ -433,7 +433,7 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
           .body(
               "errors[0].message",
               startsWith(
-                  "Failed to insert document with _id doc4: INVALID_ARGUMENT: keyspace something_else does not exist"))
+                  "Failed to insert document with _id 'doc4': INVALID_ARGUMENT: keyspace something_else does not exist"))
           .body("errors[0].exceptionClass", is("StatusRuntimeException"));
     }
 
@@ -525,7 +525,7 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
           .statusCode(200)
           .body("status.insertedIds", containsInAnyOrder("doc4", "doc5"))
           .body("data", is(nullValue()))
-          .body("errors[0].message", startsWith("Failed to insert document with _id doc4"))
+          .body("errors[0].message", startsWith("Failed to insert document with _id 'doc4'"))
           .body("errors[0].errorCode", is("DOCUMENT_ALREADY_EXISTS"));
 
       json =

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
@@ -456,7 +456,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
                     .isEqualTo("CONCURRENCY_FAILURE");
                 assertThat(commandResult.errors().get(0).message())
                     .isEqualTo(
-                        "Failed to delete documents with _id [doc1]: Unable to complete transaction due to concurrent transactions");
+                        "Failed to delete documents with _id ['doc1']: Unable to complete transaction due to concurrent transactions");
               });
     }
 
@@ -1001,7 +1001,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
                     .isEqualTo("CONCURRENCY_FAILURE");
                 assertThat(result.errors().get(0).message())
                     .isEqualTo(
-                        "Failed to delete documents with _id [doc1]: Unable to complete transaction due to concurrent transactions");
+                        "Failed to delete documents with _id ['doc1']: Unable to complete transaction due to concurrent transactions");
               });
     }
 
@@ -1174,7 +1174,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
                     .isEqualTo("CONCURRENCY_FAILURE");
                 assertThat(result.errors().get(0).message())
                     .isEqualTo(
-                        "Failed to delete documents with _id [doc1, doc2]: Unable to complete transaction due to concurrent transactions");
+                        "Failed to delete documents with _id ['doc1', 'doc2']: Unable to complete transaction due to concurrent transactions");
               });
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
@@ -182,7 +182,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
               error -> {
                 assertThat(error.message())
                     .isEqualTo(
-                        "Failed to insert document with _id doc1: Document already exists with the given _id");
+                        "Failed to insert document with _id 'doc1': Document already exists with the given _id");
                 assertThat(error.fields())
                     .containsEntry("exceptionClass", "JsonApiException")
                     .containsEntry("errorCode", "DOCUMENT_ALREADY_EXISTS");
@@ -507,7 +507,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
           .satisfies(
               error -> {
                 assertThat(error.message())
-                    .isEqualTo("Failed to insert document with _id doc1: Ivan breaks the test.");
+                    .isEqualTo("Failed to insert document with _id 'doc1': Ivan breaks the test.");
                 assertThat(error.fields()).containsEntry("exceptionClass", "RuntimeException");
               });
     }
@@ -630,7 +630,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
               error -> {
                 assertThat(error.message())
                     .isEqualTo(
-                        "Failed to insert document with _id doc2: Ivan really breaks the test.");
+                        "Failed to insert document with _id 'doc2': Ivan really breaks the test.");
                 assertThat(error.fields()).containsEntry("exceptionClass", "RuntimeException");
               });
     }
@@ -752,7 +752,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
           .satisfies(
               error -> {
                 assertThat(error.message())
-                    .isEqualTo("Failed to insert document with _id doc1: Ivan breaks the test.");
+                    .isEqualTo("Failed to insert document with _id 'doc1': Ivan breaks the test.");
                 assertThat(error.fields()).containsEntry("exceptionClass", "RuntimeException");
               });
     }
@@ -871,8 +871,8 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
           .hasSize(2)
           .extracting(CommandResult.Error::message)
           .containsExactlyInAnyOrder(
-              "Failed to insert document with _id doc1: Ivan breaks the test.",
-              "Failed to insert document with _id doc2: Ivan really breaks the test.");
+              "Failed to insert document with _id 'doc1': Ivan breaks the test.",
+              "Failed to insert document with _id 'doc2': Ivan really breaks the test.");
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
@@ -446,7 +446,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
               assertThat(error.fields()).containsEntry("errorCode", "CONCURRENCY_FAILURE");
               assertThat(error.message())
                   .isEqualTo(
-                      "Failed to update documents with _id [doc1]: Unable to complete transaction due to concurrent transactions");
+                      "Failed to update documents with _id ['doc1']: Unable to complete transaction due to concurrent transactions");
             });
   }
 
@@ -651,7 +651,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
               assertThat(error.fields()).containsEntry("errorCode", "CONCURRENCY_FAILURE");
               assertThat(error.message())
                   .isEqualTo(
-                      "Failed to update documents with _id [doc1]: Unable to complete transaction due to concurrent transactions");
+                      "Failed to update documents with _id ['doc1']: Unable to complete transaction due to concurrent transactions");
             });
   }
 
@@ -914,7 +914,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
               assertThat(error.fields()).containsEntry("errorCode", "CONCURRENCY_FAILURE");
               assertThat(error.message())
                   .isEqualTo(
-                      "Failed to update documents with _id [doc1]: Unable to complete transaction due to concurrent transactions");
+                      "Failed to update documents with _id ['doc1']: Unable to complete transaction due to concurrent transactions");
             });
   }
 
@@ -1238,7 +1238,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
                   .isEqualTo("CONCURRENCY_FAILURE");
               assertThat(commandResultSupplier.errors().get(0).message())
                   .isEqualTo(
-                      "Failed to update documents with _id [doc1, doc2]: Unable to complete transaction due to concurrent transactions");
+                      "Failed to update documents with _id ['doc1', 'doc2']: Unable to complete transaction due to concurrent transactions");
             });
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
@@ -112,7 +112,7 @@ public class ShredderTest {
 
       assertThat(doc.id()).isInstanceOf(DocumentId.StringId.class);
       // should be auto-generated UUID:
-      assertThat(UUID.fromString(doc.id().toString())).isNotNull();
+      assertThat(UUID.fromString(doc.id().asDBKey())).isNotNull();
       List<JsonPath> expPaths =
           Arrays.asList(JsonPath.from("_id"), JsonPath.from("age"), JsonPath.from("name"));
 
@@ -128,7 +128,7 @@ public class ShredderTest {
       JsonNode idNode = jsonFromShredded.get("_id");
       assertThat(idNode).isNotNull();
       String generatedId = idNode.textValue();
-      assertThat(generatedId).isEqualTo(doc.id().toString());
+      assertThat(generatedId).isEqualTo(doc.id().asDBKey());
       ((ObjectNode) inputDoc).put("_id", generatedId);
       assertThat(jsonFromShredded).isEqualTo(inputDoc);
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/util/ExceptionUtilTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/util/ExceptionUtilTest.java
@@ -41,7 +41,7 @@ public class ExceptionUtilTest {
             err -> {
               assertThat(err.message())
                   .isEqualTo(
-                      "test error for ids [doc1, doc2]: Unable to complete transaction due to concurrent transactions");
+                      "test error for ids ['doc1', 'doc2']: Unable to complete transaction due to concurrent transactions");
               assertThat(err.fields()).containsEntry("exceptionClass", "JsonApiException");
               assertThat(err.fields()).containsEntry("errorCode", "CONCURRENCY_FAILURE");
             });
@@ -52,7 +52,7 @@ public class ExceptionUtilTest {
     assertThat(error)
         .satisfies(
             err -> {
-              assertThat(err.message()).isEqualTo("test error for ids [doc1, doc2]: Some error");
+              assertThat(err.message()).isEqualTo("test error for ids ['doc1', 'doc2']: Some error");
               assertThat(err.fields()).containsEntry("exceptionClass", "RuntimeException");
             });
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/util/ExceptionUtilTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/util/ExceptionUtilTest.java
@@ -52,7 +52,8 @@ public class ExceptionUtilTest {
     assertThat(error)
         .satisfies(
             err -> {
-              assertThat(err.message()).isEqualTo("test error for ids ['doc1', 'doc2']: Some error");
+              assertThat(err.message())
+                  .isEqualTo("test error for ids ['doc1', 'doc2']: Some error");
               assertThat(err.fields()).containsEntry("exceptionClass", "RuntimeException");
             });
   }


### PR DESCRIPTION
**What this PR does**:

Enclose `String`-valued `DocumentId` in single quotes, for use in Exception messages -- avoids confusion wrt id type, contents.

Also adds a separate method to use for constructing DB primary keys, instead of `Document.toString()`.

**Which issue(s) this PR fixes**:
Fixes #240

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
