### PR TITLE
closes #298: count down latch to be decrease on assertion errors

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteManyIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteManyIntegrationTest.java
@@ -300,28 +300,33 @@ public class DeleteManyIntegrationTest extends CollectionResourceBaseIntegration
       for (int i = 0; i < threads; i++) {
         new Thread(
                 () -> {
-                  Integer deletedCount =
-                      given()
-                          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-                          .contentType(ContentType.JSON)
-                          .body(deleteJson)
-                          .when()
-                          .post(
-                              CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
-                          .then()
-                          .statusCode(200)
-                          .body(
-                              "status.deletedCount",
-                              anyOf(greaterThanOrEqualTo(0), lessThanOrEqualTo(totalDocuments)))
-                          .body("errors", is(nullValue()))
-                          .extract()
-                          .path("status.deletedCount");
+                  try {
+                    Integer deletedCount =
+                        given()
+                            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+                            .contentType(ContentType.JSON)
+                            .body(deleteJson)
+                            .when()
+                            .post(
+                                CollectionResource.BASE_PATH,
+                                keyspaceId.asInternal(),
+                                collectionName)
+                            .then()
+                            .statusCode(200)
+                            .body(
+                                "status.deletedCount",
+                                anyOf(greaterThanOrEqualTo(0), lessThanOrEqualTo(totalDocuments)))
+                            .body("errors", is(nullValue()))
+                            .extract()
+                            .path("status.deletedCount");
 
-                  // add reported deletes
-                  reportedDeletions.addAndGet(deletedCount);
+                    // add reported deletes
+                    reportedDeletions.addAndGet(deletedCount);
+                  } finally {
 
-                  // count down
-                  latch.countDown();
+                    // count down
+                    latch.countDown();
+                  }
                 })
             .start();
       }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteManyIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteManyIntegrationTest.java
@@ -19,6 +19,7 @@ import io.stargate.sgv2.api.common.config.constants.HttpConstants;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
@@ -297,7 +298,9 @@ public class DeleteManyIntegrationTest extends CollectionResourceBaseIntegration
           """;
       // start all threads
       AtomicInteger reportedDeletions = new AtomicInteger(0);
+      AtomicReferenceArray<Exception> exceptions = new AtomicReferenceArray<>(threads);
       for (int i = 0; i < threads; i++) {
+        int index = i;
         new Thread(
                 () -> {
                   try {
@@ -322,6 +325,10 @@ public class DeleteManyIntegrationTest extends CollectionResourceBaseIntegration
 
                     // add reported deletes
                     reportedDeletions.addAndGet(deletedCount);
+                  } catch (Exception e) {
+
+                    // set exception so we can rethrow
+                    exceptions.set(index, e);
                   } finally {
 
                     // count down
@@ -332,6 +339,15 @@ public class DeleteManyIntegrationTest extends CollectionResourceBaseIntegration
       }
 
       latch.await();
+
+      // check if there are any exceptions
+      // throw first that is seen
+      for (int i = 0; i < threads; i++) {
+        Exception exception = exceptions.get(i);
+        if (null != exception) {
+          throw exception;
+        }
+      }
 
       // assert reported deletes are exactly one
       assertThat(reportedDeletions.get()).isEqualTo(totalDocuments);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteOneIntegrationTest.java
@@ -329,26 +329,31 @@ public class DeleteOneIntegrationTest extends CollectionResourceBaseIntegrationT
       for (int i = 0; i < threads; i++) {
         new Thread(
                 () -> {
-                  Integer deletedCount =
-                      given()
-                          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-                          .contentType(ContentType.JSON)
-                          .body(deleteJson)
-                          .when()
-                          .post(
-                              CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
-                          .then()
-                          .statusCode(200)
-                          .body("status.deletedCount", anyOf(is(0), is(1)))
-                          .body("errors", is(nullValue()))
-                          .extract()
-                          .path("status.deletedCount");
+                  try {
+                    Integer deletedCount =
+                        given()
+                            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+                            .contentType(ContentType.JSON)
+                            .body(deleteJson)
+                            .when()
+                            .post(
+                                CollectionResource.BASE_PATH,
+                                keyspaceId.asInternal(),
+                                collectionName)
+                            .then()
+                            .statusCode(200)
+                            .body("status.deletedCount", anyOf(is(0), is(1)))
+                            .body("errors", is(nullValue()))
+                            .extract()
+                            .path("status.deletedCount");
 
-                  // add reported deletes
-                  reportedDeletions.addAndGet(deletedCount);
+                    // add reported deletes
+                    reportedDeletions.addAndGet(deletedCount);
+                  } finally {
 
-                  // count down
-                  latch.countDown();
+                    // count down
+                    latch.countDown();
+                  }
                 })
             .start();
       }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateManyIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateManyIntegrationTest.java
@@ -499,20 +499,23 @@ public class UpdateManyIntegrationTest extends CollectionResourceBaseIntegration
       for (int i = 0; i < threads; i++) {
         new Thread(
                 () -> {
-                  given()
-                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-                      .contentType(ContentType.JSON)
-                      .body(updateJson)
-                      .when()
-                      .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
-                      .then()
-                      .statusCode(200)
-                      .body("status.matchedCount", is(5))
-                      .body("status.modifiedCount", is(5))
-                      .body("errors", is(nullValue()));
+                  try {
+                    given()
+                        .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+                        .contentType(ContentType.JSON)
+                        .body(updateJson)
+                        .when()
+                        .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+                        .then()
+                        .statusCode(200)
+                        .body("status.matchedCount", is(5))
+                        .body("status.modifiedCount", is(5))
+                        .body("errors", is(nullValue()));
+                  } finally {
 
-                  // count down
-                  latch.countDown();
+                    // count down
+                    latch.countDown();
+                  }
                 })
             .start();
       }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
@@ -13,6 +13,7 @@ import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
@@ -1744,7 +1745,9 @@ public class UpdateOneIntegrationTest extends CollectionResourceBaseIntegrationT
           }
           """;
       // start all threads
+      AtomicReferenceArray<Exception> exceptions = new AtomicReferenceArray<>(threads);
       for (int i = 0; i < threads; i++) {
+        int index = i;
         new Thread(
                 () -> {
                   try {
@@ -1759,6 +1762,10 @@ public class UpdateOneIntegrationTest extends CollectionResourceBaseIntegrationT
                         .body("status.matchedCount", is(1))
                         .body("status.modifiedCount", is(1))
                         .body("errors", is(nullValue()));
+                  } catch (Exception e) {
+
+                    // set exception so we can rethrow
+                    exceptions.set(index, e);
                   } finally {
 
                     // count down
@@ -1769,6 +1776,15 @@ public class UpdateOneIntegrationTest extends CollectionResourceBaseIntegrationT
       }
 
       latch.await();
+
+      // check if there are any exceptions
+      // throw first that is seen
+      for (int i = 0; i < threads; i++) {
+        Exception exception = exceptions.get(i);
+        if (null != exception) {
+          throw exception;
+        }
+      }
 
       // assert state after all updates
       String expectedDoc =

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
@@ -1747,20 +1747,23 @@ public class UpdateOneIntegrationTest extends CollectionResourceBaseIntegrationT
       for (int i = 0; i < threads; i++) {
         new Thread(
                 () -> {
-                  given()
-                      .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-                      .contentType(ContentType.JSON)
-                      .body(updateJson)
-                      .when()
-                      .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
-                      .then()
-                      .statusCode(200)
-                      .body("status.matchedCount", is(1))
-                      .body("status.modifiedCount", is(1))
-                      .body("errors", is(nullValue()));
+                  try {
+                    given()
+                        .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+                        .contentType(ContentType.JSON)
+                        .body(updateJson)
+                        .when()
+                        .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+                        .then()
+                        .statusCode(200)
+                        .body("status.matchedCount", is(1))
+                        .body("status.modifiedCount", is(1))
+                        .body("errors", is(nullValue()));
+                  } finally {
 
-                  // count down
-                  latch.countDown();
+                    // count down
+                    latch.countDown();
+                  }
                 })
             .start();
       }


### PR DESCRIPTION
**What this PR does**:
Fixes the count down latch now being decreased on failed asserts.. This will never result in a block..

But the exception would be ignored.. Thus I am thinking what the options are:

* [x] catch any exception, set to the `AtomicReference`, after CTL goes to zero iterate over and re-throw any exception?
* [ ] better ideas?

**Which issue(s) this PR fixes**:
Fixes #298

**WARNING: remove serial consistency commit before merging**