### PR TITLE
Build and push multi architecture docker images.

### DIFF
--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build and push (Amazon ECR)
         run: |
-          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' ${{ matrix.profile }}
+          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' ${{ matrix.profile }}
 
   # signs docker image with cosign
   sign:


### PR DESCRIPTION
**What this PR does**:
Add JsonApi to build and export docker image for architecture linux/arm64.

**Which issue(s) this PR fixes**:
Fixes #245 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
