### PR TITLE
closes #321: dropNamespace command

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -290,6 +290,17 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                         }
                       """),
               @ExampleObject(
+                  name = "dropNamespace",
+                  summary = "`DropNamespace` command",
+                  value =
+                      """
+                        {
+                            "dropNamespace": {
+                              "name": "cycling"
+                            }
+                        }
+                      """),
+              @ExampleObject(
                   name = "createCollection",
                   summary = "`CreateCollection` command",
                   value =

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
@@ -8,6 +8,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.impl.CreateNamespaceCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteCollectionCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteManyCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteOneCommand;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.DropNamespaceCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndDeleteCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndReplaceCommand;
@@ -46,6 +47,7 @@ import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
   @JsonSubTypes.Type(value = DeleteCollectionCommand.class),
   @JsonSubTypes.Type(value = DeleteOneCommand.class),
   @JsonSubTypes.Type(value = DeleteManyCommand.class),
+  @JsonSubTypes.Type(value = DropNamespaceCommand.class),
   @JsonSubTypes.Type(value = FindCommand.class),
   @JsonSubTypes.Type(value = FindOneCommand.class),
   @JsonSubTypes.Type(value = FindOneAndDeleteCommand.class),

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommand.java
@@ -1,0 +1,21 @@
+package io.stargate.sgv2.jsonapi.api.model.command.impl;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.stargate.sgv2.jsonapi.api.model.command.GeneralCommand;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "Command that deletes a namespace.")
+@JsonTypeName("dropNamespace")
+public record DropNamespaceCommand(
+    @NotNull
+        @Pattern(regexp = "[a-zA-Z][a-zA-Z0-9_]*")
+        @Pattern(regexp = "^(?!system$).*")
+        @Size(min = 1, max = 48)
+        @Schema(description = "Name of the namespace")
+        String name)
+    implements GeneralCommand {
+  // TODO add NoOptions extension
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommand.java
@@ -12,7 +12,6 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 public record DropNamespaceCommand(
     @NotNull
         @Pattern(regexp = "[a-zA-Z][a-zA-Z0-9_]*")
-        @Pattern(regexp = "^(?!system$).*")
         @Size(min = 1, max = 48)
         @Schema(description = "Name of the namespace")
         String name)

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommand.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.api.model.command.impl;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.stargate.sgv2.jsonapi.api.model.command.GeneralCommand;
+import io.stargate.sgv2.jsonapi.api.model.command.NoOptionsCommand;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
@@ -15,6 +16,4 @@ public record DropNamespaceCommand(
         @Size(min = 1, max = 48)
         @Schema(description = "Name of the namespace")
         String name)
-    implements GeneralCommand {
-  // TODO add NoOptions extension
-}
+    implements GeneralCommand, NoOptionsCommand {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResource.java
@@ -51,6 +51,7 @@ public class GeneralResource {
               examples = {
                 @ExampleObject(ref = "createNamespace"),
                 @ExampleObject(ref = "createNamespaceWithReplication"),
+                @ExampleObject(ref = "dropNamespace"),
               }))
   @APIResponses(
       @APIResponse(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DropNamespaceOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DropNamespaceOperation.java
@@ -1,0 +1,33 @@
+package io.stargate.sgv2.jsonapi.service.operation.model.impl;
+
+import io.smallrye.mutiny.Uni;
+import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
+import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
+import java.util.function.Supplier;
+
+/**
+ * Operation that drops a Cassandra keyspace if it exists.
+ *
+ * @param name Name of the namespace to drop.
+ */
+public record DropNamespaceOperation(String name) implements Operation {
+
+  // simple pattern for the cql
+  private static final String DROP_KEYSPACE_CQL = "DROP KEYSPACE IF EXISTS \"%s\";";
+
+  /** {@inheritDoc} */
+  @Override
+  public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+    QueryOuterClass.Query query =
+        QueryOuterClass.Query.newBuilder().setCql(DROP_KEYSPACE_CQL.formatted(name)).build();
+
+    // execute
+    return queryExecutor
+        .executeSchemaChange(query)
+
+        // if we have a result always respond positively
+        .map(any -> new SchemaChangeResult(true));
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DropNamespaceCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DropNamespaceCommandResolver.java
@@ -1,0 +1,25 @@
+package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
+
+import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.DropNamespaceCommand;
+import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.DropNamespaceOperation;
+import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
+import javax.enterprise.context.ApplicationScoped;
+
+/** Command resolver for {@link DropNamespaceCommand}. */
+@ApplicationScoped
+public class DropNamespaceCommandResolver implements CommandResolver<DropNamespaceCommand> {
+
+  /** {@inheritDoc} */
+  @Override
+  public Class<DropNamespaceCommand> getCommandClass() {
+    return DropNamespaceCommand.class;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Operation resolveCommand(CommandContext ctx, DropNamespaceCommand command) {
+    return new DropNamespaceOperation(command.name());
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommandTest.java
@@ -86,49 +86,12 @@ class DropNamespaceCommandTest {
     }
 
     @Test
-    public void systemKeyspaceNotAllowed() throws Exception {
-      String json =
-          """
-          {
-            "dropNamespace": {
-              "name": "system"
-            }
-          }
-          """;
-
-      DropNamespaceCommand command = objectMapper.readValue(json, DropNamespaceCommand.class);
-      Set<ConstraintViolation<DropNamespaceCommand>> result = validator.validate(command);
-
-      assertThat(result)
-          .isNotEmpty()
-          .extracting(ConstraintViolation::getMessage)
-          .contains("must match \"^(?!system$).*\"");
-    }
-
-    @Test
     public void nameCorrectPattern() throws Exception {
       String json =
           """
           {
             "dropNamespace": {
-              "name": "my_system"
-            }
-          }
-          """;
-
-      DropNamespaceCommand command = objectMapper.readValue(json, DropNamespaceCommand.class);
-      Set<ConstraintViolation<DropNamespaceCommand>> result = validator.validate(command);
-
-      assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void nameCorrectPatternSystemPrefix() throws Exception {
-      String json =
-          """
-          {
-            "dropNamespace": {
-              "name": "system_keyspace"
+              "name": "my_space"
             }
           }
           """;

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DropNamespaceCommandTest.java
@@ -1,0 +1,142 @@
+package io.stargate.sgv2.jsonapi.api.model.command.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+class DropNamespaceCommandTest {
+
+  @Inject ObjectMapper objectMapper;
+
+  @Inject Validator validator;
+
+  @Nested
+  class Validation {
+
+    @Test
+    public void noName() throws Exception {
+      String json =
+          """
+          {
+            "dropNamespace": {
+            }
+          }
+          """;
+
+      DropNamespaceCommand command = objectMapper.readValue(json, DropNamespaceCommand.class);
+      Set<ConstraintViolation<DropNamespaceCommand>> result = validator.validate(command);
+
+      assertThat(result)
+          .isNotEmpty()
+          .extracting(ConstraintViolation::getMessage)
+          .contains("must not be null");
+    }
+
+    @Test
+    public void nameTooLong() throws Exception {
+      String json =
+          """
+          {
+            "dropNamespace": {
+              "name": "%s"
+            }
+          }
+          """
+              .formatted(RandomStringUtils.randomAlphabetic(49));
+
+      DropNamespaceCommand command = objectMapper.readValue(json, DropNamespaceCommand.class);
+      Set<ConstraintViolation<DropNamespaceCommand>> result = validator.validate(command);
+
+      assertThat(result)
+          .isNotEmpty()
+          .extracting(ConstraintViolation::getMessage)
+          .contains("size must be between 1 and 48");
+    }
+
+    @Test
+    public void nameWrongPattern() throws Exception {
+      String json =
+          """
+          {
+            "dropNamespace": {
+              "name": "_not_possible"
+            }
+          }
+          """;
+
+      DropNamespaceCommand command = objectMapper.readValue(json, DropNamespaceCommand.class);
+      Set<ConstraintViolation<DropNamespaceCommand>> result = validator.validate(command);
+
+      assertThat(result)
+          .isNotEmpty()
+          .extracting(ConstraintViolation::getMessage)
+          .contains("must match \"[a-zA-Z][a-zA-Z0-9_]*\"");
+    }
+
+    @Test
+    public void systemKeyspaceNotAllowed() throws Exception {
+      String json =
+          """
+          {
+            "dropNamespace": {
+              "name": "system"
+            }
+          }
+          """;
+
+      DropNamespaceCommand command = objectMapper.readValue(json, DropNamespaceCommand.class);
+      Set<ConstraintViolation<DropNamespaceCommand>> result = validator.validate(command);
+
+      assertThat(result)
+          .isNotEmpty()
+          .extracting(ConstraintViolation::getMessage)
+          .contains("must match \"^(?!system$).*\"");
+    }
+
+    @Test
+    public void nameCorrectPattern() throws Exception {
+      String json =
+          """
+          {
+            "dropNamespace": {
+              "name": "my_system"
+            }
+          }
+          """;
+
+      DropNamespaceCommand command = objectMapper.readValue(json, DropNamespaceCommand.class);
+      Set<ConstraintViolation<DropNamespaceCommand>> result = validator.validate(command);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void nameCorrectPatternSystemPrefix() throws Exception {
+      String json =
+          """
+          {
+            "dropNamespace": {
+              "name": "system_keyspace"
+            }
+          }
+          """;
+
+      DropNamespaceCommand command = objectMapper.readValue(json, DropNamespaceCommand.class);
+      Set<ConstraintViolation<DropNamespaceCommand>> result = validator.validate(command);
+
+      assertThat(result).isEmpty();
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DropNamespaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DropNamespaceIntegrationTest.java
@@ -3,9 +3,7 @@ package io.stargate.sgv2.jsonapi.api.v1;
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.blankString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -158,29 +156,6 @@ class DropNamespaceIntegrationTest extends CqlEnabledIntegrationTestBase {
           .then()
           .statusCode(200)
           .body("status.ok", is(1));
-    }
-
-    @Test
-    public void systemKeyspaceNotAllowed() {
-      String json =
-          """
-          {
-            "dropNamespace": {
-              "name": "system"
-            }
-          }
-          """;
-
-      given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(GeneralResource.BASE_PATH)
-          .then()
-          .statusCode(200)
-          .body("errors[0].message", is(not(blankString())))
-          .body("errors[0].exceptionClass", is("ConstraintViolationException"));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DropNamespaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DropNamespaceIntegrationTest.java
@@ -15,6 +15,7 @@ import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
 import io.stargate.sgv2.common.CqlEnabledIntegrationTestBase;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -61,6 +62,79 @@ class DropNamespaceIntegrationTest extends CqlEnabledIntegrationTestBase {
               row -> {
                 assertThat(row.get("keyspace_name", String.class))
                     .isNotEqualTo(keyspaceId.asInternal());
+              });
+    }
+
+    @Test
+    public final void withExistingCollection() {
+      String keyspace = "k%s".formatted(RandomStringUtils.randomAlphanumeric(8)).toLowerCase();
+      String collection = "c%s".formatted(RandomStringUtils.randomAlphanumeric(8)).toLowerCase();
+
+      String createNamespace =
+          """
+              {
+                "createNamespace": {
+                  "name": "%s"
+                }
+              }
+              """
+              .formatted(keyspace);
+      String createCollection =
+          """
+              {
+                "createCollection": {
+                  "name": "%s"
+                }
+              }
+              """
+              .formatted(collection);
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(createNamespace)
+          .when()
+          .post(GeneralResource.BASE_PATH)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(createCollection)
+          .when()
+          .post(NamespaceResource.BASE_PATH, keyspace)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+
+      String json =
+          """
+          {
+            "dropNamespace": {
+              "name": "%s"
+            }
+          }
+          """
+              .formatted(keyspace);
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(GeneralResource.BASE_PATH)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+
+      // ensure it's dropped
+      // TODO go away from session usage once we have findNamespaces
+      ResultSet keyspaces = session.execute("SELECT keyspace_name FROM system_schema.keyspaces;");
+      assertThat(keyspaces.all())
+          .allSatisfy(
+              row -> {
+                assertThat(row.get("keyspace_name", String.class)).isNotEqualTo(keyspace);
               });
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DropNamespaceCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DropNamespaceCommandResolverTest.java
@@ -1,0 +1,46 @@
+package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.DropNamespaceCommand;
+import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.DropNamespaceOperation;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+class DropNamespaceCommandResolverTest {
+
+  @Inject ObjectMapper objectMapper;
+  @Inject DropNamespaceCommandResolver resolver;
+
+  @Nested
+  class ResolveCommand {
+
+    @Test
+    public void happyPath() throws Exception {
+      String json =
+          """
+          {
+            "dropNamespace": {
+              "name" : "red_star_belgrade"
+            }
+          }
+          """;
+
+      DropNamespaceCommand command = objectMapper.readValue(json, DropNamespaceCommand.class);
+      Operation result = resolver.resolveCommand(null, command);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              DropNamespaceOperation.class,
+              op -> assertThat(op.name()).isEqualTo("red_star_belgrade"));
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does**:
Implementation of the `dropNamespace` command. I have one issue and that's deletion of the system namespaces? 

I tried to exclude `system` from the keyspaces that could not be deleted, but here are actually multiple built-in keyspaces.. How to deal with these.. Any advice would be appreciated.. 

**Which issue(s) this PR fixes**:
Fixes #321 

**Checklist**
- [x] Swagger
- [ ] Spec
- [x] Test drop with existing collection works
- [x] Resolve issue about system keyspaces
