### PR TITLE
Configure Quarkus to limit maximum HTTP request size (quarkus.http.limits.max-body-size) to 1 meg 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>2.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,6 +35,10 @@ quarkus:
           paths: /v1/*
           policy: authenticated
 
+    limits:
+      # Let's lower maximum HTTP request size from 10 megs to 1
+      max-body-size: 1024K
+
   # built-in micrometer properties
   micrometer:
     binder:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,7 +37,7 @@ quarkus:
 
     limits:
       # Let's lower maximum HTTP request size from 10 megs to 1
-      max-body-size: 1000000
+      max-body-size: 1M
 
   # built-in micrometer properties
   micrometer:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,7 +37,7 @@ quarkus:
 
     limits:
       # Let's lower maximum HTTP request size from 10 megs to 1
-      max-body-size: 1024K
+      max-body-size: 1000000
 
   # built-in micrometer properties
   micrometer:

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HTTPLimitsIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HTTPLimitsIntegrationTest.java
@@ -12,12 +12,13 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
+import io.stargate.sgv2.common.CqlEnabledIntegrationTestBase;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.junitpioneer.jupiter.RetryingTest;
 
 @QuarkusIntegrationTest
 @QuarkusTestResource(DseTestResource.class)
-public class HTTPLimitsIntegrationTest extends CollectionResourceBaseIntegrationTest {
+public class HTTPLimitsIntegrationTest extends CqlEnabledIntegrationTestBase {
   private final ObjectMapper objectMapper = new JsonMapper();
 
   // For some reason there are failures esp by Native Image, for "Broken Pipe": RestAssured
@@ -59,7 +60,8 @@ public class HTTPLimitsIntegrationTest extends CollectionResourceBaseIntegration
         .contentType(ContentType.JSON)
         .body(json)
         .when()
-        .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+        // Fails before getting to business logic no need for real collection (or keyspace fwtw)
+        .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), "noSuchCollection")
         .then()
         // While docs don't say it, Quarkus tests show 413 as expected fail message:
         .statusCode(413);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HTTPLimitsIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HTTPLimitsIntegrationTest.java
@@ -13,14 +13,17 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
-import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 @QuarkusIntegrationTest
 @QuarkusTestResource(DseTestResource.class)
 public class HTTPLimitsIntegrationTest extends CollectionResourceBaseIntegrationTest {
   private final ObjectMapper objectMapper = new JsonMapper();
 
-  @Test
+  // For some reason there are failures esp by Native Image, for "Broken Pipe": RestAssured
+  // client having trouble getting connection closed before sending whole payload.
+  // But seems to be transient issue, related to timing. So retry a few times
+  @RetryingTest(5)
   public void tryToSendTooBigInsert() {
     // Need to generate payload above 1 meg: need NOT be valid wrt Document
     // constraints (i.e. can have like 10k array elements) because request

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HTTPLimitsIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HTTPLimitsIntegrationTest.java
@@ -1,0 +1,62 @@
+package io.stargate.sgv2.jsonapi.api.v1;
+
+import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.http.ContentType;
+import io.stargate.sgv2.api.common.config.constants.HttpConstants;
+import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import org.junit.jupiter.api.Test;
+
+@QuarkusIntegrationTest
+@QuarkusTestResource(DseTestResource.class)
+public class HTTPLimitsIntegrationTest extends CollectionResourceBaseIntegrationTest {
+  private final ObjectMapper objectMapper = new JsonMapper();
+
+  @Test
+  public void tryToSendTooBigInsert() {
+    // Need to generate payload above 1 meg: need NOT be valid wrt Document
+    // constraints (i.e. can have like 10k array elements) because request
+    // size must be validated before Document constraints.
+    ObjectNode root = objectMapper.createObjectNode();
+    root.put("_id", "too-big-1");
+    ArrayNode dataArray = root.putArray("data");
+
+    // 100k numbers with 9 digits (plus separators etc) goes above 1 meg
+    for (int row = 0; row < 1000; ++row) {
+      ArrayNode rowArray = dataArray.addArray();
+      for (int col = 0; col < 100; ++col) {
+        rowArray.add(123456789);
+      }
+    }
+
+    String json =
+        """
+                {
+                  "insertOne": {
+                    "document": %s
+                  }
+                }
+            """
+            .formatted(root.toString());
+    assertThat(json.length()).isGreaterThan(1_000_000);
+
+    given()
+        .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+        .contentType(ContentType.JSON)
+        .body(json)
+        .when()
+        .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+        .then()
+        // What response code should we get here? It's quarkus limiting not our code so
+        // likely 4xx? 413, probably?
+        .statusCode(413);
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HTTPLimitsIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HTTPLimitsIntegrationTest.java
@@ -55,8 +55,7 @@ public class HTTPLimitsIntegrationTest extends CollectionResourceBaseIntegration
         .when()
         .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
         .then()
-        // What response code should we get here? It's quarkus limiting not our code so
-        // likely 4xx? 413, probably?
+        // While docs don't say it, Quarkus tests show 413 as expected fail message:
         .statusCode(413);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HTTPLimitsIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HTTPLimitsIntegrationTest.java
@@ -29,10 +29,11 @@ public class HTTPLimitsIntegrationTest extends CollectionResourceBaseIntegration
     root.put("_id", "too-big-1");
     ArrayNode dataArray = root.putArray("data");
 
-    // 100k numbers with 9 digits (plus separators etc) goes above 1 meg
-    for (int row = 0; row < 1000; ++row) {
+    // ~100k numbers with 9 digits (plus separators etc) goes above 1 meg
+    for (int row = 0; row < 1024; ++row) {
       ArrayNode rowArray = dataArray.addArray();
-      for (int col = 0; col < 100; ++col) {
+      // 9 digits plus separating comma (plus [ and ]) make it about this:
+      for (int chars = 0; chars < 1024; chars += 10) {
         rowArray.add(123456789);
       }
     }
@@ -46,7 +47,9 @@ public class HTTPLimitsIntegrationTest extends CollectionResourceBaseIntegration
                 }
             """
             .formatted(root.toString());
-    assertThat(json.length()).isGreaterThan(1_000_000);
+    // Sanity check payload is between 1 and 2 megs
+    assertThat(json.length()).isGreaterThan(1 * 1024 * 1024);
+    assertThat(json.length()).isLessThan(2 * 1024 * 1024);
 
     given()
         .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())


### PR DESCRIPTION
**What this PR does**:

Lowers limit for max HTTP request from 10 to 1 meg (for service protection); requests with bigger payload with fail with `413` HTTP Status code (non-configurable).

This setting is used in addition to document limits to prevent any processing of too big payload; document checks can only perform validation of already decoded document, in-memory data structures.

**Which issue(s) this PR fixes**:
Fixes #242

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
