### PR TITLE
Add  Document limits, validation

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -1,0 +1,48 @@
+package io.stargate.sgv2.jsonapi.config;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import javax.validation.constraints.Positive;
+
+/** Configuration Object that defines limits on Documents managed by JSON API. */
+@ConfigMapping(prefix = "stargate.jsonapi.doc-limits")
+public interface DocumentLimitsConfig {
+  /**
+   * @return Defines the maximum document page size, defaults to {@code 1 meg} (1 million
+   *     characters).
+   */
+  @Positive
+  @WithDefault("1000000")
+  int maxDocSize();
+
+  /** @return Defines the maximum document depth (nesting), defaults to {@code 8 levels} */
+  @Positive
+  @WithDefault("8")
+  int maxDocDepth();
+
+  /**
+   * @return Defines the maximum length of property names in JSON documents, defaults to {@code 48
+   *     characters} (note: length is for individual name segments; full dotted names can be longer)
+   */
+  @Positive
+  @WithDefault("48")
+  int maxNameLength();
+
+  /**
+   * @return Defines the maximum number of properties any single Object in JSON document can
+   *     contain, defaults to {@code 64} (note: this is not the total number of properties in the
+   *     whole document, only on individual main or sub-document)
+   */
+  @Positive
+  @WithDefault("64")
+  int maxObjectProperties();
+
+  /** @return Defines the maximum length of , defaults to {@code 8 levels} */
+  @Positive
+  @WithDefault("16000")
+  int maxStringLength();
+
+  @Positive
+  @WithDefault("100")
+  int maxArrayLength();
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
 
   SHRED_UNRECOGNIZED_NODE_TYPE("Unrecognized JSON node type in input document"),
 
+  SHRED_DOC_LIMIT_VIOLATION("Document size limitation violated"),
+
   UNSUPPORTED_FILTER_DATA_TYPE("Unsupported filter data type"),
 
   UNSUPPORTED_FILTER_OPERATION("Unsupported filter operator"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -89,7 +89,7 @@ public class Shredder {
     }
     // Now that we have both the traversable document and serialization, verify
     // it does not violate document limits:
-    validateDocument(docWithId, documentLimits);
+    validateDocument(documentLimits, docWithId, docJson);
 
     final WritableShreddedDocument.Builder b =
         WritableShreddedDocument.builder(new DocValueHasher(), docId, txId, docJson);
@@ -166,7 +166,17 @@ public class Shredder {
     }
   }
 
-  private void validateDocument(ObjectNode doc, DocumentLimitsConfig limits) {
-    ; // TO IMPLEMENT
+  private void validateDocument(DocumentLimitsConfig limits, ObjectNode doc, String docJson) {
+    // Is the resulting document size (as serialized) too big?
+
+    if (docJson.length() > limits.maxDocSize()) {
+      throw new JsonApiException(
+          ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
+          String.format(
+              "%s: document size (%d chars) exceeds maximum allowed (%s)",
+              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
+              docJson.length(),
+              limits.maxDocSize()));
+    }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -205,6 +205,10 @@ public class Shredder {
               arrayValue.size(),
               limits.maxArrayLength()));
     }
+
+    for (JsonNode element : arrayValue) {
+      validateDocValue(limits, element, depth);
+    }
   }
 
   private void validateObjectValue(DocumentLimitsConfig limits, JsonNode objectValue, int depth) {
@@ -256,8 +260,8 @@ public class Shredder {
       throw new JsonApiException(
           ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
           String.format(
-              "%s: document depth (%d) exceeds maximum allowed (%s)",
-              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(), depth, limits.maxDocDepth()));
+              "%s: document depth exceeds maximum allowed (%s)",
+              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(), limits.maxDocDepth()));
     }
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,15 +3,15 @@
 
 stargate:
 
+  # disable all sgv2 exception mappers, handled differently
+  exception-mappers:
+    enabled: false
+
   # metrics properties
   # see io.stargate.sgv2.api.common.config.MetricsConfig for all config properties and options
   metrics:
     global-tags:
       module: sgv2-jsonapi
-
-  # disable all sgv2 exception mappers, handled differently
-  exception-mappers:
-    enabled: false
 
 quarkus:
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -274,7 +274,7 @@ public class InsertIntegrationTest extends CollectionResourceBaseIntegrationTest
     @Test
     public void tryInsertTooBigArray() {
       final ObjectMapper mapper = new ObjectMapper();
-      // Max array elements: 100
+      // Max array elements allowed is 100; add a few more
       ObjectNode doc = mapper.createObjectNode();
       ArrayNode arr = doc.putArray("arr");
       for (int i = 0; i < 500; ++i) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -1,0 +1,53 @@
+package io.stargate.sgv2.jsonapi.service.shredding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import javax.inject.Inject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class ShredderDocLimitsTest {
+  @Inject ObjectMapper objectMapper;
+
+  @Inject Shredder shredder;
+
+  @Inject DocumentLimitsConfig docLimits;
+
+  @Nested
+  class ValidationDocShapeViolations {
+    @Test
+    public void catchTooBigDoc() throws Exception {
+      // Let's construct document above 1 meg limit (but otherwise legal), with
+      // 100 x 10k String values, divided in 10 sub documents of 10 properties
+      final ObjectNode bigDoc = objectMapper.createObjectNode();
+      bigDoc.put("_id", 123);
+
+      for (int ix1 = 0; ix1 < 10; ++ix1) {
+        ObjectNode mainProp = bigDoc.putObject("prop" + ix1);
+        for (int ix2 = 0; ix2 < 10; ++ix2) {
+          mainProp.put("sub" + ix2, RandomStringUtils.randomAscii(10_000));
+        }
+      }
+
+      Exception e = catchException(() -> shredder.shred(bigDoc));
+      assertThat(e)
+          .isNotNull()
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
+          .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
+          .hasMessageEndingWith("exceeds maximum allowed (" + docLimits.maxDocSize() + ")");
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does**:

Adds document limits to restrict size of JSON documents JSON API accepts; mostly for service protection.

**Which issue(s) this PR fixes**:
Fixes #173

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
