### PR TITLE
Add checks to make sure Update Operators do not use conflicting/overlapping paths

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateClause.java
@@ -74,6 +74,16 @@ public record UpdateClause(EnumMap<UpdateOperator, ObjectNode> updateOperationDe
 
       while (it.hasNext()) {
         var curr = it.next();
+        PathMatchLocator prevLoc = prev.getKey();
+        PathMatchLocator currLoc = curr.getKey();
+        // So, if parent/child, parent always first so this check is enough
+        if (currLoc.isSubPathOf(prevLoc)) {
+          throw new JsonApiException(
+              ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
+              "Update operator path conflict due to overlap: '%s' (%s) vs '%s' (%s)"
+                  .formatted(
+                      prevLoc, prev.getValue().operator(), currLoc, curr.getValue().operator()));
+        }
       }
     }
     actionMap.entrySet().forEach(e -> {});

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateClause.java
@@ -86,7 +86,6 @@ public record UpdateClause(EnumMap<UpdateOperator, ObjectNode> updateOperationDe
         }
       }
     }
-    actionMap.entrySet().forEach(e -> {});
 
     return new ArrayList<>(operationMap.values());
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateClause.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.api.model.command.deserializers.UpdateClauseDeserializer;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import io.stargate.sgv2.jsonapi.util.PathMatchLocator;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -37,15 +39,33 @@ public record UpdateClause(EnumMap<UpdateOperator, ObjectNode> updateOperationDe
    */
   public List<UpdateOperation> buildOperations() {
     // First, resolve operations individually; this will handle basic validation
-    var operationMap = new EnumMap<UpdateOperator, UpdateOperation>(UpdateOperator.class);
+    final var operationMap = new EnumMap<UpdateOperator, UpdateOperation>(UpdateOperator.class);
     updateOperationDefs
         .entrySet()
         .forEach(e -> operationMap.put(e.getKey(), e.getKey().resolveOperation(e.getValue())));
 
-    // Then handle cross-operation validation
+    // Then handle cross-operation validation: first, exact path conflicts:
+    final var actionMap = new TreeMap<PathMatchLocator, UpdateOperator>();
+    operationMap
+        .entrySet()
+        .forEach(
+            e -> {
+              final UpdateOperator type = e.getKey();
+              List<ActionWithLocator> actions = e.getValue().actions();
+              for (ActionWithLocator action : actions) {
+                UpdateOperator prevType = actionMap.put(action.locator(), type);
+                if (prevType != null) {
+                  throw new JsonApiException(
+                      ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
+                      "Update operators '%s' and '%s' must not refer to same path: '%s'"
+                          .formatted(prevType.operator(), type.operator(), action.locator()));
+                }
+              }
+            });
 
-    // First: verify $set and $unset do NOT have overlapping keys
+    // First: build an ordered Map and check for exact conflicting paths:
 
+    /*
     UpdateOperation<?> setOp = operationMap.get(UpdateOperator.SET);
     UpdateOperation<?> unsetOp = operationMap.get(UpdateOperator.UNSET);
 
@@ -60,7 +80,7 @@ public record UpdateClause(EnumMap<UpdateOperator, ObjectNode> updateOperationDe
                 .formatted(paths.iterator().next()));
       }
     }
-
+     */
     return new ArrayList<>(operationMap.values());
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/update/UpdateClause.java
@@ -63,24 +63,21 @@ public record UpdateClause(EnumMap<UpdateOperator, ObjectNode> updateOperationDe
               }
             });
 
-    // First: build an ordered Map and check for exact conflicting paths:
+    // Second: check for sub-paths -- efficiently done by using alphabetic-sorted paths
+    // and comparing adjacent ones; for each pair see if later one is longer one and
+    // starts with dot.
+    // For example: "path.x" vs "path.x.some.more" we notice latter has suffix ".some.more"
+    // and is thereby conflicting.
+    if (!actionMap.isEmpty()) {
+      var it = actionMap.entrySet().iterator();
+      var prev = it.next();
 
-    /*
-    UpdateOperation<?> setOp = operationMap.get(UpdateOperator.SET);
-    UpdateOperation<?> unsetOp = operationMap.get(UpdateOperator.UNSET);
-
-    if ((setOp != null) && (unsetOp != null)) {
-      Set<String> paths = getPaths(setOp);
-      paths.retainAll(getPaths(unsetOp));
-
-      if (!paths.isEmpty()) {
-        throw new JsonApiException(
-            ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM,
-            "Update operators '$set' and '$unset' must not refer to same path: '%s'"
-                .formatted(paths.iterator().next()));
+      while (it.hasNext()) {
+        var curr = it.next();
       }
     }
-     */
+    actionMap.entrySet().forEach(e -> {});
+
     return new ArrayList<>(operationMap.values());
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/util/PathMatchLocator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/util/PathMatchLocator.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
  *       possibly Projection)
  * </ul>
  */
