### PR TITLE
FindOneAndDelete command implementation

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -126,7 +126,8 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                         {
                           "findOneAndDelete": {
                               "filter": {"location": "London"},
-                              "sort" : ["race.start_date"]
+                              "sort" : ["race.start_date"],
+                              "projection" : {"location": 1}
                           }
                         }
                         """),
@@ -145,7 +146,8 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                             },
                             "options" : {
                                "returnDocument" : "before"
-                            }
+                            },
+                            "projection" : {"location": 1}
                         }
                       }
                       """),

--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -64,25 +64,25 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                   summary = "`findOne` command",
                   value =
                       """
-                              {
-                                "findOne": {
-                                    "filter": {"location": "London", "race.competitors" : {"$eq" : 100}},
-                                    "projection": {"_id":0, "location":1, "race.start_date":1, "tags":1},
-                                    "sort" : ["race.start_date"]
-                                }
-                              }
-                              """),
+                      {
+                        "findOne": {
+                            "filter": {"location": "London", "race.competitors" : {"$eq" : 100}},
+                            "projection": {"_id":0, "location":1, "race.start_date":1, "tags":1},
+                            "sort" : ["race.start_date"]
+                        }
+                      }
+                      """),
               @ExampleObject(
                   name = "countDocuments",
                   summary = "`countDocuments` command",
                   value =
                       """
-                            {
-                              "countDocuments": {
-                                  "filter": {"location": "London", "race.competitors" : {"$eq" : 100}}
-                              }
-                            }
-                            """),
+                      {
+                        "countDocuments": {
+                            "filter": {"location": "London", "race.competitors" : {"$eq" : 100}}
+                        }
+                      }
+                    """),
               @ExampleObject(
                   name = "find",
                   summary = "`find` command",
@@ -119,6 +119,18 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                       }
                       """),
               @ExampleObject(
+                  name = "findOneAndDelete",
+                  summary = "`findOneAndDelete` command",
+                  value =
+                      """
+                        {
+                          "findOneAndDelete": {
+                              "filter": {"location": "London"},
+                              "sort" : ["race.start_date"]
+                          }
+                        }
+                        """),
+              @ExampleObject(
                   name = "findOneAndReplace",
                   summary = "`findOneAndReplace` command",
                   value =
@@ -126,7 +138,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                       {
                         "findOneAndReplace": {
                             "filter": {"location": "London"},
-                            "sort" : ["race.start_date"]
+                            "sort" : ["race.start_date"],
                             "replacement": {
                                 "location": "New York",
                                 "count": 3
@@ -385,7 +397,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                           }
                         }
                       }
-                  """),
+                      """),
               @ExampleObject(
                   name = "resultFindOneAndReplace",
                   summary = "`findOneAndReplace` command result",
@@ -408,6 +420,27 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                        }
                      }
                      """),
