### PR TITLE
closes #322: implement findNamespaces command

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -290,6 +290,16 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                         }
                       """),
               @ExampleObject(
+                  name = "findNamespaces",
+                  summary = "`FindNamespaces` command",
+                  value =
+                      """
+                        {
+                            "findNamespaces": {
+                            }
+                        }
+                      """),
+              @ExampleObject(
                   name = "dropNamespace",
                   summary = "`DropNamespace` command",
                   value =

--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -573,6 +573,19 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                                 }
                                 """),
               @ExampleObject(
+                  name = "resultFindNamespaces",
+                  summary = "`findNamespaces` command result",
+                  value =
+                      """
+                                {
+                                  "status": {
+                                    "existingNamespaces": [
+                                      "cycling"
+                                    ]
+                                  }
+                                }
+                                """),
+              @ExampleObject(
                   name = "resultError",
                   summary = "Error result",
                   value =

--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -579,7 +579,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                       """
                                 {
                                   "status": {
-                                    "existingNamespaces": [
+                                    "namespaces": [
                                       "cycling"
                                     ]
                                   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Command.java
@@ -10,6 +10,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteManyCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteOneCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.DropNamespaceCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindCommand;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.FindNamespacesCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndDeleteCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndReplaceCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndUpdateCommand;
@@ -49,6 +50,7 @@ import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
   @JsonSubTypes.Type(value = DeleteManyCommand.class),
   @JsonSubTypes.Type(value = DropNamespaceCommand.class),
   @JsonSubTypes.Type(value = FindCommand.class),
+  @JsonSubTypes.Type(value = FindNamespacesCommand.class),
   @JsonSubTypes.Type(value = FindOneCommand.class),
   @JsonSubTypes.Type(value = FindOneAndDeleteCommand.class),
   @JsonSubTypes.Type(value = FindOneAndReplaceCommand.class),

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandStatus.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandStatus.java
@@ -10,6 +10,9 @@ public enum CommandStatus {
   /** The element has the count of deleted documents */
   @JsonProperty("deletedCount")
   DELETED_COUNT,
+  /** Status for reporting existing namespaces. */
+  @JsonProperty("existingNamespaces")
+  EXISTING_NAMESPACES,
   /** The element has the list of inserted ids */
   @JsonProperty("insertedIds")
   INSERTED_IDS,

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandStatus.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandStatus.java
@@ -11,7 +11,7 @@ public enum CommandStatus {
   @JsonProperty("deletedCount")
   DELETED_COUNT,
   /** Status for reporting existing namespaces. */
-  @JsonProperty("existingNamespaces")
+  @JsonProperty("namespaces")
   EXISTING_NAMESPACES,
   /** The element has the list of inserted ids */
   @JsonProperty("insertedIds")

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindNamespacesCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindNamespacesCommand.java
@@ -1,0 +1,10 @@
+package io.stargate.sgv2.jsonapi.api.model.command.impl;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.stargate.sgv2.jsonapi.api.model.command.GeneralCommand;
+import io.stargate.sgv2.jsonapi.api.model.command.NoOptionsCommand;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "Command that lists all available namespaces.")
+@JsonTypeName("findNamespaces")
+public record FindNamespacesCommand() implements GeneralCommand, NoOptionsCommand {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResource.java
@@ -65,6 +65,7 @@ public class GeneralResource {
                   schema = @Schema(implementation = CommandResult.class),
                   examples = {
                     @ExampleObject(ref = "resultCreate"),
+                    @ExampleObject(ref = "resultFindNamespaces"),
                     @ExampleObject(ref = "resultError"),
                   })))
   @POST

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResource.java
@@ -51,6 +51,7 @@ public class GeneralResource {
               examples = {
                 @ExampleObject(ref = "createNamespace"),
                 @ExampleObject(ref = "createNamespaceWithReplication"),
+                @ExampleObject(ref = "findNamespaces"),
                 @ExampleObject(ref = "dropNamespace"),
               }))
   @APIResponses(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindNamespacesOperations.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindNamespacesOperations.java
@@ -1,0 +1,48 @@
+package io.stargate.sgv2.jsonapi.service.operation.model.impl;
+
+import io.smallrye.mutiny.Uni;
+import io.stargate.sgv2.api.common.schema.SchemaManager;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
+import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
+import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Operation that list all available namespaces into the {@link CommandStatus#EXISTING_NAMESPACES}
+ * command status.
+ *
+ * @param schemaManager SGv2 schema manager for keyspace fetching
+ */
+public record FindNamespacesOperations(SchemaManager schemaManager) implements Operation {
+
+  /** {@inheritDoc} */
+  @Override
+  public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+    // get all existing keyspaces
+    return schemaManager
+        .getKeyspaces()
+
+        // map to keyspace name
+        .map(k -> k.getCqlKeyspace().getName())
+
+        // get as list
+        .collect()
+        .asList()
+
+        // wrap into command result
+        .map(Result::new);
+  }
+
+  // simple result wrapper
+  private record Result(List<String> keyspaces) implements Supplier<CommandResult> {
+
+    @Override
+    public CommandResult get() {
+      Map<CommandStatus, Object> statuses = Map.of(CommandStatus.EXISTING_NAMESPACES, keyspaces);
+      return new CommandResult(statuses);
+    }
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindNamespacesCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindNamespacesCommandResolver.java
@@ -1,0 +1,34 @@
+package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
+
+import io.stargate.sgv2.api.common.schema.SchemaManager;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.FindNamespacesCommand;
+import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindNamespacesOperations;
+import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+/** Command resolver for {@link FindNamespacesCommand}. */
+@ApplicationScoped
+public class FindNamespacesCommandResolver implements CommandResolver<FindNamespacesCommand> {
+
+  private final SchemaManager schemaManager;
+
+  @Inject
+  public FindNamespacesCommandResolver(SchemaManager schemaManager) {
+    this.schemaManager = schemaManager;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Class<FindNamespacesCommand> getCommandClass() {
+    return FindNamespacesCommand.class;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Operation resolveCommand(CommandContext ctx, FindNamespacesCommand command) {
+    return new FindNamespacesOperations(schemaManager);
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DropNamespaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DropNamespaceIntegrationTest.java
@@ -69,7 +69,7 @@ class DropNamespaceIntegrationTest extends CqlEnabledIntegrationTestBase {
           .post(GeneralResource.BASE_PATH)
           .then()
           .statusCode(200)
-          .body("status.existingNamespaces", not(hasItem(keyspaceId.asInternal())));
+          .body("status.namespaces", not(hasItem(keyspaceId.asInternal())));
     }
 
     @Test
@@ -152,7 +152,7 @@ class DropNamespaceIntegrationTest extends CqlEnabledIntegrationTestBase {
           .post(GeneralResource.BASE_PATH)
           .then()
           .statusCode(200)
-          .body("status.existingNamespaces", not(hasItem(keyspace)));
+          .body("status.namespaces", not(hasItem(keyspace)));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DropNamespaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DropNamespaceIntegrationTest.java
@@ -2,10 +2,10 @@ package io.stargate.sgv2.jsonapi.api.v1;
 
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
-import com.datastax.oss.driver.api.core.cql.ResultSet;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
@@ -53,14 +53,23 @@ class DropNamespaceIntegrationTest extends CqlEnabledIntegrationTestBase {
           .body("status.ok", is(1));
 
       // ensure it's dropped
-      // TODO go away from session usage once we have findNamespaces
-      ResultSet keyspaces = session.execute("SELECT keyspace_name FROM system_schema.keyspaces;");
-      assertThat(keyspaces.all())
-          .allSatisfy(
-              row -> {
-                assertThat(row.get("keyspace_name", String.class))
-                    .isNotEqualTo(keyspaceId.asInternal());
-              });
+      json =
+          """
+              {
+                "findNamespaces": {
+                }
+              }
+              """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(GeneralResource.BASE_PATH)
+          .then()
+          .statusCode(200)
+          .body("status.existingNamespaces", not(hasItem(keyspaceId.asInternal())));
     }
 
     @Test
@@ -127,13 +136,23 @@ class DropNamespaceIntegrationTest extends CqlEnabledIntegrationTestBase {
           .body("status.ok", is(1));
 
       // ensure it's dropped
-      // TODO go away from session usage once we have findNamespaces
-      ResultSet keyspaces = session.execute("SELECT keyspace_name FROM system_schema.keyspaces;");
-      assertThat(keyspaces.all())
-          .allSatisfy(
-              row -> {
-                assertThat(row.get("keyspace_name", String.class)).isNotEqualTo(keyspace);
-              });
+      json =
+          """
+              {
+                "findNamespaces": {
+                }
+              }
+              """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(GeneralResource.BASE_PATH)
+          .then()
+          .statusCode(200)
+          .body("status.existingNamespaces", not(hasItem(keyspace)));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindNamespacesIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindNamespacesIntegrationTest.java
@@ -47,8 +47,8 @@ class FindNamespacesIntegrationTest extends CqlEnabledIntegrationTestBase {
           .post(GeneralResource.BASE_PATH)
           .then()
           .statusCode(200)
-          .body("status.existingNamespaces", hasSize(greaterThan(1)))
-          .body("status.existingNamespaces", hasItem(keyspaceId.asInternal()));
+          .body("status.namespaces", hasSize(greaterThan(1)))
+          .body("status.namespaces", hasItem(keyspaceId.asInternal()));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindNamespacesIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindNamespacesIntegrationTest.java
@@ -1,0 +1,54 @@
+package io.stargate.sgv2.jsonapi.api.v1;
+
+import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.stargate.sgv2.api.common.config.constants.HttpConstants;
+import io.stargate.sgv2.common.CqlEnabledIntegrationTestBase;
+import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusIntegrationTest
+@QuarkusTestResource(DseTestResource.class)
+class FindNamespacesIntegrationTest extends CqlEnabledIntegrationTestBase {
+
+  @BeforeAll
+  public static void enableLog() {
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+  }
+
+  @Nested
+  class FindNamespaces {
+
+    @Test
+    public final void happyPath() {
+      String json =
+          """
+          {
+            "findNamespaces": {
+            }
+          }
+          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(GeneralResource.BASE_PATH)
+          .then()
+          .statusCode(200)
+          .body("status.existingNamespaces", hasSize(greaterThan(1)))
+          .body("status.existingNamespaces", hasItem(keyspaceId.asInternal()));
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does**:
The most primitive implementation of the `findNamespaces` command. Lists all available keyspaces. Example:

```
$ curl -X 'POST' \
>   'http://localhost:8080/v1' \
>   -H 'accept: application/json' \
>   -H 'X-Cassandra-Token: 1c048d89-e2b8-413b-9dab-38950f417272' \
>   -H 'Content-Type: application/json' \
>   -d '{
>     "findNamespaces": {}
>   }' | jq .

{
  "status": {
    "existingNamespaces": [
      "cycling",
      "system_auth",
      "system",
      "system_backups",
      "system_distributed",
      "system_schema",
      "data_endpoint_auth",
      "system_traces"
    ]
  }
}
```

Since there was no spec for this command available, there are few open questions:

* The namespace names are returned as the array in the  `existingNamespaces` status flag.. I was guided by the `insertedIds` approach.. If you have better suggestions please write them down..
* There is no filter for the keyspaces, should we add one.. And if yes what would be the approach?
   * Option to explicitly ignore keyspaces by config pattern
   * Option to list only empty namespaces or the ones that contain at least one jsonapi table

**Which issue(s) this PR fixes**:
Fixes #322
