### PR TITLE
relates to #178: namespace and collection commands per spec

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
@@ -2,15 +2,17 @@ package io.stargate.sgv2.jsonapi.api.model.command.impl;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.stargate.sgv2.jsonapi.api.model.command.NamespaceCommand;
-import javax.annotation.Nullable;
-import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(description = "Command that creates a collection.")
 @JsonTypeName("createCollection")
 public record CreateCollectionCommand(
-    @NotBlank @Schema(description = "Name of the collection") String name,
-    @Nullable Options options)
-    implements NamespaceCommand {
-  public record Options() {}
-}
+    @NotNull
+        @Size(min = 1, max = 48)
+        @Pattern(regexp = "[a-zA-Z][a-zA-Z0-9_]*")
+        @Schema(description = "Name of the collection")
+        String name)
+    implements NamespaceCommand {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateNamespaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateNamespaceCommand.java
@@ -7,7 +7,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.GeneralCommand;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
@@ -16,7 +15,11 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Schema(description = "Command that creates a namespace.")
 @JsonTypeName("createNamespace")
 public record CreateNamespaceCommand(
-    @NotBlank @Size(min = 1, max = 48) @Schema(description = "Name of the namespace") String name,
+    @NotNull
+        @Pattern(regexp = "[a-zA-Z][a-zA-Z0-9_]*")
+        @Size(min = 1, max = 48)
+        @Schema(description = "Name of the namespace")
+        String name,
     @Nullable @Valid CreateNamespaceCommand.Options options)
     implements GeneralCommand {
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteCollectionCommand.java
@@ -2,7 +2,9 @@ package io.stargate.sgv2.jsonapi.api.model.command.impl;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.stargate.sgv2.jsonapi.api.model.command.NamespaceCommand;
-import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
@@ -13,5 +15,9 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Schema(description = "Command that deletes a collection if one exists.")
 @JsonTypeName("deleteCollection")
 public record DeleteCollectionCommand(
-    @NotBlank @Schema(description = "Name of the collection") String name)
+    @NotNull
+        @Size(min = 1, max = 48)
+        @Pattern(regexp = "[a-zA-Z][a-zA-Z0-9_]*")
+        @Schema(description = "Name of the collection")
+        String name)
     implements NamespaceCommand {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
@@ -8,7 +8,7 @@ import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
 import javax.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
-public class CreateCollectionResolver implements CommandResolver<CreateCollectionCommand> {
+public class CreateCollectionCommandResolver implements CommandResolver<CreateCollectionCommand> {
   @Override
   public Class<CreateCollectionCommand> getCommandClass() {
     return CreateCollectionCommand.class;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateNamespaceCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateNamespaceCommandResolver.java
@@ -13,7 +13,7 @@ import javax.enterprise.context.ApplicationScoped;
  * map.
  */
 @ApplicationScoped
-public class CreateNamespaceResolver implements CommandResolver<CreateNamespaceCommand> {
+public class CreateNamespaceCommandResolver implements CommandResolver<CreateNamespaceCommand> {
 
   // default if omitted
   private static final String DEFAULT_REPLICATION_MAP =

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteCollectionCommandResolver.java
@@ -9,7 +9,7 @@ import javax.enterprise.context.ApplicationScoped;
 
 /** Resolver for the {@link DeleteCollectionCommand}. */
 @ApplicationScoped
-public class DeleteCollectionResolver implements CommandResolver<DeleteCollectionCommand> {
+public class DeleteCollectionCommandResolver implements CommandResolver<DeleteCollectionCommand> {
   @Override
   public Class<DeleteCollectionCommand> getCommandClass() {
     return DeleteCollectionCommand.class;

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommandTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
-class DeleteCollectionCommandTest {
+class CreateCollectionCommandTest {
 
   @Inject ObjectMapper objectMapper;
 
@@ -26,17 +26,17 @@ class DeleteCollectionCommandTest {
   class Validation {
 
     @Test
-    public void noName() throws Exception {
+    public void nameNull() throws Exception {
       String json =
           """
           {
-            "deleteCollection": {
+            "createCollection": {
             }
           }
           """;
 
-      DeleteCollectionCommand command = objectMapper.readValue(json, DeleteCollectionCommand.class);
-      Set<ConstraintViolation<DeleteCollectionCommand>> result = validator.validate(command);
+      CreateCollectionCommand command = objectMapper.readValue(json, CreateCollectionCommand.class);
+      Set<ConstraintViolation<CreateCollectionCommand>> result = validator.validate(command);
 
       assertThat(result)
           .isNotEmpty()
@@ -49,14 +49,14 @@ class DeleteCollectionCommandTest {
       String json =
           """
           {
-            "deleteCollection": {
+            "createCollection": {
               "name": ""
             }
           }
           """;
 
-      DeleteCollectionCommand command = objectMapper.readValue(json, DeleteCollectionCommand.class);
-      Set<ConstraintViolation<DeleteCollectionCommand>> result = validator.validate(command);
+      CreateCollectionCommand command = objectMapper.readValue(json, CreateCollectionCommand.class);
+      Set<ConstraintViolation<CreateCollectionCommand>> result = validator.validate(command);
 
       assertThat(result)
           .isNotEmpty()
@@ -70,15 +70,15 @@ class DeleteCollectionCommandTest {
       String json =
           """
           {
-            "deleteCollection": {
+            "createCollection": {
               "name": "%s"
             }
           }
           """
               .formatted(name);
 
-      DeleteCollectionCommand command = objectMapper.readValue(json, DeleteCollectionCommand.class);
-      Set<ConstraintViolation<DeleteCollectionCommand>> result = validator.validate(command);
+      CreateCollectionCommand command = objectMapper.readValue(json, CreateCollectionCommand.class);
+      Set<ConstraintViolation<CreateCollectionCommand>> result = validator.validate(command);
 
       assertThat(result)
           .isNotEmpty()
@@ -91,14 +91,14 @@ class DeleteCollectionCommandTest {
       String json =
           """
           {
-            "deleteCollection": {
+            "createCollection": {
               "name": "_not_possible"
             }
           }
           """;
 
-      DeleteCollectionCommand command = objectMapper.readValue(json, DeleteCollectionCommand.class);
-      Set<ConstraintViolation<DeleteCollectionCommand>> result = validator.validate(command);
+      CreateCollectionCommand command = objectMapper.readValue(json, CreateCollectionCommand.class);
+      Set<ConstraintViolation<CreateCollectionCommand>> result = validator.validate(command);
 
       assertThat(result)
           .isNotEmpty()
@@ -112,14 +112,14 @@ class DeleteCollectionCommandTest {
       String json =
           """
           {
-            "deleteCollection": {
+            "createCollection": {
               "name": "is_possible_10"
             }
           }
           """;
 
-      DeleteCollectionCommand command = objectMapper.readValue(json, DeleteCollectionCommand.class);
-      Set<ConstraintViolation<DeleteCollectionCommand>> result = validator.validate(command);
+      CreateCollectionCommand command = objectMapper.readValue(json, CreateCollectionCommand.class);
+      Set<ConstraintViolation<CreateCollectionCommand>> result = validator.validate(command);
 
       assertThat(result).isEmpty();
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateNamespaceCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateNamespaceCommandTest.java
@@ -41,7 +41,7 @@ class CreateNamespaceCommandTest {
       assertThat(result)
           .isNotEmpty()
           .extracting(ConstraintViolation::getMessage)
-          .contains("must not be blank");
+          .contains("must not be null");
     }
 
     @Test
@@ -63,6 +63,43 @@ class CreateNamespaceCommandTest {
           .isNotEmpty()
           .extracting(ConstraintViolation::getMessage)
           .contains("size must be between 1 and 48");
+    }
+
+    @Test
+    public void nameWrongPattern() throws Exception {
+      String json =
+          """
+          {
+            "createNamespace": {
+              "name": "_not_possible"
+            }
+          }
+          """;
+
+      CreateNamespaceCommand command = objectMapper.readValue(json, CreateNamespaceCommand.class);
+      Set<ConstraintViolation<CreateNamespaceCommand>> result = validator.validate(command);
+
+      assertThat(result)
+          .isNotEmpty()
+          .extracting(ConstraintViolation::getMessage)
+          .contains("must match \"[a-zA-Z][a-zA-Z0-9_]*\"");
+    }
+
+    @Test
+    public void nameCorrectPattern() throws Exception {
+      String json =
+          """
+          {
+            "createNamespace": {
+              "name": "is_possible_10"
+            }
+          }
+          """;
+
+      CreateNamespaceCommand command = objectMapper.readValue(json, CreateNamespaceCommand.class);
+      Set<ConstraintViolation<CreateNamespaceCommand>> result = validator.validate(command);
+
+      assertThat(result).isEmpty();
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateNamespaceCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateNamespaceCommandResolverTest.java
@@ -15,10 +15,10 @@ import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
-class CreateNamespaceResolverTest {
+class CreateNamespaceCommandResolverTest {
 
   @Inject ObjectMapper objectMapper;
-  @Inject CreateNamespaceResolver resolver;
+  @Inject CreateNamespaceCommandResolver resolver;
 
   @Nested
   class ResolveCommand {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteCollectionCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteCollectionCommandResolverTest.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.Mock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
@@ -16,13 +17,15 @@ import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
-class DeleteCollectionResolverTest {
+class DeleteCollectionCommandResolverTest {
 
   @Inject ObjectMapper objectMapper;
-  @Inject DeleteCollectionResolver resolver;
+  @Inject DeleteCollectionCommandResolver resolver;
 
   @Nested
   class ResolveCommand {
+
+    @Mock CommandContext commandContext;
 
     @Test
     public void happyPath() throws Exception {
@@ -36,15 +39,14 @@ class DeleteCollectionResolverTest {
           """;
 
       DeleteCollectionCommand command = objectMapper.readValue(json, DeleteCollectionCommand.class);
-      CommandContext context = new CommandContext("my_namespace", null);
-      Operation result = resolver.resolveCommand(context, command);
+      Operation result = resolver.resolveCommand(commandContext, command);
 
       assertThat(result)
           .isInstanceOfSatisfying(
               DeleteCollectionOperation.class,
               op -> {
                 assertThat(op.name()).isEqualTo("my_collection");
-                assertThat(op.context()).isEqualTo(context);
+                assertThat(op.context()).isEqualTo(commandContext);
               });
     }
   }


### PR DESCRIPTION
**What this PR does**:

Makes `createNamespace`, `createCollection` & `deleteCollection` per spec:

* match name patterns and size limitations
* add validation tests
* add missing resolver tests

