### PR TITLE
(WIP) Add @JsonIgnoreProperties for optional "options" property

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.api.model.command;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.CountDocumentsCommands;
@@ -51,5 +52,10 @@ import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
   @JsonSubTypes.Type(value = InsertManyCommand.class),
   @JsonSubTypes.Type(value = UpdateManyCommand.class),
   @JsonSubTypes.Type(value = UpdateOneCommand.class),
+})
+@JsonIgnoreProperties({
+  // Conditional ignoral so command impls may or may not have "options" property but
+  // even if they don't, no error if caller passes such property.
+  "options"
 })
 public interface Command {}


### PR DESCRIPTION
**What this PR does**:

Adds `@JsonIgnoreProperties("options")` in `Command` to make "options" truly optional

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
