### PR TITLE
closes #261: grpc retries and timeouts to fix availability failures

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/grpc/retries/impl/JsonApiGrpcRetryPolicy.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/grpc/retries/impl/JsonApiGrpcRetryPolicy.java
@@ -5,14 +5,13 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.ProtoUtils;
 import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.api.common.grpc.retries.GrpcRetryPredicate;
 import java.util.Objects;
-import java.util.function.Predicate;
 import javax.enterprise.context.ApplicationScoped;
 
 /** Default gRPC retry policy used in the project. */
 @ApplicationScoped
-// TODO correct type here
-public class JsonApiGrpcRetryPolicy implements Predicate<StatusRuntimeException> {
+public class JsonApiGrpcRetryPolicy implements GrpcRetryPredicate {
 
   private static final Metadata.Key<QueryOuterClass.WriteTimeout> WRITE_TIMEOUT_KEY =
       ProtoUtils.keyForProto(QueryOuterClass.WriteTimeout.getDefaultInstance());

--- a/src/main/java/io/stargate/sgv2/jsonapi/grpc/retries/impl/JsonApiGrpcRetryPolicy.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/grpc/retries/impl/JsonApiGrpcRetryPolicy.java
@@ -1,0 +1,54 @@
+package io.stargate.sgv2.jsonapi.grpc.retries.impl;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.ProtoUtils;
+import io.stargate.bridge.proto.QueryOuterClass;
+import java.util.Objects;
+import java.util.function.Predicate;
+import javax.enterprise.context.ApplicationScoped;
+
+/** Default gRPC retry policy used in the project. */
+@ApplicationScoped
+// TODO correct type here
+public class JsonApiGrpcRetryPolicy implements Predicate<StatusRuntimeException> {
+
+  private static final Metadata.Key<QueryOuterClass.WriteTimeout> WRITE_TIMEOUT_KEY =
+      ProtoUtils.keyForProto(QueryOuterClass.WriteTimeout.getDefaultInstance());
+
+  private static final Metadata.Key<QueryOuterClass.ReadTimeout> READ_TIMEOUT_KEY =
+      ProtoUtils.keyForProto(QueryOuterClass.ReadTimeout.getDefaultInstance());
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean test(StatusRuntimeException e) {
+    Status status = e.getStatus();
+    Status.Code code = status.getCode();
+
+    // always retry unavailable
+    if (Objects.equals(code, Status.Code.UNAVAILABLE)) {
+      return true;
+    }
+
+    // for timeouts, retry only server side timeouts
+    if (Objects.equals(code, Status.Code.DEADLINE_EXCEEDED)) {
+      return isValidServerSideTimeout(e.getTrailers());
+    }
+
+    // nothing else
+    return false;
+  }
+
+  // ensure we retry only server side timeouts we want
+  private boolean isValidServerSideTimeout(Metadata trailers) {
+    // if we have trailers
+    if (null != trailers) {
+      // TODO double check the CAS write timeout retries are fine
+      return trailers.containsKey(READ_TIMEOUT_KEY) || trailers.containsKey(WRITE_TIMEOUT_KEY);
+    }
+
+    // otherwise not
+    return false;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/grpc/retries/impl/JsonApiGrpcRetryPolicy.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/grpc/retries/impl/JsonApiGrpcRetryPolicy.java
@@ -9,7 +9,19 @@ import io.stargate.sgv2.api.common.grpc.retries.GrpcRetryPredicate;
 import java.util.Objects;
 import javax.enterprise.context.ApplicationScoped;
 
-/** Default gRPC retry policy used in the project. */
+/**
+ * Default gRPC retry policy used in the project. The policy defines retries when:
+ *
+ * <ol>
+ *   <li>The received GRPC status code is <code>UNAVAILABLE</code>
+ *   <li>The received GRPC status code is <code>DEADLINE_EXCEEDED</code>, but the metadata received
+ *       contains the trailers set by the Bridge in case of a server-side read, write and CAS write
+ *       timeouts.
+ * </ol>
+ *
+ * Note that this class only defines the policy. Amount of retries and other retry properties are
+ * defined by <code>stargate.grpc.retries</code> property group.
+ */
 @ApplicationScoped
 public class JsonApiGrpcRetryPolicy implements GrpcRetryPredicate {
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/grpc/retries/impl/JsonApiGrpcRetryPolicy.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/grpc/retries/impl/JsonApiGrpcRetryPolicy.java
@@ -43,7 +43,7 @@ public class JsonApiGrpcRetryPolicy implements GrpcRetryPredicate {
   private boolean isValidServerSideTimeout(Metadata trailers) {
     // if we have trailers
     if (null != trailers) {
-      // TODO double check the CAS write timeout retries are fine
+      // read, write and CAS write timeouts will include one of two trailers
       return trailers.containsKey(READ_TIMEOUT_KEY) || trailers.containsKey(WRITE_TIMEOUT_KEY);
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,19 @@ stargate:
   exception-mappers:
     enabled: false
 
+  # custom grpc settings
+  grpc:
+
+    # default client timeout 2x from max server side timeout
+    # see https://docs.datastax.com/en/dse/6.8/dse-dev/datastax_enterprise/config/configCassandra_yaml.html#Networktimeoutsettings
+    call-deadline: PT20S
+
+    # retries use custom policy, see io.stargate.sgv2.jsonapi.grpc.retries.impl.JsonApiGrpcRetryPolicy
+    retires:
+      enabled: true
+      max-attempts: 1
+      policy: custom
+
   # metrics properties
   # see io.stargate.sgv2.api.common.config.MetricsConfig for all config properties and options
   metrics:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,7 +15,7 @@ stargate:
     call-deadline: PT20S
 
     # retries use custom policy, see io.stargate.sgv2.jsonapi.grpc.retries.impl.JsonApiGrpcRetryPolicy
-    retires:
+    retries:
       enabled: true
       max-attempts: 1
       policy: custom

--- a/src/test/java/io/stargate/sgv2/jsonapi/grpc/retries/impl/JsonApiGrpcRetryPolicyBridgeTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/grpc/retries/impl/JsonApiGrpcRetryPolicyBridgeTest.java
@@ -1,0 +1,160 @@
+package io.stargate.sgv2.jsonapi.grpc.retries.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.ProtoUtils;
+import io.grpc.stub.StreamObserver;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.api.common.grpc.RetriableStargateBridge;
+import io.stargate.sgv2.api.common.grpc.qualifier.Retriable;
+import io.stargate.sgv2.common.bridge.BridgeTest;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+class JsonApiGrpcRetryPolicyBridgeTest extends BridgeTest {
+
+  @Retriable @Inject RetriableStargateBridge bridge;
+
+  @Test
+  public void unavailable() {
+    Status status = Status.UNAVAILABLE;
+    StatusRuntimeException ex = new StatusRuntimeException(status);
+
+    doAnswer(
+            invocationOnMock -> {
+              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+
+              observer.onError(ex);
+              return null;
+            })
+        .when(bridgeService)
+        .executeQuery(any(), any());
+
+    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+    Throwable failure =
+        bridge
+            .executeQuery(request)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create())
+            .awaitFailure()
+            .getFailure();
+
+    assertThat(failure)
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            e -> assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.UNAVAILABLE));
+
+    // original call + retry
+    verify(bridgeService, times(2)).executeQuery(eq(request), any());
+  }
+
+  @Test
+  public void serverSideTimeout() {
+    Metadata.Key<QueryOuterClass.WriteTimeout> key =
+        ProtoUtils.keyForProto(QueryOuterClass.WriteTimeout.getDefaultInstance());
+    QueryOuterClass.WriteTimeout value = QueryOuterClass.WriteTimeout.newBuilder().build();
+    Metadata metadata = new Metadata();
+    metadata.put(key, value);
+    Status status = Status.DEADLINE_EXCEEDED;
+    StatusRuntimeException ex = new StatusRuntimeException(status, metadata);
+
+    doAnswer(
+            invocationOnMock -> {
+              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+              observer.onError(ex);
+              return null;
+            })
+        .when(bridgeService)
+        .executeQuery(any(), any());
+
+    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+    Throwable failure =
+        bridge
+            .executeQuery(request)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create())
+            .awaitFailure()
+            .getFailure();
+
+    assertThat(failure)
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            e -> assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.DEADLINE_EXCEEDED));
+
+    // original call + retry
+    verify(bridgeService, times(2)).executeQuery(eq(request), any());
+  }
+
+  @Test
+  public void clientSideTimeout() {
+    Status status = Status.DEADLINE_EXCEEDED;
+    StatusRuntimeException ex = new StatusRuntimeException(status);
+
+    doAnswer(
+            invocationOnMock -> {
+              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+              observer.onError(ex);
+              return null;
+            })
+        .when(bridgeService)
+        .executeQuery(any(), any());
+
+    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+    Throwable failure =
+        bridge
+            .executeQuery(request)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create())
+            .awaitFailure()
+            .getFailure();
+
+    assertThat(failure)
+        .isInstanceOfSatisfying(
+            StatusRuntimeException.class,
+            e -> assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.DEADLINE_EXCEEDED));
+
+    // original call only, no retry on client side
+    verify(bridgeService).executeQuery(eq(request), any());
+  }
+
+  @Test
+  public void noRetry() {
+    QueryOuterClass.Response response = QueryOuterClass.Response.newBuilder().build();
+
+    doAnswer(
+            invocationOnMock -> {
+              StreamObserver<QueryOuterClass.Response> observer = invocationOnMock.getArgument(1);
+              observer.onNext(response);
+              observer.onCompleted();
+              return null;
+            })
+        .when(bridgeService)
+        .executeQuery(any(), any());
+
+    QueryOuterClass.Query request = QueryOuterClass.Query.newBuilder().build();
+    bridge
+        .executeQuery(request)
+        .subscribe()
+        .withSubscriber(UniAssertSubscriber.create())
+        .awaitItem()
+        .assertItem(response)
+        .assertCompleted();
+
+    // verify one call only
+    verify(bridgeService).executeQuery(eq(request), any());
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/grpc/retries/impl/JsonApiGrpcRetryPolicyTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/grpc/retries/impl/JsonApiGrpcRetryPolicyTest.java
@@ -1,0 +1,89 @@
+package io.stargate.sgv2.jsonapi.grpc.retries.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.ProtoUtils;
+import io.stargate.bridge.proto.QueryOuterClass;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class JsonApiGrpcRetryPolicyTest {
+
+  JsonApiGrpcRetryPolicy policy = new JsonApiGrpcRetryPolicy();
+
+  @Nested
+  class PredicateTest {
+
+    @Test
+    public void unavailable() {
+      StatusRuntimeException e = new StatusRuntimeException(Status.UNAVAILABLE);
+
+      boolean result = policy.test(e);
+
+      assertThat(result).isTrue();
+    }
+
+    @Test
+    public void deadlineWithReadTimeout() {
+      Metadata.Key<QueryOuterClass.ReadTimeout> key =
+          ProtoUtils.keyForProto(QueryOuterClass.ReadTimeout.getDefaultInstance());
+      QueryOuterClass.ReadTimeout value = QueryOuterClass.ReadTimeout.newBuilder().build();
+      Metadata metadata = new Metadata();
+      metadata.put(key, value);
+      StatusRuntimeException e = new StatusRuntimeException(Status.DEADLINE_EXCEEDED, metadata);
+
+      boolean result = policy.test(e);
+
+      assertThat(result).isTrue();
+    }
+
+    @Test
+    public void deadlineWithWriteTimeout() {
+      Metadata.Key<QueryOuterClass.WriteTimeout> key =
+          ProtoUtils.keyForProto(QueryOuterClass.WriteTimeout.getDefaultInstance());
+      QueryOuterClass.WriteTimeout value = QueryOuterClass.WriteTimeout.newBuilder().build();
+      Metadata metadata = new Metadata();
+      metadata.put(key, value);
+      StatusRuntimeException e = new StatusRuntimeException(Status.DEADLINE_EXCEEDED, metadata);
+
+      boolean result = policy.test(e);
+
+      assertThat(result).isTrue();
+    }
+
+    @Test
+    public void deadlineWithWrongTrailer() {
+      Metadata.Key<QueryOuterClass.Unavailable> key =
+          ProtoUtils.keyForProto(QueryOuterClass.Unavailable.getDefaultInstance());
+      QueryOuterClass.Unavailable value = QueryOuterClass.Unavailable.newBuilder().build();
+      Metadata metadata = new Metadata();
+      metadata.put(key, value);
+      StatusRuntimeException e = new StatusRuntimeException(Status.DEADLINE_EXCEEDED, metadata);
+
+      boolean result = policy.test(e);
+
+      assertThat(result).isFalse();
+    }
+
+    @Test
+    public void deadlineWithoutTrailer() {
+      StatusRuntimeException e = new StatusRuntimeException(Status.DEADLINE_EXCEEDED);
+
+      boolean result = policy.test(e);
+
+      assertThat(result).isFalse();
+    }
+
+    @Test
+    public void ignoredStatusCode() {
+      StatusRuntimeException e = new StatusRuntimeException(Status.INTERNAL);
+
+      boolean result = policy.test(e);
+
+      assertThat(result).isFalse();
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Sets correct gRPC client timeouts and client retries for the jsonapi.

**This issue depends on the Stargate v2.0.11**.

**Which issue(s) this PR fixes**:
Fixes #261 

**Checklist**
- [x] update to Stargate `2.0.11`
- [x] create integration test for confirming policy is used
