### PR TITLE
cancel running ci workflows for pr branches

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -17,6 +17,11 @@ on:
 
   workflow_dispatch:
 
+# cancel same workflows in progress for pull request branches
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 
 # global env vars, available in all jobs and steps
 env:

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -40,6 +40,9 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
 
+    # max run time 5 minutes
+    timeout-minutes: 5
+
     steps:
       - uses: actions/checkout@v3
 
@@ -59,6 +62,9 @@ jobs:
     name: Integration tests
     needs: [ build ]
     runs-on: ubuntu-latest
+
+    # max run time 20 minutes
+    timeout-minutes: 20
 
     strategy:
 


### PR DESCRIPTION
**What this PR does**:
Cancel existing workflows for PR branches on update. Meaning once you push a new commit to a PR branch, we will cancel the workflow that might still be running. This ensures even more saving of minutes and cancelling runs of unnecessary CI.

**Which issue(s) this PR fixes**:
Port of https://github.com/stargate/stargate/issues/2493