+              @ExampleObject(
+                  name = "resultFindOneAndDelete",
+                  summary = "`findOneAndDetele` command result",
+                  value =
+                      """
+                       {
+                         "data": {
+                           "docs": [
+                             {
+                               "_id": "1",
+                               "location": "New York",
+                               "count": 3
+                             }
+                           ],
+                           "count": 1,
+                           "status": {
+                             "deletedCount": 1
+                           }
+                         }
+                       }
+                       """),
               @ExampleObject(
                   name = "resultFindOneAndUpdateUpsert",
                   summary = "`findOneAndUpdate` command with upsert result",

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
@@ -9,6 +9,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteCollectionCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteManyCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteOneCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindCommand;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndDeleteCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndReplaceCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndUpdateCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneCommand;
@@ -47,6 +48,7 @@ import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
   @JsonSubTypes.Type(value = DeleteManyCommand.class),
   @JsonSubTypes.Type(value = FindCommand.class),
   @JsonSubTypes.Type(value = FindOneCommand.class),
+  @JsonSubTypes.Type(value = FindOneAndDeleteCommand.class),
   @JsonSubTypes.Type(value = FindOneAndReplaceCommand.class),
   @JsonSubTypes.Type(value = FindOneAndUpdateCommand.class),
   @JsonSubTypes.Type(value = InsertOneCommand.class),

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndDeleteCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndDeleteCommand.java
@@ -1,0 +1,22 @@
+package io.stargate.sgv2.jsonapi.api.model.command.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.stargate.sgv2.jsonapi.api.model.command.Filterable;
+import io.stargate.sgv2.jsonapi.api.model.command.ModifyCommand;
+import io.stargate.sgv2.jsonapi.api.model.command.Projectable;
+import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.FilterClause;
+import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
+import javax.validation.Valid;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(
+    description =
+        "Command that finds a single JSON document from a collection and deletes it. The deleted document is returned")
+@JsonTypeName("findOneAndDelete")
+public record FindOneAndDeleteCommand(
+    @Valid @JsonProperty("filter") FilterClause filterClause,
+    @Valid @JsonProperty("sort") SortClause sortClause,
+    @JsonProperty("projection") JsonNode projectionDefinition)
+    implements ModifyCommand, Filterable, Projectable {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndReplaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndReplaceCommand.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.api.model.command.Filterable;
+import io.stargate.sgv2.jsonapi.api.model.command.ModifyCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.Projectable;
-import io.stargate.sgv2.jsonapi.api.model.command.ReadCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.FilterClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
 import javax.annotation.Nullable;
@@ -25,7 +25,7 @@ public record FindOneAndReplaceCommand(
     @JsonProperty("projection") JsonNode projectionDefinition,
     @NotNull @Valid @JsonProperty("replacement") ObjectNode replacementDocument,
     @Valid @Nullable Options options)
-    implements ReadCommand, Filterable, Projectable {
+    implements ModifyCommand, Filterable, Projectable {
 
   @Schema(
       name = "FindOneAndReplaceCommand.Options",

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
@@ -8,6 +8,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.impl.CountDocumentsCommands;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteManyCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteOneCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindCommand;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndDeleteCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndReplaceCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndUpdateCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneCommand;
@@ -75,6 +76,7 @@ public class CollectionResource {
                         DeleteManyCommand.class,
                         FindOneCommand.class,
                         FindCommand.class,
+                        FindOneAndDeleteCommand.class,
                         FindOneAndReplaceCommand.class,
                         FindOneAndUpdateCommand.class,
                         InsertOneCommand.class,
@@ -88,6 +90,7 @@ public class CollectionResource {
                 @ExampleObject(ref = "deleteMany"),
                 @ExampleObject(ref = "find"),
                 @ExampleObject(ref = "findOne"),
+                @ExampleObject(ref = "findOneAndDelete"),
                 @ExampleObject(ref = "findOneAndReplace"),
                 @ExampleObject(ref = "findOneAndUpdate"),
                 @ExampleObject(ref = "insertOne"),
@@ -110,6 +113,7 @@ public class CollectionResource {
                     @ExampleObject(ref = "resultDeleteMany"),
                     @ExampleObject(ref = "resultFind"),
                     @ExampleObject(ref = "resultFindOne"),
+                    @ExampleObject(ref = "resultFindOneAndDelete"),
                     @ExampleObject(ref = "resultFindOneAndReplace"),
                     @ExampleObject(ref = "resultFindOneAndUpdate"),
                     @ExampleObject(ref = "resultFindOneAndUpdateUpsert"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
@@ -125,8 +125,11 @@ public interface ReadOperation extends Operation {
         .uni(
             () -> new AtomicReference<String>(null),
             stateRef -> {
-              return queryExecutor.executeRead(
-                  query, Optional.ofNullable(stateRef.get()), pageSize);
+              final Uni<QueryOuterClass.ResultSet> resultSet =
+                  queryExecutor.executeRead(query, Optional.ofNullable(stateRef.get()), pageSize);
+              return resultSet
+                  .onItem()
+                  .invoke(rs -> stateRef.set(extractPagingStateFromResultSet(rs)));
             })
         // Read document while pagingState exists, limit for read is set at updateLimit +1
         .whilst(resultSet -> extractPagingStateFromResultSet(resultSet) != null)

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
@@ -125,9 +125,8 @@ public interface ReadOperation extends Operation {
         .uni(
             () -> new AtomicReference<String>(null),
             stateRef -> {
-              final Uni<QueryOuterClass.ResultSet> resultSet =
-                  queryExecutor.executeRead(query, Optional.ofNullable(stateRef.get()), pageSize);
-              return resultSet
+              return queryExecutor
+                  .executeRead(query, Optional.ofNullable(stateRef.get()), pageSize)
                   .onItem()
                   .invoke(rs -> stateRef.set(extractPagingStateFromResultSet(rs)));
             })

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperation.java
@@ -127,7 +127,7 @@ public record DeleteOperation(
                           Tuple3.of(
                               deleted != null ? deleted.getItem1() : false,
                               error,
-                              error != null && returnDocumentInResponse
+                              error == null && returnDocumentInResponse
                                   ? applyProjection(deleted.getItem2())
                                   : document));
             })

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperation.java
@@ -169,8 +169,9 @@ public record DeleteOperation(
    * @param queryExecutor
    * @param query
    * @param doc
-   * @return Uni<Boolean> `true` if deleted successfully, else `false` if data changed and no longer
-   *     match the conditions and throws JsonApiException if LWT failure.
+   * @return Uni<Tuple2<Boolean, ReadDocument>> where boolean `true` if deleted successfully, else
+   *     `false` if data changed and no longer match the conditions and throws JsonApiException if
+   *     LWT failure. ReadDocument is the document that was deleted.
    */
   private Uni<Tuple2<Boolean, ReadDocument>> deleteDocument(
       QueryExecutor queryExecutor, QueryOuterClass.Query query, ReadDocument doc)

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteManyCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteManyCommandResolver.java
@@ -37,7 +37,7 @@ public class DeleteManyCommandResolver extends FilterableResolver<DeleteManyComm
   @Override
   public Operation resolveCommand(CommandContext commandContext, DeleteManyCommand command) {
     final FindOperation findOperation = getFindOperation(commandContext, command);
-    return new DeleteOperation(
+    return DeleteOperation.delete(
         commandContext,
         findOperation,
         documentConfig.maxDocumentDeleteCount(),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolver.java
@@ -37,7 +37,7 @@ public class DeleteOneCommandResolver extends FilterableResolver<DeleteOneComman
   @Override
   public Operation resolveCommand(CommandContext commandContext, DeleteOneCommand command) {
     FindOperation findOperation = getFindOperation(commandContext, command);
-    return new DeleteOperation(commandContext, findOperation, 1, documentConfig.lwt().retries());
+    return DeleteOperation.delete(commandContext, findOperation, 1, documentConfig.lwt().retries());
   }
 
   @Override

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolver.java
@@ -1,0 +1,90 @@
+package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
+import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndDeleteCommand;
+import io.stargate.sgv2.jsonapi.service.bridge.config.DocumentConfig;
+import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
+import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.DeleteOperation;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
+import io.stargate.sgv2.jsonapi.service.resolver.model.impl.matcher.FilterableResolver;
+import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
+import io.stargate.sgv2.jsonapi.util.SortClauseUtil;
+import java.util.List;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+/** Resolves the {@link FindOneAndDeleteCommand } */
+@ApplicationScoped
+public class FindOneAndDeleteCommandResolver extends FilterableResolver<FindOneAndDeleteCommand>
+    implements CommandResolver<FindOneAndDeleteCommand> {
+  private final Shredder shredder;
+  private final DocumentConfig documentConfig;
+  private final ObjectMapper objectMapper;
+
+  @Inject
+  public FindOneAndDeleteCommandResolver(
+      ObjectMapper objectMapper, DocumentConfig documentConfig, Shredder shredder) {
+    super();
+    this.objectMapper = objectMapper;
+    this.shredder = shredder;
+    this.documentConfig = documentConfig;
+  }
+
+  @Override
+  public Class<FindOneAndDeleteCommand> getCommandClass() {
+    return FindOneAndDeleteCommand.class;
+  }
+
+  @Override
+  public Operation resolveCommand(CommandContext commandContext, FindOneAndDeleteCommand command) {
+    FindOperation findOperation = getFindOperation(commandContext, command);
+    // return
+    return DeleteOperation.deleteOneAndReturn(
+        commandContext, findOperation, documentConfig.lwt().retries(), command.buildProjector());
+  }
+
+  private FindOperation getFindOperation(
+      CommandContext commandContext, FindOneAndDeleteCommand command) {
+    List<DBFilterBase> filters = resolve(commandContext, command);
+    final SortClause sortClause = command.sortClause();
+    List<FindOperation.OrderBy> orderBy = SortClauseUtil.resolveOrderBy(sortClause);
+    // If orderBy present
+    if (orderBy != null) {
+      return FindOperation.sorted(
+          commandContext,
+          filters,
+          // 24-Mar-2023, tatu: Since we update the document, need to avoid modifications on
+          // read path, hence pass identity projector.
+          DocumentProjector.identityProjector(),
+          null,
+          1,
+          // For in memory sorting we read more data than needed, so defaultSortPageSize like 100
+          documentConfig.defaultSortPageSize(),
+          ReadType.SORTED_DOCUMENT,
+          objectMapper,
+          orderBy,
+          0,
+          // For in memory sorting if no limit provided in the request will use
+          // documentConfig.defaultPageSize() as limit
+          documentConfig.maxSortReadLimit());
+    } else {
+      return FindOperation.unsorted(
+          commandContext,
+          filters,
+          // 24-Mar-2023, tatu: Since we update the document, need to avoid modifications on
+          // read path, hence pass identity projector.
+          DocumentProjector.identityProjector(),
+          null,
+          1,
+          1,
+          ReadType.DOCUMENT,
+          objectMapper);
+    }
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolver.java
@@ -59,8 +59,6 @@ public class FindOneAndDeleteCommandResolver extends FilterableResolver<FindOneA
       return FindOperation.sorted(
           commandContext,
           filters,
-          // 24-Mar-2023, tatu: Since we update the document, need to avoid modifications on
-          // read path, hence pass identity projector.
           DocumentProjector.identityProjector(),
           null,
           1,
@@ -77,8 +75,6 @@ public class FindOneAndDeleteCommandResolver extends FilterableResolver<FindOneA
       return FindOperation.unsorted(
           commandContext,
           filters,
-          // 24-Mar-2023, tatu: Since we update the document, need to avoid modifications on
-          // read path, hence pass identity projector.
           DocumentProjector.identityProjector(),
           null,
           1,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolver.java
@@ -77,8 +77,6 @@ public class FindOneAndReplaceCommandResolver extends FilterableResolver<FindOne
       return FindOperation.sorted(
           commandContext,
           filters,
-          // 24-Mar-2023, tatu: Since we update the document, need to avoid modifications on
-          // read path, hence pass identity projector.
           DocumentProjector.identityProjector(),
           null,
           1,
@@ -95,8 +93,6 @@ public class FindOneAndReplaceCommandResolver extends FilterableResolver<FindOne
       return FindOperation.unsorted(
           commandContext,
           filters,
-          // 24-Mar-2023, tatu: Since we update the document, need to avoid modifications on
-          // read path, hence pass identity projector.
           DocumentProjector.identityProjector(),
           null,
           1,

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndDeleteCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneAndDeleteCommandTest.java
@@ -1,0 +1,119 @@
+package io.stargate.sgv2.jsonapi.api.model.command.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.api.model.command.Command;
+import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.FilterClause;
+import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
+import javax.inject.Inject;
+import javax.validation.Validator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class FindOneAndDeleteCommandTest {
+  @Inject ObjectMapper objectMapper;
+
+  @Inject Validator validator;
+
+  @Nested
+  class Validation {
+    @Test
+    public void happyPath() throws Exception {
+      String json =
+          """
+          {
+            "findOneAndDelete": {
+                "filter" : {"username" : "update_user5"}
+              }
+          }
+          """;
+
+      Command result = objectMapper.readValue(json, Command.class);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              FindOneAndDeleteCommand.class,
+              findOneAndDeleteCommand -> {
+                FilterClause filterClause = findOneAndDeleteCommand.filterClause();
+                assertThat(filterClause).isNotNull();
+              });
+    }
+
+    @Test
+    public void withSort() throws Exception {
+      String json =
+          """
+          {
+            "findOneAndDelete": {
+                "filter" : {"username" : "update_user5"},
+                "sort" : ["location"]
+              }
+          }
+          """;
+
+      Command result = objectMapper.readValue(json, Command.class);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              FindOneAndDeleteCommand.class,
+              findOneAndDeleteCommand -> {
+                FilterClause filterClause = findOneAndDeleteCommand.filterClause();
+                assertThat(filterClause).isNotNull();
+                final SortClause sortClause = findOneAndDeleteCommand.sortClause();
+                assertThat(sortClause).isNotNull();
+                assertThat(sortClause)
+                    .satisfies(
+                        sort -> {
+                          assertThat(sort.sortExpressions()).hasSize(1);
+                          assertThat(sort.sortExpressions().get(0).path()).isEqualTo("location");
+                        });
+              });
+    }
+
+    @Test
+    public void sortAndProject() throws Exception {
+      String json =
+          """
+          {
+            "findOneAndDelete": {
+                "filter" : {"username" : "update_user5"},
+                "sort" : ["location"],
+                "projection" : {"username" : 1}
+            }
+          }
+          """;
+
+      Command result = objectMapper.readValue(json, Command.class);
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              FindOneAndDeleteCommand.class,
+              findOneAndDeleteCommand -> {
+                FilterClause filterClause = findOneAndDeleteCommand.filterClause();
+                assertThat(filterClause).isNotNull();
+                final SortClause sortClause = findOneAndDeleteCommand.sortClause();
+                assertThat(sortClause).isNotNull();
+                assertThat(sortClause)
+                    .satisfies(
+                        sort -> {
+                          assertThat(sort.sortExpressions()).hasSize(1);
+                          assertThat(sort.sortExpressions().get(0).path()).isEqualTo("location");
+                        });
+                final JsonNode projector = findOneAndDeleteCommand.projectionDefinition();
+                assertThat(projector).isNotNull();
+                assertThat(projector)
+                    .satisfies(
+                        project -> {
+                          assertThat(project)
+                              .isEqualTo(objectMapper.readTree("{\"username\" : 1}"));
+                        });
+              });
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndDeleteIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndDeleteIntegrationTest.java
@@ -101,7 +101,6 @@ public class FindOneAndDeleteIntegrationTest extends CollectionResourceBaseInteg
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("data.docs", hasSize(0))
           .body("status.deletedCount", is(0))
           .body("errors", is(nullValue()));
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndDeleteIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndDeleteIntegrationTest.java
@@ -1,0 +1,311 @@
+package io.stargate.sgv2.jsonapi.api.v1;
+
+import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.http.ContentType;
+import io.stargate.sgv2.api.common.config.constants.HttpConstants;
+import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusIntegrationTest
+@QuarkusTestResource(DseTestResource.class)
+public class FindOneAndDeleteIntegrationTest extends CollectionResourceBaseIntegrationTest {
+  @Nested
+  class FindOneAndDelete {
+    @Test
+    public void byId() {
+      String document =
+          """
+          {
+            "_id": "doc3",
+            "username": "user3",
+            "active_user" : true
+          }
+          """;
+      insertDoc(document);
+
+      String json =
+          """
+          {
+            "findOneAndDelete": {
+              "filter" : {"_id" : "doc3"}
+            }
+          }
+          """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(document))
+          .body("status.deletedCount", is(1))
+          .body("errors", is(nullValue()));
+
+      // assert state after update
+      json =
+          """
+          {
+            "find": {
+              "filter" : {"_id" : "doc3"}
+            }
+          }
+          """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs", hasSize(0));
+    }
+
+    @Test
+    public void byIdNoData() {
+      String document =
+          """
+          {
+            "_id": "doc3",
+            "username": "user3",
+            "active_user" : true
+          }
+          """;
+      insertDoc(document);
+
+      String json =
+          """
+          {
+            "findOneAndDelete": {
+              "filter" : {"_id" : "doc5"}
+            }
+          }
+          """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs", hasSize(0))
+          .body("status.deletedCount", is(0))
+          .body("errors", is(nullValue()));
+    }
+
+    @Test
+    public void withSortDesc() {
+      String document =
+          """
+        {
+          "_id": "doc3",
+          "username": "user3",
+          "active_user" : true
+        }
+        """;
+      insertDoc(document);
+
+      String document1 =
+          """
+        {
+          "_id": "doc2",
+          "username": "user2",
+          "active_user" : true
+        }
+        """;
+      insertDoc(document1);
+
+      String json =
+          """
+        {
+          "findOneAndDelete": {
+            "filter" : {"active_user" : true},
+            "sort" : ["-username"]
+          }
+        }
+        """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(document))
+          .body("status.deletedCount", is(1))
+          .body("errors", is(nullValue()));
+
+      // assert state after update
+      json =
+          """
+          {
+            "find": {
+              "filter" : {"_id" : "doc3"}
+            }
+          }
+          """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs", hasSize(0));
+    }
+
+    @Test
+    public void withSort() {
+      String document =
+          """
+        {
+          "_id": "doc3",
+          "username": "user3",
+          "active_user" : true
+        }
+        """;
+      insertDoc(document);
+
+      String document1 =
+          """
+        {
+          "_id": "doc2",
+          "username": "user2",
+          "active_user" : true
+        }
+        """;
+      insertDoc(document1);
+
+      String json =
+          """
+        {
+          "findOneAndDelete": {
+            "filter" : {"active_user" : true},
+            "sort" : ["username"]
+          }
+        }
+        """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(document1))
+          .body("status.deletedCount", is(1))
+          .body("errors", is(nullValue()));
+
+      // assert state after update
+      json =
+          """
+        {
+          "find": {
+            "filter" : {"_id" : "doc2"}
+          }
+        }
+        """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs", hasSize(0));
+    }
+
+    @Test
+    public void withSortProjection() {
+      String document =
+          """
+        {
+          "_id": "doc3",
+          "username": "user3",
+          "active_user" : true
+        }
+        """;
+      insertDoc(document);
+
+      String document1 =
+          """
+        {
+          "_id": "doc2",
+          "username": "user2",
+          "active_user" : true
+        }
+        """;
+      insertDoc(document1);
+
+      String expected =
+          """
+                {
+                  "username": "user2"
+                }
+                """;
+
+      String json =
+          """
+        {
+          "findOneAndDelete": {
+            "filter" : {"active_user" : true},
+            "sort" : ["username"],
+            "projection" : { "_id":0, "username":1 }
+          }
+        }
+        """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(expected))
+          .body("status.deletedCount", is(1))
+          .body("errors", is(nullValue()));
+
+      // assert state after update
+      json =
+          """
+        {
+          "find": {
+            "filter" : {"_id" : "doc2"}
+          }
+        }
+        """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs", hasSize(0));
+    }
+  }
+
+  @AfterEach
+  public void cleanUpData() {
+    deleteAllDocuments();
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
@@ -21,6 +21,7 @@ import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocValueHasher;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -100,7 +101,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               null,
               0,
               0);
-      DeleteOperation operation = new DeleteOperation(COMMAND_CONTEXT, findOperation, 1, 3);
+      DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 3);
       Supplier<CommandResult> execute =
           operation
               .execute(queryExecutor)
@@ -116,6 +117,306 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
       // then result
       CommandResult result = execute.get();
       assertThat(result.status()).hasSize(1).containsEntry(CommandStatus.DELETED_COUNT, 1);
+    }
+
+    @Test
+    public void deleteOneAndReturnById() {
+      UUID tx_id = UUID.randomUUID();
+      String docJson = "{\"_id\":\"doc1\",\"a\":1}";
+      String collectionReadCql =
+          "SELECT key, tx_id, doc_json FROM \"%s\".\"%s\" WHERE key = ? LIMIT 1"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert readAssert =
+          withQuery(
+                  collectionReadCql,
+                  Values.of(
+                      CustomValueSerializers.getDocumentIdValue(DocumentId.fromString("doc1"))))
+              .withPageSize(1)
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("key")
+                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("tx_id")
+                          .setType(TypeSpecs.UUID)
+                          .build()))
+              .returning(
+                  List.of(
+                      List.of(
+                          Values.of(
+                              CustomValueSerializers.getDocumentIdValue(
+                                  DocumentId.fromString("doc1"))),
+                          Values.of(tx_id),
+                          Values.of(docJson))));
+
+      String collectionDeleteCql =
+          "DELETE FROM \"%s\".\"%s\" WHERE key = ? IF tx_id = ?"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert deleteAssert =
+          withQuery(
+                  collectionDeleteCql,
+                  Values.of(
+                      CustomValueSerializers.getDocumentIdValue(DocumentId.fromString("doc1"))),
+                  Values.of(tx_id))
+              .returning(List.of(List.of(Values.of(true))));
+
+      FindOperation findOperation =
+          new FindOperation(
+              COMMAND_CONTEXT,
+              List.of(
+                  new DBFilterBase.IDFilter(
+                      DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"))),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              1,
+              ReadType.DOCUMENT,
+              objectMapper,
+              null,
+              0,
+              0);
+      DeleteOperation operation =
+          DeleteOperation.deleteOneAndReturn(
+              COMMAND_CONTEXT, findOperation, 3, DocumentProjector.identityProjector());
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
+
+      // assert query execution
+      readAssert.assertExecuteCount().isOne();
+      deleteAssert.assertExecuteCount().isOne();
+
+      // then result
+      CommandResult result = execute.get();
+      assertThat(result.status()).hasSize(1).containsEntry(CommandStatus.DELETED_COUNT, 1);
+      assertThat(result.data().docs()).hasSize(1);
+      assertThat(result.data().docs().get(0).toString()).isEqualTo(docJson);
+    }
+
+    @Test
+    public void deleteOneAndReturnWithSort() {
+      UUID tx_id1 = UUID.randomUUID();
+      UUID tx_id2 = UUID.randomUUID();
+      String docJson1 = "{\"_id\":\"doc1\",\"username\":1,\"status\":\"active\"}";
+      String docJson2 = "{\"_id\":\"doc2\",\"username\":2,\"status\":\"active\"}";
+      String collectionReadCql =
+          "SELECT key, tx_id, doc_json, query_text_values['username'], query_dbl_values['username'], query_bool_values['username'], query_null_values['username'] FROM \"%s\".\"%s\" WHERE array_contains CONTAINS ? LIMIT 3"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert candidatesAssert =
+          withQuery(
+                  collectionReadCql,
+                  Values.of("status " + new DocValueHasher().getHash("active").hash()))
+              .withPageSize(2)
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("key")
+                          .setType(TypeSpecs.VARCHAR)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("tx_id")
+                          .setType(TypeSpecs.UUID)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("query_text_values['username']")
+                          .setType(TypeSpecs.VARCHAR)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("query_dbl_values['username']")
+                          .setType(TypeSpecs.DECIMAL)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("query_bool_values['username']")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("query_null_values['username']")
+                          .setType(TypeSpecs.VARCHAR)
+                          .build()))
+              .returning(
+                  List.of(
+                      List.of(
+                          Values.of(
+                              CustomValueSerializers.getDocumentIdValue(
+                                  DocumentId.fromString("doc1"))),
+                          Values.of(tx_id1),
+                          Values.of(docJson1),
+                          Values.NULL,
+                          Values.of(new BigDecimal(1)),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of(
+                              CustomValueSerializers.getDocumentIdValue(
+                                  DocumentId.fromString("doc2"))),
+                          Values.of(tx_id2),
+                          Values.of(docJson2),
+                          Values.NULL,
+                          Values.of(new BigDecimal(2)),
+                          Values.NULL,
+                          Values.NULL)));
+
+      String collectionDeleteCql =
+          "DELETE FROM \"%s\".\"%s\" WHERE key = ? IF tx_id = ?"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert deleteFirstAsser =
+          withQuery(
+                  collectionDeleteCql,
+                  Values.of(
+                      CustomValueSerializers.getDocumentIdValue(DocumentId.fromString("doc1"))),
+                  Values.of(tx_id1))
+              .returning(List.of(List.of(Values.of(true))));
+
+      FindOperation findOperation =
+          new FindOperation(
+              COMMAND_CONTEXT,
+              List.of(
+                  new DBFilterBase.TextFilter(
+                      "status", DBFilterBase.MapFilterBase.Operator.EQ, "active")),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              2,
+              ReadType.SORTED_DOCUMENT,
+              objectMapper,
+              List.of(new FindOperation.OrderBy("username", true)),
+              0,
+              3);
+      DeleteOperation operation =
+          DeleteOperation.deleteOneAndReturn(
+              COMMAND_CONTEXT, findOperation, 3, DocumentProjector.identityProjector());
+
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
+
+      candidatesAssert.assertExecuteCount().isEqualTo(2);
+      deleteFirstAsser.assertExecuteCount().isOne();
+
+      // then result
+      CommandResult result = execute.get();
+      assertThat(result.status()).hasSize(1).containsEntry(CommandStatus.DELETED_COUNT, 1);
+      assertThat(result.data().docs().get(0).toString()).isEqualTo(docJson1);
+    }
+
+    @Test
+    public void deleteOneAndReturnWithSortDesc() {
+      UUID tx_id1 = UUID.randomUUID();
+      UUID tx_id2 = UUID.randomUUID();
+      String docJson1 = "{\"_id\":\"doc1\",\"username\":1,\"status\":\"active\"}";
+      String docJson2 = "{\"_id\":\"doc2\",\"username\":2,\"status\":\"active\"}";
+      String collectionReadCql =
+          "SELECT key, tx_id, doc_json, query_text_values['username'], query_dbl_values['username'], query_bool_values['username'], query_null_values['username'] FROM \"%s\".\"%s\" WHERE array_contains CONTAINS ? LIMIT 3"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert candidatesAssert =
+          withQuery(
+                  collectionReadCql,
+                  Values.of("status " + new DocValueHasher().getHash("active").hash()))
+              .withPageSize(2)
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("key")
+                          .setType(TypeSpecs.VARCHAR)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("tx_id")
+                          .setType(TypeSpecs.UUID)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("query_text_values['username']")
+                          .setType(TypeSpecs.VARCHAR)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("query_dbl_values['username']")
+                          .setType(TypeSpecs.DECIMAL)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("query_bool_values['username']")
+                          .setType(TypeSpecs.BOOLEAN)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("query_null_values['username']")
+                          .setType(TypeSpecs.VARCHAR)
+                          .build()))
+              .returning(
+                  List.of(
+                      List.of(
+                          Values.of(
+                              CustomValueSerializers.getDocumentIdValue(
+                                  DocumentId.fromString("doc1"))),
+                          Values.of(tx_id1),
+                          Values.of(docJson1),
+                          Values.NULL,
+                          Values.of(new BigDecimal(1)),
+                          Values.NULL,
+                          Values.NULL),
+                      List.of(
+                          Values.of(
+                              CustomValueSerializers.getDocumentIdValue(
+                                  DocumentId.fromString("doc2"))),
+                          Values.of(tx_id2),
+                          Values.of(docJson2),
+                          Values.NULL,
+                          Values.of(new BigDecimal(2)),
+                          Values.NULL,
+                          Values.NULL)));
+
+      String collectionDeleteCql =
+          "DELETE FROM \"%s\".\"%s\" WHERE key = ? IF tx_id = ?"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      ValidatingStargateBridge.QueryAssert deleteFirstAsser =
+          withQuery(
+                  collectionDeleteCql,
+                  Values.of(
+                      CustomValueSerializers.getDocumentIdValue(DocumentId.fromString("doc2"))),
+                  Values.of(tx_id2))
+              .returning(List.of(List.of(Values.of(true))));
+
+      FindOperation findOperation =
+          new FindOperation(
+              COMMAND_CONTEXT,
+              List.of(
+                  new DBFilterBase.TextFilter(
+                      "status", DBFilterBase.MapFilterBase.Operator.EQ, "active")),
+              DocumentProjector.identityProjector(),
+              null,
+              1,
+              2,
+              ReadType.SORTED_DOCUMENT,
+              objectMapper,
+              List.of(new FindOperation.OrderBy("username", false)),
+              0,
+              3);
+      DeleteOperation operation =
+          DeleteOperation.deleteOneAndReturn(
+              COMMAND_CONTEXT, findOperation, 3, DocumentProjector.identityProjector());
+
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
+
+      candidatesAssert.assertExecuteCount().isEqualTo(2);
+      deleteFirstAsser.assertExecuteCount().isOne();
+
+      // then result
+      CommandResult result = execute.get();
+      assertThat(result.status()).hasSize(1).containsEntry(CommandStatus.DELETED_COUNT, 1);
+      assertThat(result.data().docs().get(0).toString()).isEqualTo(docJson2);
     }
 
     @Test
@@ -157,7 +458,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               0,
               0);
 
-      DeleteOperation operation = new DeleteOperation(COMMAND_CONTEXT, findOperation, 1, 3);
+      DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 3);
       Supplier<CommandResult> execute =
           operation
               .execute(queryExecutor)
@@ -229,7 +530,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               null,
               0,
               0);
-      DeleteOperation operation = new DeleteOperation(COMMAND_CONTEXT, findOperation, 1, 3);
+      DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 3);
 
       Supplier<CommandResult> execute =
           operation
@@ -339,7 +640,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               null,
               0,
               0);
-      DeleteOperation operation = new DeleteOperation(COMMAND_CONTEXT, findOperation, 1, 2);
+      DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 2);
 
       Supplier<CommandResult> execute =
           operation
@@ -451,7 +752,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               null,
               0,
               0);
-      DeleteOperation operation = new DeleteOperation(COMMAND_CONTEXT, findOperation, 1, 2);
+      DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 2);
 
       Supplier<CommandResult> execute =
           operation
@@ -558,7 +859,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               null,
               0,
               0);
-      DeleteOperation operation = new DeleteOperation(COMMAND_CONTEXT, findOperation, 1, 2);
+      DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 2);
 
       Supplier<CommandResult> execute =
           operation
