### PR TITLE
use DSE 6.8.33 in int tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <!-- Integration test props -->
     <!-- When updating please change defaults in the DseTestResource class -->
     <stargate.int-test.cassandra.image>datastax/dse-server</stargate.int-test.cassandra.image>
-    <stargate.int-test.cassandra.image-tag>6.8.32</stargate.int-test.cassandra.image-tag>
+    <stargate.int-test.cassandra.image-tag>6.8.33</stargate.int-test.cassandra.image-tag>
     <stargate.int-test.coordinator.image>stargateio/coordinator-dse-68</stargate.int-test.coordinator.image>
     <stargate.int-test.coordinator.image-tag>v${stargate.version}</stargate.int-test.coordinator.image-tag>
     <stargate.int-test.cluster.name>dse-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -10,7 +10,7 @@ public class DseTestResource extends StargateTestResource {
     super();
 
     if (null == System.getProperty("testing.containers.cassandra-image")) {
-      System.setProperty("testing.containers.cassandra-image", "datastax/dse-server:6.8.32");
+      System.setProperty("testing.containers.cassandra-image", "datastax/dse-server:6.8.33");
     }
 
     if (null == System.getProperty("testing.containers.stargate-image")) {


### PR DESCRIPTION
**What this PR does**:
Uses latest DSE in int tests.

**Which issue(s) this PR fixes**:
Fixes #287 
