### PR TITLE
Fix #158: support empty Projection clause; add full decoding of projection definition (but not yet processing)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Projectable.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Projectable.java
@@ -1,0 +1,15 @@
+package io.stargate.sgv2.jsonapi.api.model.command;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+
+/*
+ * All the commands that need Projection definitions will have to implement this.
+ */
+public interface Projectable {
+  JsonNode projectionDefinition();
+
+  default DocumentProjector buildProjector() {
+    return DocumentProjector.createFromDefinition(projectionDefinition());
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
@@ -2,7 +2,9 @@ package io.stargate.sgv2.jsonapi.api.model.command.impl;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.stargate.sgv2.jsonapi.api.model.command.Filterable;
+import io.stargate.sgv2.jsonapi.api.model.command.Projectable;
 import io.stargate.sgv2.jsonapi.api.model.command.ReadCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.FilterClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
@@ -15,9 +17,10 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @JsonTypeName("find")
 public record FindCommand(
     @Valid @JsonProperty("filter") FilterClause filterClause,
+    @JsonProperty("projection") JsonNode projectionDefinition,
     @Valid @JsonProperty("sort") SortClause sortClause,
     @Valid @Nullable Options options)
-    implements ReadCommand, Filterable {
+    implements ReadCommand, Filterable, Projectable {
 
   public record Options(
       @Valid

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndUpdateCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndUpdateCommand.java
@@ -2,7 +2,9 @@ package io.stargate.sgv2.jsonapi.api.model.command.impl;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.stargate.sgv2.jsonapi.api.model.command.Filterable;
+import io.stargate.sgv2.jsonapi.api.model.command.Projectable;
 import io.stargate.sgv2.jsonapi.api.model.command.ReadCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.FilterClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateClause;
@@ -18,9 +20,10 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @JsonTypeName("findOneAndUpdate")
 public record FindOneAndUpdateCommand(
     @Valid @JsonProperty("filter") FilterClause filterClause,
+    @JsonProperty("projection") JsonNode projectionDefinition,
     @NotNull @Valid @JsonProperty("update") UpdateClause updateClause,
     @Valid @Nullable Options options)
-    implements ReadCommand, Filterable {
+    implements ReadCommand, Filterable, Projectable {
 
   @Schema(
       name = "FindOneAndUpdateCommand.Options",

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneCommand.java
@@ -2,7 +2,9 @@ package io.stargate.sgv2.jsonapi.api.model.command.impl;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.stargate.sgv2.jsonapi.api.model.command.Filterable;
+import io.stargate.sgv2.jsonapi.api.model.command.Projectable;
 import io.stargate.sgv2.jsonapi.api.model.command.ReadCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.FilterClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
@@ -13,5 +15,6 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @JsonTypeName("findOne")
 public record FindOneCommand(
     @Valid @JsonProperty("filter") FilterClause filterClause,
+    @JsonProperty("projection") JsonNode projectionDefinition,
     @Valid @JsonProperty("sort") SortClause sortClause)
-    implements ReadCommand, Filterable {}
+    implements ReadCommand, Filterable, Projectable {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -34,6 +34,8 @@ public enum ErrorCode {
 
   UNSUPPORTED_OPERATION("Unsupported operation class"),
 
+  UNSUPPORTED_PROJECTION_PARAM("Unsupported projection parameter"),
+
   UNSUPPORTED_UPDATE_DATA_TYPE("Unsupported update data type"),
 
   UNSUPPORTED_UPDATE_OPERATION("Unsupported update operation"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
@@ -66,7 +66,8 @@ public record FindOperation(
             pagingState,
             pageSize,
             ReadType.DOCUMENT == readType,
-            objectMapper);
+            objectMapper,
+            projection);
       }
       default -> {
         JsonApiException failure =

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
@@ -15,6 +15,7 @@ import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadOperation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.function.Supplier;
 public record FindOperation(
     CommandContext commandContext,
     List<DBFilterBase> filters,
+    DocumentProjector projection,
     String pagingState,
     int limit,
     int pageSize,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
@@ -12,7 +12,6 @@ import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers;
 import io.stargate.sgv2.jsonapi.service.operation.model.ModifyOperation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadOperation;
-import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
@@ -182,10 +181,11 @@ public record ReadAndUpdateOperation(
                         if (returnDocumentInResponse) {
                           documentToReturn =
                               returnUpdatedDocument ? updatedDocument : originalDocument;
-                          // In this case, we'll apply projection on before/after document (was
-                          // not applied during find() phase
-                          DocumentProjector projector = findOperation().projection();
-                          projector.applyProjection(documentToReturn);
+                          // 24-Mar-2023, tatu: Will need to add projection in follow-up PR;
+                          //   one we get here is identity-projection which does nothing.
+                          //
+                          // DocumentProjector projector = findOperation().projection();
+                          // projector.applyProjection(documentToReturn);
                         }
                         return new UpdatedDocument(
                             writableShreddedDocument.id(), upsert, documentToReturn, null);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
@@ -12,6 +12,7 @@ import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers;
 import io.stargate.sgv2.jsonapi.service.operation.model.ModifyOperation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadOperation;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
@@ -181,6 +182,10 @@ public record ReadAndUpdateOperation(
                         if (returnDocumentInResponse) {
                           documentToReturn =
                               returnUpdatedDocument ? updatedDocument : originalDocument;
+                          // In this case, we'll apply projection on before/after document (was
+                          // not applied during find() phase
+                          DocumentProjector projector = findOperation().projection();
+                          projector.applyProjection(documentToReturn);
                         }
                         return new UpdatedDocument(
                             writableShreddedDocument.id(), upsert, documentToReturn, null);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -5,8 +5,13 @@ import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.math.BigDecimal;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * Helper class that implements functionality needed to support projections on documents fetched via
@@ -14,9 +19,17 @@ import java.util.Set;
  */
 public class DocumentProjector {
   /** Pseudo-projector that makes no modifications to documents */
-  private static final DocumentProjector IDENTITY_PROJECTOR = new DocumentProjector();
+  private static final DocumentProjector IDENTITY_PROJECTOR = new DocumentProjector(null, true);
 
-  private DocumentProjector() {}
+  private final ProjectionLayer rootLayer;
+
+  /** Whether this projector is inclusion- ({@code true}) or exclusion ({@code false}) based. */
+  private final boolean inclusion;
+
+  private DocumentProjector(ProjectionLayer rootLayer, boolean inclusion) {
+    this.rootLayer = rootLayer;
+    this.inclusion = inclusion;
+  }
 
   public static DocumentProjector createFromDefinition(JsonNode projectionDefinition) {
     if (projectionDefinition == null) {
@@ -29,12 +42,7 @@ public class DocumentProjector {
               + ": definition must be OBJECT, was "
               + projectionDefinition.getNodeType());
     }
-    PathCollector paths = PathCollector.collectPaths(projectionDefinition);
-    if (paths.isIdentityProjection()) {
-      return identityProjector();
-    }
-
-    return new DocumentProjector();
+    return PathCollector.collectPaths(projectionDefinition).buildProjector();
   }
 
   public static DocumentProjector identityProjector() {
@@ -42,21 +50,25 @@ public class DocumentProjector {
   }
 
   public void applyProjection(JsonNode document) {
-    ; // To implement
+    if (rootLayer != null) { // null -> identity projection (no-op)
+      throw new JsonApiException(
+          ErrorCode.UNSUPPORTED_PROJECTION_PARAM, "Non-identity Projections not yet supported");
+    }
   }
 
   // Mostly for deserialization tests
   @Override
   public boolean equals(Object o) {
     if (o instanceof DocumentProjector) {
-      return true;
+      DocumentProjector other = (DocumentProjector) o;
+      return (this.inclusion == other.inclusion) && Objects.equals(this.rootLayer, other.rootLayer);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return 1;
+    return rootLayer.hashCode();
   }
 
   /**
@@ -65,7 +77,7 @@ public class DocumentProjector {
    * actual matching.
    */
   private static class PathCollector {
-    private Set<String> paths = new HashSet<>();
+    private List<String> paths = new ArrayList<>();
 
     private int exclusions, inclusions;
 
@@ -75,6 +87,14 @@ public class DocumentProjector {
 
     static PathCollector collectPaths(JsonNode def) {
       return new PathCollector().collectFromObject(def, null);
+    }
+
+    public DocumentProjector buildProjector() {
+      if (isIdentityProjection()) {
+        return DocumentProjector.identityProjector();
+      }
+
+      return new DocumentProjector(ProjectionLayer.buildLayers(paths), inclusions > 0);
     }
 
     /**
@@ -160,6 +180,105 @@ public class DocumentProjector {
         ++inclusions;
         paths.add(path);
       }
+    }
+  }
+
+  /**
+   * Helper class that handles projection traversal for one level of nesting. Layers are either
+   * non-terminal (branches) or terminal (leaves)
+   */
+  private static class ProjectionLayer {
+    private static final Pattern DOT = Pattern.compile(Pattern.quote("."));
+
+    /** Whether this layer is terminal (matching) or branch (non-matching) */
+    private final boolean isTerminal;
+
+    /**
+     * Full path either to this layer (terminal), or to the first path through it (non-terminal) --
+     * needed for conflict reporting.
+     */
+    private String fullPath;
+
+    /** For non-terminal layers, segment-indexed next layers */
+    private final Map<String, ProjectionLayer> nextLayers;
+
+    ProjectionLayer(boolean terminal, String fullPath) {
+      isTerminal = terminal;
+      this.fullPath = fullPath;
+      nextLayers = isTerminal ? null : new HashMap<>();
+    }
+
+    public static ProjectionLayer buildLayers(Collection<String> dotPaths) {
+      // Root is always branch (not terminal):
+      ProjectionLayer root = new ProjectionLayer(false, "");
+      for (String fullPath : dotPaths) {
+        String[] segments = DOT.split(fullPath);
+        buildPath(fullPath, root, segments);
+      }
+      return root;
+    }
+
+    static void buildPath(String fullPath, ProjectionLayer layer, String[] segments) {
+      // First create branches
+      final int last = segments.length - 1;
+      for (int i = 0; i < last; ++i) {
+        // Try to find or create branch
+        layer = layer.findOrCreateBranch(fullPath, segments[i]);
+      }
+      // And then attach terminal (leaf)
+      layer.addTerminal(fullPath, segments[last]);
+    }
+
+    ProjectionLayer findOrCreateBranch(String fullPath, String segment) {
+      // Cannot proceed past terminal layer (shorter path):
+      if (isTerminal) {
+        reportPathConflict(this.fullPath, fullPath);
+      }
+      ProjectionLayer next = nextLayers.get(segment);
+      if (next == null) {
+        next = new ProjectionLayer(false, fullPath);
+        nextLayers.put(segment, next);
+      }
+      return next;
+    }
+
+    void addTerminal(String fullPath, String segment) {
+      // Cannot proceed past terminal layer (shorter path):
+      if (isTerminal) {
+        reportPathConflict(this.fullPath, fullPath);
+      }
+      // But will also not allow existing longer path:
+      ProjectionLayer next = nextLayers.get(segment);
+      if (next != null) {
+        reportPathConflict(fullPath, next.fullPath);
+      }
+      nextLayers.put(segment, new ProjectionLayer(true, fullPath));
+    }
+
+    void reportPathConflict(String fullPath1, String fullPath2) {
+      throw new JsonApiException(
+          ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
+          ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
+              + ": projection path conflict between '"
+              + fullPath1
+              + "' and '"
+              + fullPath2
+              + "'");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) return true;
+      if (!(o instanceof ProjectionLayer)) return false;
+      ProjectionLayer other = (ProjectionLayer) o;
+      return (this.isTerminal == other.isTerminal)
+          && Objects.equals(this.fullPath, other.fullPath)
+          && Objects.equals(this.nextLayers, other.nextLayers);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(isTerminal, fullPath, nextLayers);
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -38,4 +38,18 @@ public class DocumentProjector {
   public void applyProjection(JsonNode document) {
     ; // To implement
   }
+
+  // Mostly for deserialization tests
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof DocumentProjector) {
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return 1;
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -1,8 +1,12 @@
 package io.stargate.sgv2.jsonapi.service.projection;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Helper class that implements functionality needed to support projections on documents fetched via
@@ -28,6 +32,8 @@ public class DocumentProjector {
     if (projectionDefinition.isEmpty()) {
       return identityProjector();
     }
+    PathCollector paths = PathCollector.collectPaths(projectionDefinition);
+
     return new DocumentProjector();
   }
 
@@ -51,5 +57,98 @@ public class DocumentProjector {
   @Override
   public int hashCode() {
     return 1;
+  }
+
+  /** Helper object used to traverse and collection inclusion/exclusion definitions */
+  private static class PathCollector {
+    private Set<String> exclusions;
+    private Set<String> inclusions;
+
+    private Boolean idInclusion = null;
+
+    private PathCollector() {}
+
+    static PathCollector collectPaths(JsonNode def) {
+      return new PathCollector().collectFromObject(def, null);
+    }
+
+    PathCollector collectFromObject(JsonNode ob, String parentPath) {
+      var it = ob.fields();
+      while (it.hasNext()) {
+        var entry = it.next();
+        String path = entry.getKey();
+        if (parentPath != null) {
+          path = parentPath + "." + path;
+        }
+        JsonNode value = entry.getValue();
+        if (value.isNumber()) {
+          // "0" means exclude (like false); any other number include
+          if (BigDecimal.ZERO.equals(value.decimalValue())) {
+            addExclusion(path);
+          } else {
+            addInclusion(path);
+          }
+        } else if (value.isBoolean()) {
+          if (value.booleanValue()) {
+            addInclusion(path);
+          } else {
+            addExclusion(path);
+          }
+        } else if (value.isObject()) {
+          // Nested definitions allowed, too
+          collectFromObject(value, path);
+        } else {
+          // Unknown JSON node type; error
+          throw new JsonApiException(
+              ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
+              ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
+                  + ": path ('"
+                  + path
+                  + "') value must be NUMBER, BOOLEAN or OBJECT, was "
+                  + value.getNodeType());
+        }
+      }
+      return this;
+    }
+
+    private void addExclusion(String path) {
+      if (DocumentConstants.Fields.DOC_ID.equals(path)) {
+        idInclusion = false;
+      } else {
+        if (exclusions == null) {
+          // Must not mix exclusions and inclusions
+          if (inclusions != null) {
+            throw new JsonApiException(
+                ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
+                ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
+                    + ": cannot exclude '"
+                    + path
+                    + "' on inclusion projection");
+          }
+          exclusions = new HashSet<>();
+        }
+        exclusions.add(path);
+      }
+    }
+
+    private void addInclusion(String path) {
+      if (DocumentConstants.Fields.DOC_ID.equals(path)) {
+        idInclusion = true;
+      } else {
+        if (inclusions == null) {
+          // Must not mix exclusions and inclusions
+          if (exclusions != null) {
+            throw new JsonApiException(
+                ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
+                ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
+                    + ": cannot include '"
+                    + path
+                    + "' on exclusion projection");
+          }
+          inclusions = new HashSet<>();
+        }
+        inclusions.add(path);
+      }
+    }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -1,0 +1,34 @@
+package io.stargate.sgv2.jsonapi.service.projection;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+
+/**
+ * Helper class that implements functionality needed to support projections on documents fetched via
+ * various {@code find} commands.
+ */
+public class DocumentProjector {
+  private DocumentProjector() {}
+
+  public static DocumentProjector createFromDefinition(JsonNode projectionDefinition) {
+    if (projectionDefinition == null) {
+      return null;
+    }
+    if (!projectionDefinition.isObject()) {
+      throw new JsonApiException(
+          ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
+          ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
+              + ": definition must be OBJECT, was "
+              + projectionDefinition.getNodeType());
+    }
+    if (projectionDefinition.isEmpty()) {
+      return null;
+    }
+    return new DocumentProjector();
+  }
+
+  public void applyProjection(JsonNode document) {
+    ; // To implement
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -94,7 +94,16 @@ public class DocumentProjector {
         return DocumentProjector.identityProjector();
       }
 
-      return new DocumentProjector(ProjectionLayer.buildLayers(paths), inclusions > 0);
+      // One more thing: do we need to add document id?
+      if (inclusions > 0) { // inclusion-based projection
+        // doc-id included unless explicitly excluded
+        return new DocumentProjector(
+            ProjectionLayer.buildLayers(paths, !Boolean.FALSE.equals(idInclusion)), true);
+      } else { // exclusion-based
+        // doc-id excluded only if explicitly excluded
+        return new DocumentProjector(
+            ProjectionLayer.buildLayers(paths, Boolean.FALSE.equals(idInclusion)), false);
+      }
     }
 
     /**
@@ -208,12 +217,17 @@ public class DocumentProjector {
       nextLayers = isTerminal ? null : new HashMap<>();
     }
 
-    public static ProjectionLayer buildLayers(Collection<String> dotPaths) {
+    public static ProjectionLayer buildLayers(Collection<String> dotPaths, boolean addDocId) {
       // Root is always branch (not terminal):
       ProjectionLayer root = new ProjectionLayer(false, "");
       for (String fullPath : dotPaths) {
         String[] segments = DOT.split(fullPath);
         buildPath(fullPath, root, segments);
+      }
+      // May need to add doc-id inclusion/exclusion as well
+      if (addDocId) {
+        buildPath(
+            DocumentConstants.Fields.DOC_ID, root, new String[] {DocumentConstants.Fields.DOC_ID});
       }
       return root;
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -9,11 +9,14 @@ import io.stargate.sgv2.jsonapi.exception.JsonApiException;
  * various {@code find} commands.
  */
 public class DocumentProjector {
+  /** Pseudo-projector that makes no modifications to documents */
+  private static final DocumentProjector IDENTITY_PROJECTOR = new DocumentProjector();
+
   private DocumentProjector() {}
 
   public static DocumentProjector createFromDefinition(JsonNode projectionDefinition) {
     if (projectionDefinition == null) {
-      return null;
+      return identityProjector();
     }
     if (!projectionDefinition.isObject()) {
       throw new JsonApiException(
@@ -23,9 +26,13 @@ public class DocumentProjector {
               + projectionDefinition.getNodeType());
     }
     if (projectionDefinition.isEmpty()) {
-      return null;
+      return identityProjector();
     }
     return new DocumentProjector();
+  }
+
+  public static DocumentProjector identityProjector() {
+    return IDENTITY_PROJECTOR;
   }
 
   public void applyProjection(JsonNode document) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -6,12 +6,8 @@ import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 /**
  * Helper class that implements functionality needed to support projections on documents fetched via
@@ -47,6 +43,10 @@ public class DocumentProjector {
 
   public static DocumentProjector identityProjector() {
     return IDENTITY_PROJECTOR;
+  }
+
+  public boolean isInclusion() {
+    return inclusion;
   }
 
   public void applyProjection(JsonNode document) {
@@ -189,110 +189,6 @@ public class DocumentProjector {
         ++inclusions;
         paths.add(path);
       }
-    }
-  }
-
-  /**
-   * Helper class that handles projection traversal for one level of nesting. Layers are either
-   * non-terminal (branches) or terminal (leaves)
-   */
-  private static class ProjectionLayer {
-    private static final Pattern DOT = Pattern.compile(Pattern.quote("."));
-
-    /** Whether this layer is terminal (matching) or branch (non-matching) */
-    private final boolean isTerminal;
-
-    /**
-     * Full path either to this layer (terminal), or to the first path through it (non-terminal) --
-     * needed for conflict reporting.
-     */
-    private String fullPath;
-
-    /** For non-terminal layers, segment-indexed next layers */
-    private final Map<String, ProjectionLayer> nextLayers;
-
-    ProjectionLayer(boolean terminal, String fullPath) {
-      isTerminal = terminal;
-      this.fullPath = fullPath;
-      nextLayers = isTerminal ? null : new HashMap<>();
-    }
-
-    public static ProjectionLayer buildLayers(Collection<String> dotPaths, boolean addDocId) {
-      // Root is always branch (not terminal):
-      ProjectionLayer root = new ProjectionLayer(false, "");
-      for (String fullPath : dotPaths) {
-        String[] segments = DOT.split(fullPath);
-        buildPath(fullPath, root, segments);
-      }
-      // May need to add doc-id inclusion/exclusion as well
-      if (addDocId) {
-        buildPath(
-            DocumentConstants.Fields.DOC_ID, root, new String[] {DocumentConstants.Fields.DOC_ID});
-      }
-      return root;
-    }
-
-    static void buildPath(String fullPath, ProjectionLayer layer, String[] segments) {
-      // First create branches
-      final int last = segments.length - 1;
-      for (int i = 0; i < last; ++i) {
-        // Try to find or create branch
-        layer = layer.findOrCreateBranch(fullPath, segments[i]);
-      }
-      // And then attach terminal (leaf)
-      layer.addTerminal(fullPath, segments[last]);
-    }
-
-    ProjectionLayer findOrCreateBranch(String fullPath, String segment) {
-      // Cannot proceed past terminal layer (shorter path):
-      if (isTerminal) {
-        reportPathConflict(this.fullPath, fullPath);
-      }
-      ProjectionLayer next = nextLayers.get(segment);
-      if (next == null) {
-        next = new ProjectionLayer(false, fullPath);
-        nextLayers.put(segment, next);
-      }
-      return next;
-    }
-
-    void addTerminal(String fullPath, String segment) {
-      // Cannot proceed past terminal layer (shorter path):
-      if (isTerminal) {
-        reportPathConflict(this.fullPath, fullPath);
-      }
-      // But will also not allow existing longer path:
-      ProjectionLayer next = nextLayers.get(segment);
-      if (next != null) {
-        reportPathConflict(fullPath, next.fullPath);
-      }
-      nextLayers.put(segment, new ProjectionLayer(true, fullPath));
-    }
-
-    void reportPathConflict(String fullPath1, String fullPath2) {
-      throw new JsonApiException(
-          ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
-          ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
-              + ": projection path conflict between '"
-              + fullPath1
-              + "' and '"
-              + fullPath2
-              + "'");
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (o == this) return true;
-      if (!(o instanceof ProjectionLayer)) return false;
-      ProjectionLayer other = (ProjectionLayer) o;
-      return (this.isTerminal == other.isTerminal)
-          && Objects.equals(this.fullPath, other.fullPath)
-          && Objects.equals(this.nextLayers, other.nextLayers);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(isTerminal, fullPath, nextLayers);
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
@@ -1,0 +1,114 @@
+package io.stargate.sgv2.jsonapi.service.projection;
+
+import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Helper class that handles projection traversal for one level of nesting. Layers are either
+ * non-terminal (branches) or terminal (leaves)
+ */
+class ProjectionLayer {
+  private static final Pattern DOT = Pattern.compile(Pattern.quote("."));
+
+  /** Whether this layer is terminal (matching) or branch (non-matching) */
+  private final boolean isTerminal;
+
+  /**
+   * Full path either to this layer (terminal), or to the first path through it (non-terminal) --
+   * needed for conflict reporting.
+   */
+  private final String fullPath;
+
+  /** For non-terminal layers, segment-indexed next layers */
+  private final Map<String, ProjectionLayer> nextLayers;
+
+  ProjectionLayer(boolean terminal, String fullPath) {
+    isTerminal = terminal;
+    this.fullPath = fullPath;
+    nextLayers = isTerminal ? null : new HashMap<>();
+  }
+
+  public static ProjectionLayer buildLayers(Collection<String> dotPaths, boolean addDocId) {
+    // Root is always branch (not terminal):
+    ProjectionLayer root = new ProjectionLayer(false, "");
+    for (String fullPath : dotPaths) {
+      String[] segments = DOT.split(fullPath);
+      buildPath(fullPath, root, segments);
+    }
+    // May need to add doc-id inclusion/exclusion as well
+    if (addDocId) {
+      buildPath(
+          DocumentConstants.Fields.DOC_ID, root, new String[] {DocumentConstants.Fields.DOC_ID});
+    }
+    return root;
+  }
+
+  static void buildPath(String fullPath, ProjectionLayer layer, String[] segments) {
+    // First create branches
+    final int last = segments.length - 1;
+    for (int i = 0; i < last; ++i) {
+      // Try to find or create branch
+      layer = layer.findOrCreateBranch(fullPath, segments[i]);
+    }
+    // And then attach terminal (leaf)
+    layer.addTerminal(fullPath, segments[last]);
+  }
+
+  ProjectionLayer findOrCreateBranch(String fullPath, String segment) {
+    // Cannot proceed past terminal layer (shorter path):
+    if (isTerminal) {
+      reportPathConflict(this.fullPath, fullPath);
+    }
+    ProjectionLayer next = nextLayers.get(segment);
+    if (next == null) {
+      next = new ProjectionLayer(false, fullPath);
+      nextLayers.put(segment, next);
+    }
+    return next;
+  }
+
+  void addTerminal(String fullPath, String segment) {
+    // Cannot proceed past terminal layer (shorter path):
+    if (isTerminal) {
+      reportPathConflict(this.fullPath, fullPath);
+    }
+    // But will also not allow existing longer path:
+    ProjectionLayer next = nextLayers.get(segment);
+    if (next != null) {
+      reportPathConflict(fullPath, next.fullPath);
+    }
+    nextLayers.put(segment, new ProjectionLayer(true, fullPath));
+  }
+
+  void reportPathConflict(String fullPath1, String fullPath2) {
+    throw new JsonApiException(
+        ErrorCode.UNSUPPORTED_PROJECTION_PARAM,
+        ErrorCode.UNSUPPORTED_PROJECTION_PARAM.getMessage()
+            + ": projection path conflict between '"
+            + fullPath1
+            + "' and '"
+            + fullPath2
+            + "'");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) return true;
+    if (!(o instanceof ProjectionLayer)) return false;
+    ProjectionLayer other = (ProjectionLayer) o;
+    return (this.isTerminal == other.isTerminal)
+        && Objects.equals(this.fullPath, other.fullPath)
+        && Objects.equals(this.nextLayers, other.nextLayers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(isTerminal, fullPath, nextLayers);
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteManyCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteManyCommandResolver.java
@@ -9,6 +9,7 @@ import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DeleteOperation;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
 import io.stargate.sgv2.jsonapi.service.resolver.model.impl.matcher.FilterableResolver;
 import java.util.List;
@@ -54,6 +55,7 @@ public class DeleteManyCommandResolver extends FilterableResolver<DeleteManyComm
     return new FindOperation(
         commandContext,
         filters,
+        DocumentProjector.identityProjector(),
         null,
         documentConfig.maxDocumentDeleteCount() + 1,
         documentConfig.defaultPageSize(),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolver.java
@@ -9,6 +9,7 @@ import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DeleteOperation;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
 import io.stargate.sgv2.jsonapi.service.resolver.model.impl.matcher.FilterableResolver;
 import java.util.List;
@@ -46,6 +47,14 @@ public class DeleteOneCommandResolver extends FilterableResolver<DeleteOneComman
 
   private FindOperation getFindOperation(CommandContext commandContext, DeleteOneCommand command) {
     List<DBFilterBase> filters = resolve(commandContext, command);
-    return new FindOperation(commandContext, filters, null, 1, 1, ReadType.KEY, objectMapper);
+    return new FindOperation(
+        commandContext,
+        filters,
+        DocumentProjector.identityProjector(),
+        null,
+        1,
+        1,
+        ReadType.KEY,
+        objectMapper);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolver.java
@@ -45,6 +45,13 @@ public class FindCommandResolver extends FilterableResolver<FindCommand>
     int pageSize = documentConfig.defaultPageSize();
     String pagingState = command.options() != null ? command.options().pagingState() : null;
     return new FindOperation(
-        commandContext, filters, pagingState, limit, pageSize, ReadType.DOCUMENT, objectMapper);
+        commandContext,
+        filters,
+        command.buildProjector(),
+        pagingState,
+        limit,
+        pageSize,
+        ReadType.DOCUMENT,
+        objectMapper);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
@@ -9,6 +9,7 @@ import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.ReadAndUpdateOperation;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
 import io.stargate.sgv2.jsonapi.service.resolver.model.impl.matcher.FilterableResolver;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
@@ -70,7 +71,9 @@ public class FindOneAndUpdateCommandResolver extends FilterableResolver<FindOneA
     return new FindOperation(
         commandContext,
         filters,
-        command.buildProjector(),
+        // 24-Mar-2023, tatu: Since we update the document, need to avoid modifications on
+        // read path, hence pass identity projector.
+        DocumentProjector.identityProjector(),
         null,
         1,
         1,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
@@ -67,6 +67,14 @@ public class FindOneAndUpdateCommandResolver extends FilterableResolver<FindOneA
   private FindOperation getFindOperation(
       CommandContext commandContext, FindOneAndUpdateCommand command) {
     List<DBFilterBase> filters = resolve(commandContext, command);
-    return new FindOperation(commandContext, filters, null, 1, 1, ReadType.DOCUMENT, objectMapper);
+    return new FindOperation(
+        commandContext,
+        filters,
+        command.buildProjector(),
+        null,
+        1,
+        1,
+        ReadType.DOCUMENT,
+        objectMapper);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneCommandResolver.java
@@ -32,8 +32,15 @@ public class FindOneCommandResolver extends FilterableResolver<FindOneCommand>
 
   @Override
   public Operation resolveCommand(CommandContext commandContext, FindOneCommand command) {
-
     List<DBFilterBase> filters = resolve(commandContext, command);
-    return new FindOperation(commandContext, filters, null, 1, 1, ReadType.DOCUMENT, objectMapper);
+    return new FindOperation(
+        commandContext,
+        filters,
+        command.buildProjector(),
+        null,
+        1,
+        1,
+        ReadType.DOCUMENT,
+        objectMapper);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateManyCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateManyCommandResolver.java
@@ -9,6 +9,7 @@ import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.ReadAndUpdateOperation;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
 import io.stargate.sgv2.jsonapi.service.resolver.model.impl.matcher.FilterableResolver;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
@@ -67,6 +68,7 @@ public class UpdateManyCommandResolver extends FilterableResolver<UpdateManyComm
     return new FindOperation(
         commandContext,
         filters,
+        DocumentProjector.identityProjector(),
         null,
         documentConfig.maxDocumentUpdateCount() + 1,
         documentConfig.defaultPageSize(),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateOneCommandResolver.java
@@ -9,6 +9,7 @@ import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.ReadAndUpdateOperation;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
 import io.stargate.sgv2.jsonapi.service.resolver.model.impl.matcher.FilterableResolver;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
@@ -64,6 +65,14 @@ public class UpdateOneCommandResolver extends FilterableResolver<UpdateOneComman
 
   private FindOperation getFindOperation(CommandContext commandContext, UpdateOneCommand command) {
     List<DBFilterBase> filters = resolve(commandContext, command);
-    return new FindOperation(commandContext, filters, null, 1, 1, ReadType.DOCUMENT, objectMapper);
+    return new FindOperation(
+        commandContext,
+        filters,
+        DocumentProjector.identityProjector(),
+        null,
+        1,
+        1,
+        ReadType.DOCUMENT,
+        objectMapper);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
@@ -18,6 +18,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
 import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocValueHasher;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import java.util.List;
@@ -90,6 +91,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               List.of(
                   new DBFilterBase.IDFilter(
                       DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"))),
+              DocumentProjector.identityProjector(),
               null,
               1,
               1,
@@ -142,6 +144,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               List.of(
                   new DBFilterBase.IDFilter(
                       DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"))),
+              DocumentProjector.identityProjector(),
               null,
               1,
               1,
@@ -211,6 +214,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
+              DocumentProjector.identityProjector(),
               null,
               1,
               1,
@@ -317,6 +321,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
+              DocumentProjector.identityProjector(),
               null,
               1,
               1,
@@ -425,6 +430,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
+              DocumentProjector.identityProjector(),
               null,
               1,
               1,
@@ -528,6 +534,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
+              DocumentProjector.identityProjector(),
               null,
               1,
               1,
@@ -613,6 +620,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
+              DocumentProjector.identityProjector(),
               null,
               3,
               2,
@@ -696,6 +704,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
+              DocumentProjector.identityProjector(),
               null,
               3,
               1,
@@ -785,6 +794,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
+              DocumentProjector.identityProjector(),
               null,
               3,
               1,
@@ -845,6 +855,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
+              DocumentProjector.identityProjector(),
               null,
               1,
               1,
@@ -965,6 +976,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
+              DocumentProjector.identityProjector(),
               null,
               3,
               3,
@@ -1135,6 +1147,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
+              DocumentProjector.identityProjector(),
               null,
               3,
               3,

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -18,6 +18,7 @@ import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadOperation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocValueHasher;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import java.util.List;
@@ -98,7 +99,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
 
       FindOperation operation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(), null, 20, 20, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(),
+              DocumentProjector.identityProjector(),
+              null,
+              20,
+              20,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -166,7 +174,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation operation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -219,7 +234,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation operation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -284,7 +306,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           new DBFilterBase.TextFilter("username", DBFilterBase.MapFilterBase.Operator.EQ, "user1");
       FindOperation operation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -351,7 +380,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               "registration_active", DBFilterBase.MapFilterBase.Operator.EQ, true);
       FindOperation operation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -414,7 +450,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
       DBFilterBase.ExistsFilter filter = new DBFilterBase.ExistsFilter("registration_active", true);
       FindOperation operation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -480,7 +523,15 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               new DBFilterBase.AllFilter(new DocValueHasher(), "tags", "tag1"),
               new DBFilterBase.AllFilter(new DocValueHasher(), "tags", "tag2"));
       FindOperation operation =
-          new FindOperation(COMMAND_CONTEXT, filters, null, 1, 1, ReadType.DOCUMENT, objectMapper);
+          new FindOperation(
+              COMMAND_CONTEXT,
+              filters,
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -544,7 +595,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
       DBFilterBase.SizeFilter filter = new DBFilterBase.SizeFilter("tags", 2);
       FindOperation operation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -610,7 +668,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           new DBFilterBase.ArrayEqualsFilter(new DocValueHasher(), "tags", List.of("tag1", "tag2"));
       FindOperation operation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -677,7 +742,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               new DocValueHasher(), "sub_doc", Map.of("col", "val"));
       FindOperation operation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -735,7 +807,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation operation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       Throwable failure =
           operation
@@ -803,7 +882,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       ReadOperation.FindResponse result =
           findOperation
@@ -868,7 +954,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       ReadOperation.FindResponse result =
           findOperation
@@ -931,7 +1024,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           new DBFilterBase.TextFilter("username", DBFilterBase.MapFilterBase.Operator.EQ, "user1");
       FindOperation findOperation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       ReadOperation.FindResponse result =
           findOperation
@@ -996,7 +1096,14 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           new DBFilterBase.TextFilter("username", DBFilterBase.MapFilterBase.Operator.EQ, "user1");
       FindOperation findOperation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
 
       DBFilterBase.IDFilter idFilter =
           new DBFilterBase.IDFilter(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
@@ -20,6 +20,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateOperator;
 import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocValueHasher;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
@@ -213,7 +214,14 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         new DBFilterBase.TextFilter("username", DBFilterBase.MapFilterBase.Operator.EQ, "user1");
     FindOperation findOperation =
         new FindOperation(
-            COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+            COMMAND_CONTEXT,
+            List.of(filter),
+            DocumentProjector.identityProjector(),
+            null,
+            1,
+            1,
+            ReadType.DOCUMENT,
+            objectMapper);
     DocumentUpdater documentUpdater =
         DocumentUpdater.construct(
             DocumentUpdaterUtils.updateClause(
@@ -409,7 +417,14 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         new DBFilterBase.TextFilter("username", DBFilterBase.MapFilterBase.Operator.EQ, "user1");
     FindOperation findOperation =
         new FindOperation(
-            COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+            COMMAND_CONTEXT,
+            List.of(filter),
+            DocumentProjector.identityProjector(),
+            null,
+            1,
+            1,
+            ReadType.DOCUMENT,
+            objectMapper);
     DocumentUpdater documentUpdater =
         DocumentUpdater.construct(
             DocumentUpdaterUtils.updateClause(
@@ -614,7 +629,14 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         new DBFilterBase.TextFilter("username", DBFilterBase.MapFilterBase.Operator.EQ, "user1");
     FindOperation findOperation =
         new FindOperation(
-            COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+            COMMAND_CONTEXT,
+            List.of(filter),
+            DocumentProjector.identityProjector(),
+            null,
+            1,
+            1,
+            ReadType.DOCUMENT,
+            objectMapper);
     DocumentUpdater documentUpdater =
         DocumentUpdater.construct(
             DocumentUpdaterUtils.updateClause(
@@ -876,7 +898,14 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         new DBFilterBase.TextFilter("status", DBFilterBase.MapFilterBase.Operator.EQ, "active");
     FindOperation findOperation =
         new FindOperation(
-            COMMAND_CONTEXT, List.of(filter), null, 3, 3, ReadType.DOCUMENT, objectMapper);
+            COMMAND_CONTEXT,
+            List.of(filter),
+            DocumentProjector.identityProjector(),
+            null,
+            3,
+            3,
+            ReadType.DOCUMENT,
+            objectMapper);
     DocumentUpdater documentUpdater =
         DocumentUpdater.construct(
             DocumentUpdaterUtils.updateClause(
@@ -1195,7 +1224,14 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         new DBFilterBase.TextFilter("status", DBFilterBase.MapFilterBase.Operator.EQ, "active");
     FindOperation findOperation =
         new FindOperation(
-            COMMAND_CONTEXT, List.of(filter), null, 3, 3, ReadType.DOCUMENT, objectMapper);
+            COMMAND_CONTEXT,
+            List.of(filter),
+            DocumentProjector.identityProjector(),
+            null,
+            3,
+            3,
+            ReadType.DOCUMENT,
+            objectMapper);
     DocumentUpdater documentUpdater =
         DocumentUpdater.construct(
             DocumentUpdaterUtils.updateClause(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -20,6 +20,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateOperator;
 import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
@@ -155,7 +156,14 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(
@@ -275,7 +283,14 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(
@@ -339,7 +354,14 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 1, 1, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper);
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(
@@ -535,7 +557,14 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           new DBFilterBase.TextFilter("status", DBFilterBase.MapFilterBase.Operator.EQ, "active");
       FindOperation findOperation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 21, 20, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              21,
+              20,
+              ReadType.DOCUMENT,
+              objectMapper);
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(
@@ -656,7 +685,14 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 21, 20, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              21,
+              20,
+              ReadType.DOCUMENT,
+              objectMapper);
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(
@@ -716,7 +752,14 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           new DBFilterBase.TextFilter("status", DBFilterBase.MapFilterBase.Operator.EQ, "active");
       FindOperation findOperation =
           new FindOperation(
-              COMMAND_CONTEXT, List.of(filter), null, 21, 20, ReadType.DOCUMENT, objectMapper);
+              COMMAND_CONTEXT,
+              List.of(filter),
+              DocumentProjector.identityProjector(),
+              null,
+              21,
+              20,
+              ReadType.DOCUMENT,
+              objectMapper);
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
@@ -33,9 +33,50 @@ public class DocumentProjectorTest {
     }
 
     @Test
+    public void verifyNoIncludeAfterExclude() throws Exception {
+      JsonNode def =
+          objectMapper.readTree(
+              """
+              { "excludeMe" : 0,
+                "excludeMeToo" : 0,
+                "include.me" : 1
+              }
+              """);
+      Throwable t = catchThrowable(() -> DocumentProjector.createFromDefinition(def));
+      assertThat(t)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_PROJECTION_PARAM)
+          .hasMessage(
+              "Unsupported projection parameter: cannot include 'include.me' on exclusion projection");
+    }
+
+    @Test
+    public void verifyNoExcludeAfterInclude() throws Exception {
+      JsonNode def =
+          objectMapper.readTree(
+              """
+              { "includeMe" : 1,
+                "misc" : {
+                   "nested": {
+                     "do" : true,
+                     "dont" : false
+                    }
+                },
+                "includeMe2" : 1
+              }
+              """);
+      Throwable t = catchThrowable(() -> DocumentProjector.createFromDefinition(def));
+      assertThat(t)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_PROJECTION_PARAM)
+          .hasMessage(
+              "Unsupported projection parameter: cannot exclude 'misc.nested.dont' on inclusion projection");
+    }
+
+    @Test
     public void verifyProjectionEquality() throws Exception {
-      String defStr1 = "{ \"field1\" : 1, \"field2\": 0 }";
-      String defStr2 = "{ \"field1\" : 0, \"field2\": 1 }";
+      String defStr1 = "{ \"field1\" : 1, \"field2\": 1 }";
+      String defStr2 = "{ \"field1\" : 1, \"field3\": 1 }";
 
       DocumentProjector proj1 =
           DocumentProjector.createFromDefinition(objectMapper.readTree(defStr1));

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
@@ -1,0 +1,54 @@
+package io.stargate.sgv2.jsonapi.service.projection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class DocumentProjectorTest {
+  @Inject ObjectMapper objectMapper;
+
+  // Tests for validating issues with Projection definitions
+  @Nested
+  class ProjectorDefValidation {
+    @Test
+    public void verifyProjectionJsonObject() throws Exception {
+      JsonNode def = objectMapper.readTree(" [ 1, 2, 3 ]");
+      Throwable t = catchThrowable(() -> DocumentProjector.createFromDefinition(def));
+      assertThat(t)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_PROJECTION_PARAM)
+          .hasMessage("Unsupported projection parameter: definition must be OBJECT, was ARRAY");
+    }
+
+    @Test
+    public void verifyProjectionEquality() throws Exception {
+      String defStr1 = "{ \"field1\" : 1, \"field2\": 0 }";
+      String defStr2 = "{ \"field1\" : 0, \"field2\": 1 }";
+
+      DocumentProjector proj1 =
+          DocumentProjector.createFromDefinition(objectMapper.readTree(defStr1));
+      DocumentProjector proj2 =
+          DocumentProjector.createFromDefinition(objectMapper.readTree(defStr2));
+
+      // First, verify equality of identical definitions
+      assertThat(proj1)
+          .isEqualTo(DocumentProjector.createFromDefinition(objectMapper.readTree(defStr1)));
+      assertThat(proj2)
+          .isEqualTo(DocumentProjector.createFromDefinition(objectMapper.readTree(defStr2)));
+
+      // TODO: inequality
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
@@ -13,6 +13,7 @@ import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import java.util.List;
 import javax.inject.Inject;
@@ -49,6 +50,7 @@ public class FindCommandResolverTest {
               List.of(
                   new DBFilterBase.IDFilter(
                       DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("id"))),
+              DocumentProjector.identityProjector(),
               null,
               documentConfig.maxLimit(),
               documentConfig.defaultPageSize(),
@@ -80,6 +82,7 @@ public class FindCommandResolverTest {
           new FindOperation(
               commandContext,
               List.of(),
+              DocumentProjector.identityProjector(),
               null,
               documentConfig.maxLimit(),
               documentConfig.defaultPageSize(),
@@ -115,6 +118,7 @@ public class FindCommandResolverTest {
           new FindOperation(
               commandContext,
               List.of(),
+              DocumentProjector.identityProjector(),
               "dlavjhvbavkjbna",
               10,
               documentConfig.defaultPageSize(),
@@ -149,6 +153,7 @@ public class FindCommandResolverTest {
               List.of(
                   new DBFilterBase.TextFilter(
                       "col", DBFilterBase.MapFilterBase.Operator.EQ, "val")),
+              DocumentProjector.identityProjector(),
               null,
               documentConfig.maxLimit(),
               documentConfig.defaultPageSize(),

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -154,6 +155,94 @@ public class FindCommandResolverTest {
                   new DBFilterBase.TextFilter(
                       "col", DBFilterBase.MapFilterBase.Operator.EQ, "val")),
               DocumentProjector.identityProjector(),
+              null,
+              documentConfig.maxLimit(),
+              documentConfig.defaultPageSize(),
+              ReadType.DOCUMENT,
+              objectMapper);
+      assertThat(operation)
+          .isInstanceOf(FindOperation.class)
+          .satisfies(
+              op -> {
+                assertThat(op).isEqualTo(expected);
+              });
+    }
+  }
+
+  @Nested
+  class FindCommandResolveWithProjection {
+    @Test
+    public void idFilterConditionAndProjection() throws Exception {
+      final JsonNode projectionDef =
+          objectMapper.readTree(
+              """
+              {
+                "field1" : 1,
+                "field2" : 1
+               }
+               """);
+      String json =
+          """
+                      {
+                        "find": {
+                          "filter" : {"_id" : "id"},
+                          "projection": %s
+                        }
+                      }
+                      """
+              .formatted(projectionDef);
+      FindCommand findCommand = objectMapper.readValue(json, FindCommand.class);
+      final CommandContext commandContext = new CommandContext("namespace", "collection");
+      final Operation operation = findCommandResolver.resolveCommand(commandContext, findCommand);
+      FindOperation expected =
+          new FindOperation(
+              commandContext,
+              List.of(
+                  new DBFilterBase.IDFilter(
+                      DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("id"))),
+              DocumentProjector.createFromDefinition(projectionDef),
+              null,
+              documentConfig.maxLimit(),
+              documentConfig.defaultPageSize(),
+              ReadType.DOCUMENT,
+              objectMapper);
+      assertThat(operation)
+          .isInstanceOf(FindOperation.class)
+          .satisfies(
+              op -> {
+                assertThat(op).isEqualTo(expected);
+              });
+    }
+
+    @Test
+    public void noFilterConditionWithProjection() throws Exception {
+      final JsonNode projectionDef =
+          objectMapper.readTree(
+              """
+              {
+                "field1" : 1,
+                "field2" : 1
+               }
+               """);
+      String json =
+          """
+                  {
+                    "find": {
+                      "projection" : %s
+                    }
+                  }
+                  """
+              .formatted(projectionDef);
+
+      FindCommand findOneCommand = objectMapper.readValue(json, FindCommand.class);
+      final CommandContext commandContext = new CommandContext("namespace", "collection");
+      final Operation operation =
+          findCommandResolver.resolveCommand(commandContext, findOneCommand);
+      FindOperation expected =
+          new FindOperation(
+              commandContext,
+              List.of(),
+              DocumentProjector.createFromDefinition(projectionDef),
               null,
               documentConfig.maxLimit(),
               documentConfig.defaultPageSize(),


### PR DESCRIPTION
**What this PR does**:

Adds support for optional empty "projection" parameter, validation that if passed its JSON Object.
Serves as the base for actual projection implementation

**Which issue(s) this PR fixes**:
Fixes #158

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