@@ -647,7 +948,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               null,
               0,
               0);
-      DeleteOperation operation = new DeleteOperation(COMMAND_CONTEXT, findOperation, 2, 3);
+      DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 2, 3);
 
       Supplier<CommandResult> execute =
           operation
@@ -734,7 +1035,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               null,
               0,
               0);
-      DeleteOperation operation = new DeleteOperation(COMMAND_CONTEXT, findOperation, 2, 3);
+      DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 2, 3);
 
       Supplier<CommandResult> execute =
           operation
@@ -827,7 +1128,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               null,
               0,
               0);
-      DeleteOperation operation = new DeleteOperation(COMMAND_CONTEXT, findOperation, 2, 3);
+      DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 2, 3);
 
       Supplier<CommandResult> execute =
           operation
@@ -891,7 +1192,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               null,
               0,
               0);
-      DeleteOperation operation = new DeleteOperation(COMMAND_CONTEXT, findOperation, 1, 3);
+      DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 3);
 
       Supplier<CommandResult> execute =
           operation
@@ -1015,7 +1316,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               null,
               0,
               0);
-      DeleteOperation operation = new DeleteOperation(COMMAND_CONTEXT, findOperation, 2, 3);
+      DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 2, 3);
 
       Supplier<CommandResult> execute =
           operation