-public class PathMatchLocator {
+public class PathMatchLocator implements Comparable<PathMatchLocator> {
   private static final Pattern DOT = Pattern.compile(Pattern.quote("."));
 
   private static final Pattern INDEX_SEGMENT = Pattern.compile("0|[1-9][0-9]*");
@@ -240,5 +240,15 @@ public class PathMatchLocator {
   @Override
   public int hashCode() {
     return dotPath.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return dotPath;
+  }
+
+  @Override
+  public int compareTo(PathMatchLocator o) {
+    return dotPath.compareTo(o.dotPath);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/util/PathMatchLocator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/util/PathMatchLocator.java
@@ -36,6 +36,27 @@ public class PathMatchLocator implements Comparable<PathMatchLocator> {
   }
 
   /**
+   * Method that will check whether this locator represents a "sub-path" of given locator: this is
+   * the case if the "parent" path is a proper prefix of this path, followed by a comma and path
+   * segment(s). For example: if this locator has path {@code a.b.c} and {@code possibleParent} has
+   * path {@code a.b} then method would return true (as suffix is {@code .c}).
+   *
+   * <p>Note: if paths are the same, will NOT be considered a sub-path (returns {@code false}).
+   *
+   * @param possibleParent Locator to check against
+   * @return True if this locator has a path that is sub-path of path of {@code possibleParent}
+   */
+  public boolean isSubPathOf(PathMatchLocator possibleParent) {
+    String parentPath = possibleParent.path();
+    String thisPath = path();
+    final int parentLen = parentPath.length();
+
+    return thisPath.startsWith(parentPath)
+        && parentLen < thisPath.length()
+        && thisPath.charAt(parentLen) == '.';
+  }
+
+  /**
    * Factory method for constructing path; also does minimal verification of path: currently only
    * verification is to ensure there are no empty segments.
    *

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 public class UpdateOneIntegrationTest extends CollectionResourceBaseIntegrationTest {
 
   @Nested
-  class UpdateOne {
+  class UpdateOneWithSet {
     @Test
     public void findByIdAndSet() {
       String json =
@@ -297,66 +297,6 @@ public class UpdateOneIntegrationTest extends CollectionResourceBaseIntegrationT
     }
 
     @Test
-    public void findByIdAndUnset() {
-      String document =
-          """
-          {
-            "_id": "update_doc3",
-            "username": "update_user3",
-            "unset_col": "val"
-          }
-          """;
-      insertDoc(document);
-
-      String json =
-          """
-          {
-            "findOneAndUpdate": {
-              "filter" : {"_id" : "update_doc3"},
-              "update" : {"$unset" : {"unset_col": ""}}
-            }
-          }
-          """;
-      given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
-          .then()
-          .statusCode(200)
-          .body("status.matchedCount", is(1))
-          .body("status.modifiedCount", is(1))
-          .body("errors", is(nullValue()));
-
-      // assert state after update
-      String expected =
-          """
-          {
-            "_id":"update_doc3",
-            "username":"update_user3"
-          }
-          """;
-      json =
-          """
-          {
-            "find": {
-              "filter" : {"_id" : "update_doc3"}
-            }
-          }
-          """;
-      given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
-          .then()
-          .statusCode(200)
-          .body("data.docs[0]", jsonEquals(expected));
-    }
-
-    @Test
     public void findByColumnAndSetArray() {
       String json =
           """
@@ -487,6 +427,69 @@ public class UpdateOneIntegrationTest extends CollectionResourceBaseIntegrationT
             }
           }
           """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(expected));
+    }
+  }
+
+  @Nested
+  class UpdateOneWithUnset {
+    @Test
+    public void findByIdAndUnset() {
+      String document =
+          """
+              {
+                "_id": "update_doc3",
+                "username": "update_user3",
+                "unset_col": "val"
+              }
+              """;
+      insertDoc(document);
+
+      String json =
+          """
+              {
+                "findOneAndUpdate": {
+                  "filter" : {"_id" : "update_doc3"},
+                  "update" : {"$unset" : {"unset_col": ""}}
+                }
+              }
+              """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.matchedCount", is(1))
+          .body("status.modifiedCount", is(1))
+          .body("errors", is(nullValue()));
+
+      // assert state after update
+      String expected =
+          """
+              {
+                "_id":"update_doc3",
+                "username":"update_user3"
+              }
+              """;
+      json =
+          """
+              {
+                "find": {
+                  "filter" : {"_id" : "update_doc3"}
+                }
+              }
+              """;
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdaterTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdaterTest.java
@@ -272,5 +272,31 @@ public class DocumentUpdaterTest {
           .hasMessage(
               "Update operator path conflict due to overlap: 'root' ($set) vs 'root.1' ($set)");
     }
+
+    @Test
+    public void invalidSetOnParentPathWithDollar() {
+      Throwable t =
+          catchThrowable(
+              () ->
+                  DocumentUpdater.construct(
+                      DocumentUpdaterUtils.updateClause(
+                          UpdateOperator.SET,
+                          (ObjectNode)
+                              objectMapper.readTree(
+                                  """
+          {
+            "root" : 7,
+            "x" : 3,
+            "root$x" : 5,
+            "y" : 5,
+            "root.a" : 3
+          }
+          """))));
+      assertThat(t)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM)
+          .hasMessage(
+              "Update operator path conflict due to overlap: 'root' ($set) vs 'root.a' ($set)");
+    }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdaterTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdaterTest.java
@@ -244,18 +244,33 @@ public class DocumentUpdaterTest {
     public void invalidMulAndIncSameFieldNested() {
       Throwable t =
           catchThrowable(
-              () -> {
-                DocumentUpdater.construct(
-                    DocumentUpdaterUtils.updateClause(
-                        UpdateOperator.INC,
-                        (ObjectNode) objectMapper.readTree("{\"root.x\":-7, \"root.inc\":-3}"),
-                        UpdateOperator.MUL,
-                        (ObjectNode) objectMapper.readTree("{\"root.mul\":3, \"root.x\":2}")));
-              });
+              () ->
+                  DocumentUpdater.construct(
+                      DocumentUpdaterUtils.updateClause(
+                          UpdateOperator.INC,
+                          (ObjectNode) objectMapper.readTree("{\"root.x\":-7, \"root.inc\":-3}"),
+                          UpdateOperator.MUL,
+                          (ObjectNode) objectMapper.readTree("{\"root.mul\":3, \"root.x\":2}"))));
       assertThat(t)
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM)
           .hasMessage("Update operators '$inc' and '$mul' must not refer to same path: 'root.x'");
+    }
+
+    @Test
+    public void invalidSetOnParentPath() {
+      Throwable t =
+          catchThrowable(
+              () ->
+                  DocumentUpdater.construct(
+                      DocumentUpdaterUtils.updateClause(
+                          UpdateOperator.SET,
+                          (ObjectNode) objectMapper.readTree("{\"root.1\":-7, \"root\":[ ]}"))));
+      assertThat(t)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM)
+          .hasMessage(
+              "Update operator path conflict due to overlap: 'root' ($set) vs 'root.1' ($set)");
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdaterTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/updater/DocumentUpdaterTest.java
@@ -235,10 +235,27 @@ public class DocumentUpdaterTest {
                         (ObjectNode) objectMapper.readTree("{\"unsetField\":1, \"common\":1}")));
               });
       assertThat(t)
-          .isNotNull()
           .isInstanceOf(JsonApiException.class)
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM)
           .hasMessage("Update operators '$set' and '$unset' must not refer to same path: 'common'");
+    }
+
+    @Test
+    public void invalidMulAndIncSameFieldNested() {
+      Throwable t =
+          catchThrowable(
+              () -> {
+                DocumentUpdater.construct(
+                    DocumentUpdaterUtils.updateClause(
+                        UpdateOperator.INC,
+                        (ObjectNode) objectMapper.readTree("{\"root.x\":-7, \"root.inc\":-3}"),
+                        UpdateOperator.MUL,
+                        (ObjectNode) objectMapper.readTree("{\"root.mul\":3, \"root.x\":2}")));
+              });
+      assertThat(t)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_UPDATE_OPERATION_PARAM)
+          .hasMessage("Update operators '$inc' and '$mul' must not refer to same path: 'root.x'");
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/util/PathMatchLocatorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/util/PathMatchLocatorTest.java
@@ -393,6 +393,50 @@ public class PathMatchLocatorTest {
     }
   }
 
+  @Nested
+  class Sorting {
+    @Test
+    public void testOrdering() {
+      verifyOrdering(PathMatchLocator.forPath("root"), PathMatchLocator.forPath("rootValue"));
+      verifyOrdering(PathMatchLocator.forPath("root.x"), PathMatchLocator.forPath("root.y"));
+      verifyOrdering(PathMatchLocator.forPath("root.abc"), PathMatchLocator.forPath("root.abcdef"));
+      verifyOrdering(PathMatchLocator.forPath("root.a"), PathMatchLocator.forPath("root.a.3"));
+    }
+
+    private void verifyOrdering(PathMatchLocator loc1, PathMatchLocator loc2) {
+      assertThat(loc1.compareTo(loc2)).isLessThan(0);
+      assertThat(loc2.compareTo(loc1)).isGreaterThan(0);
+    }
+
+    @Test
+    public void testSubPath() {
+      // Not sub-path, no dot separator
+      verifyNotSubPath(PathMatchLocator.forPath("root"), PathMatchLocator.forPath("rootValue"));
+      // Same path is NOT sub-path
+      verifyNotSubPath(PathMatchLocator.forPath("root"), PathMatchLocator.forPath("root"));
+      // Nor siblings
+      verifyNotSubPath(PathMatchLocator.forPath("root.x"), PathMatchLocator.forPath("root.y"));
+
+      // But with dot, is
+      verifyIsSubPath(PathMatchLocator.forPath("root"), PathMatchLocator.forPath("root.Value"));
+      verifyIsSubPath(PathMatchLocator.forPath("root"), PathMatchLocator.forPath("root.x.y.z"));
+      verifyIsSubPath(
+          PathMatchLocator.forPath("root.branch"), PathMatchLocator.forPath("root.branch.4"));
+    }
+
+    private void verifyIsSubPath(PathMatchLocator parent, PathMatchLocator child) {
+      // One way it is true; the other not
+      assertThat(child.isSubPathOf(parent)).isTrue();
+      assertThat(parent.isSubPathOf(child)).isFalse();
+    }
+
+    private void verifyNotSubPath(PathMatchLocator parent, PathMatchLocator child) {
+      // Neither is true
+      assertThat(child.isSubPathOf(parent)).isFalse();
+      assertThat(parent.isSubPathOf(child)).isFalse();
+    }
+  }
+
   protected ObjectNode objectFromJson(String json) {
     return (ObjectNode) fromJson(json);
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/util/PathMatchLocatorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/util/PathMatchLocatorTest.java
@@ -397,8 +397,11 @@ public class PathMatchLocatorTest {
   class Sorting {
     @Test
     public void testOrdering() {
-      verifyOrdering(PathMatchLocator.forPath("root"), PathMatchLocator.forPath("rootValue"));
+      // Simple alphabetic ordering in general
+      verifyOrdering(PathMatchLocator.forPath("abc"), PathMatchLocator.forPath("def"));
       verifyOrdering(PathMatchLocator.forPath("root.x"), PathMatchLocator.forPath("root.y"));
+      // Longer one later (if common prefix; parent/child)
+      verifyOrdering(PathMatchLocator.forPath("root"), PathMatchLocator.forPath("rootValue"));
       verifyOrdering(PathMatchLocator.forPath("root.abc"), PathMatchLocator.forPath("root.abcdef"));
       verifyOrdering(PathMatchLocator.forPath("root.a"), PathMatchLocator.forPath("root.a.3"));
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/util/PathMatchLocatorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/util/PathMatchLocatorTest.java
@@ -404,6 +404,12 @@ public class PathMatchLocatorTest {
       verifyOrdering(PathMatchLocator.forPath("root"), PathMatchLocator.forPath("rootValue"));
       verifyOrdering(PathMatchLocator.forPath("root.abc"), PathMatchLocator.forPath("root.abcdef"));
       verifyOrdering(PathMatchLocator.forPath("root.a"), PathMatchLocator.forPath("root.a.3"));
+
+      // Important! Need to ensure "dot-segment" sorts before continued value; "$" and "+"
+      // particular
+      // concerns as their ASCII/Unicode value below comma
+      verifyOrdering(PathMatchLocator.forPath("root.a"), PathMatchLocator.forPath("root$a"));
+      verifyOrdering(PathMatchLocator.forPath("x.y"), PathMatchLocator.forPath("x+y.a"));
     }
 
     private void verifyOrdering(PathMatchLocator loc1, PathMatchLocator loc2) {
@@ -419,6 +425,8 @@ public class PathMatchLocatorTest {
       verifyNotSubPath(PathMatchLocator.forPath("root"), PathMatchLocator.forPath("root"));
       // Nor siblings
       verifyNotSubPath(PathMatchLocator.forPath("root.x"), PathMatchLocator.forPath("root.y"));
+      // Nor with "weird" characters
+      verifyNotSubPath(PathMatchLocator.forPath("root"), PathMatchLocator.forPath("root$x"));
 
       // But with dot, is
       verifyIsSubPath(PathMatchLocator.forPath("root"), PathMatchLocator.forPath("root.Value"));


### PR DESCRIPTION
**What this PR does**:

Improves checking of dotted paths used with update operator to ensure overlapping paths are not allowed (same as with other mongoose backends).

**Which issue(s) this PR fixes**:
Fixes #232

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
