### PR TITLE
fix bumping of parent version script

### DIFF
--- a/scripts/bump_stargate.sh
+++ b/scripts/bump_stargate.sh
@@ -15,5 +15,5 @@ else
    exit 1
 fi
 
-# Note: brackets around version needed for parent (version "range") but not for child modules
-./mvnw -B versions:update-parent -DparentVersion="[${STARGATE_VERSION_NUMBER}]" -DgenerateBackupPoms=false -DallowSnapshots=true
+# update parent version only
+sed -i '0,/<\/parent>/ { /<version>/ { s|<version>[^<]*<\/version>|<version>'"$STARGATE_VERSION_NUMBER"'<\/version>|; } }' pom.xml

--- a/scripts/bump_stargate.sh
+++ b/scripts/bump_stargate.sh
@@ -15,5 +15,15 @@ else
    exit 1
 fi
 
+# macOS will not work
+if [[ $OSTYPE == 'darwin'* ]]; then
+  echo 'You are running macOS, which is not supported by this script'
+  echo 'You can automatically bump the Stargate version using the GitHub workflow https://github.com/stargate/jsonapi/actions/workflows/update-parent-version.yaml'
+  echo 'If you still want to bump the version manually, then follow the steps below:'
+  echo ' 1. Update the version of the sgv2-api-parent parent in the pom.xml'
+  echo ' 2. Commit and push your changes'
+  exit 1
+fi
+
 # update parent version only
 sed -i '0,/<\/parent>/ { /<version>/ { s|<version>[^<]*<\/version>|<version>'"$STARGATE_VERSION_NUMBER"'<\/version>|; } }' pom.xml


### PR DESCRIPTION
**What this PR does**:

Unfortunately the existing way of bumping the parent version works only if parent exists on the maven repository.. However, it ususally takes 15-20 minutes for new version to be available on the maven repository.. And since we use the script in the automated way, once the release is done it could actually resolve the new version to be not available and thus not updating the pom..

This is also the reason why automated workflow so far did not create any PR.. Simply there we no changes in the working three so you could not create a PR..

The update command sets the parent directly..