@@ -1189,7 +1490,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               null,
               0,
               0);
-      DeleteOperation operation = new DeleteOperation(COMMAND_CONTEXT, findOperation, 2, 3);
+      DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 2, 3);
 
       Supplier<CommandResult> execute =
           operation

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -267,11 +267,11 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("query_dbl_values['username']")
-                          .setType(TypeSpecs.VARCHAR)
+                          .setType(TypeSpecs.DECIMAL)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("query_bool_values['username']")
-                          .setType(TypeSpecs.VARCHAR)
+                          .setType(TypeSpecs.BOOLEAN)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("query_null_values['username']")
@@ -630,11 +630,11 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("query_dbl_values['username']")
-                          .setType(TypeSpecs.VARCHAR)
+                          .setType(TypeSpecs.DECIMAL)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("query_bool_values['username']")
-                          .setType(TypeSpecs.VARCHAR)
+                          .setType(TypeSpecs.BOOLEAN)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("query_null_values['username']")
@@ -824,11 +824,11 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("query_dbl_values['username']")
-                          .setType(TypeSpecs.VARCHAR)
+                          .setType(TypeSpecs.DECIMAL)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("query_bool_values['username']")
-                          .setType(TypeSpecs.VARCHAR)
+                          .setType(TypeSpecs.BOOLEAN)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("query_null_values['username']")

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolverTest.java
@@ -1,0 +1,165 @@
+package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.Mock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndDeleteCommand;
+import io.stargate.sgv2.jsonapi.service.bridge.config.DocumentConfig;
+import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
+import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.DeleteOperation;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
+import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
+import java.util.List;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class FindOneAndDeleteCommandResolverTest {
+  @Inject ObjectMapper objectMapper;
+  @Inject DocumentConfig documentConfig;
+  @Inject Shredder shredder;
+  @Inject FindOneAndDeleteCommandResolver resolver;
+
+  @Nested
+  class Resolve {
+
+    @Mock CommandContext commandContext;
+
+    @Test
+    public void idFilterCondition() throws Exception {
+      String json =
+          """
+        {
+          "findOneAndDelete": {
+            "filter" : {"_id" : "id"}
+          }
+        }
+        """;
+      FindOneAndDeleteCommand command = objectMapper.readValue(json, FindOneAndDeleteCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, command);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              DeleteOperation.class,
+              op -> {
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.returnDocumentInResponse()).isTrue();
+                assertThat(op.retryLimit()).isEqualTo(documentConfig.lwt().retries());
+                assertThat(op.findOperation())
+                    .isInstanceOfSatisfying(
+                        FindOperation.class,
+                        find -> {
+                          DBFilterBase.IDFilter filter =
+                              new DBFilterBase.IDFilter(
+                                  DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("id"));
+
+                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                          assertThat(find.commandContext()).isEqualTo(commandContext);
+                          assertThat(find.pageSize()).isEqualTo(1);
+                          assertThat(find.limit()).isEqualTo(1);
+                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
+                          assertThat(find.filters()).singleElement().isEqualTo(filter);
+                        });
+              });
+    }
+
+    @Test
+    public void filterConditionSort() throws Exception {
+      String json =
+          """
+        {
+          "findOneAndDelete": {
+            "filter" : {"status" : "active"},
+            "sort" : ["user"]
+          }
+        }
+        """;
+
+      FindOneAndDeleteCommand command = objectMapper.readValue(json, FindOneAndDeleteCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, command);
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              DeleteOperation.class,
+              op -> {
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.returnDocumentInResponse()).isTrue();
+                assertThat(op.retryLimit()).isEqualTo(documentConfig.lwt().retries());
+                assertThat(op.findOperation())
+                    .isInstanceOfSatisfying(
+                        FindOperation.class,
+                        find -> {
+                          DBFilterBase.TextFilter filter =
+                              new DBFilterBase.TextFilter(
+                                  "status", DBFilterBase.MapFilterBase.Operator.EQ, "active");
+
+                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                          assertThat(find.commandContext()).isEqualTo(commandContext);
+                          assertThat(find.pageSize()).isEqualTo(100);
+                          assertThat(find.limit()).isEqualTo(1);
+                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
+                          assertThat(find.filters()).singleElement().isEqualTo(filter);
+                          assertThat(find.orderBy()).hasSize(1);
+                          assertThat(find.orderBy())
+                              .isEqualTo(List.of(new FindOperation.OrderBy("user", true)));
+                        });
+              });
+    }
+
+    @Test
+    public void idFilterWithProjection() throws Exception {
+      String json =
+          """
+          {
+            "findOneAndDelete": {
+              "filter" : {"_id" : "id"},
+              "projection" : { "x":0, "subdoc.c":0 }
+            }
+          }
+          """;
+      FindOneAndDeleteCommand command = objectMapper.readValue(json, FindOneAndDeleteCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, command);
+      JsonNode projection = objectMapper.readTree("{\"x\":0, \"subdoc.c\":0}");
+      final DocumentProjector projector = DocumentProjector.createFromDefinition(projection);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              DeleteOperation.class,
+              op -> {
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.returnDocumentInResponse()).isTrue();
+                assertThat(op.retryLimit()).isEqualTo(documentConfig.lwt().retries());
+                assertThat(op.resultProjection()).isEqualTo(projector);
+                assertThat(op.findOperation())
+                    .isInstanceOfSatisfying(
+                        FindOperation.class,
+                        find -> {
+                          DBFilterBase.IDFilter filter =
+                              new DBFilterBase.IDFilter(
+                                  DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("id"));
+
+                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                          assertThat(find.commandContext()).isEqualTo(commandContext);
+                          assertThat(find.pageSize()).isEqualTo(1);
+                          assertThat(find.limit()).isEqualTo(1);
+                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
+                          assertThat(find.filters()).singleElement().isEqualTo(filter);
+                        });
+              });
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolverTest.java
@@ -43,13 +43,13 @@ public class FindOneAndReplaceCommandResolverTest {
     public void idFilterCondition() throws Exception {
       String json =
           """
-                {
-                  "findOneAndReplace": {
-                    "filter" : {"_id" : "id"},
-                    "replacement" : {"col1" : "val1", "col2" : "val2"}
-                  }
-                }
-                """;
+        {
+          "findOneAndReplace": {
+            "filter" : {"_id" : "id"},
+            "replacement" : {"col1" : "val1", "col2" : "val2"}
+          }
+        }
+        """;
       String expected = "{\"col1\":\"val1\",\"col2\":\"val2\"}";
       FindOneAndReplaceCommand command =
           objectMapper.readValue(json, FindOneAndReplaceCommand.class);
@@ -104,13 +104,13 @@ public class FindOneAndReplaceCommandResolverTest {
     public void idFilterConditionWithId() throws Exception {
       String json =
           """
-                {
-                  "findOneAndReplace": {
-                    "filter" : {"_id" : "id"},
-                    "replacement" : {"_id": "id", "col1" : "val1", "col2" : "val2"}
-                  }
-                }
-                """;
+        {
+          "findOneAndReplace": {
+            "filter" : {"_id" : "id"},
+            "replacement" : {"_id": "id", "col1" : "val1", "col2" : "val2"}
+          }
+        }
+        """;
 
       FindOneAndReplaceCommand command =
           objectMapper.readValue(json, FindOneAndReplaceCommand.class);
@@ -165,14 +165,14 @@ public class FindOneAndReplaceCommandResolverTest {
     public void filterConditionSort() throws Exception {
       String json =
           """
-            {
-              "findOneAndReplace": {
-                "filter" : {"status" : "active"},
-                "sort" : ["user"],
-                "replacement" : {"col1" : "val1", "col2" : "val2"}
-              }
-            }
-            """;
+        {
+          "findOneAndReplace": {
+            "filter" : {"status" : "active"},
+            "sort" : ["user"],
+            "replacement" : {"col1" : "val1", "col2" : "val2"}
+          }
+        }
+        """;
 
       FindOneAndReplaceCommand command =
           objectMapper.readValue(json, FindOneAndReplaceCommand.class);
@@ -230,14 +230,14 @@ public class FindOneAndReplaceCommandResolverTest {
     public void idFilterConditionWithOptions() throws Exception {
       String json =
           """
-            {
-              "findOneAndReplace": {
-                "filter" : {"_id" : "id"},
-                "replacement" : {"col1" : "val1", "col2" : "val2"},
-                "options" : {"returnDocument" : "after", "upsert": true }
-              }
-            }
-            """;
+        {
+          "findOneAndReplace": {
+            "filter" : {"_id" : "id"},
+            "replacement" : {"col1" : "val1", "col2" : "val2"},
+            "options" : {"returnDocument" : "after", "upsert": true }
+          }
+        }
+        """;
 
       FindOneAndReplaceCommand command =
           objectMapper.readValue(json, FindOneAndReplaceCommand.class);
@@ -292,18 +292,18 @@ public class FindOneAndReplaceCommandResolverTest {
     public void filterConditionWithOptionsSort() throws Exception {
       String json =
           """
-            {
-              "findOneAndReplace": {
-                "filter" : {"age" : 35},
-                "sort": [
-                  "user.name",
-                  "-user.age"
-                ],
-                "replacement" : {"col1" : "val1", "col2" : "val2"},
-                "options" : {"returnDocument" : "after"}
-              }
-            }
-            """;
+        {
+          "findOneAndReplace": {
+            "filter" : {"age" : 35},
+            "sort": [
+              "user.name",
+              "-user.age"
+            ],
+            "replacement" : {"col1" : "val1", "col2" : "val2"},
+            "options" : {"returnDocument" : "after"}
+          }
+        }
+        """;
 
       FindOneAndReplaceCommand command =
           objectMapper.readValue(json, FindOneAndReplaceCommand.class);
@@ -366,13 +366,13 @@ public class FindOneAndReplaceCommandResolverTest {
     public void dynamicFilterCondition() throws Exception {
       String json =
           """
-            {
-              "findOneAndReplace": {
-                "filter" : {"col" : "val"},
-                "replacement" : {"col1" : "val1", "col2" : "val2"}
-              }
-            }
-            """;
+        {
+          "findOneAndReplace": {
+            "filter" : {"col" : "val"},
+            "replacement" : {"col1" : "val1", "col2" : "val2"}
+          }
+        }
+        """;
 
       FindOneAndReplaceCommand command =
           objectMapper.readValue(json, FindOneAndReplaceCommand.class);


### PR DESCRIPTION
**What this PR does**:
Implement findOneAndDelete command which finds and deletes a document and returns the deleted document in the response
**Which issue(s) this PR fixes**:
Fixes #319 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
