### PR TITLE
`$in` operator support for `_id` field

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/ValueComparisonOperator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/ValueComparisonOperator.java
@@ -5,7 +5,8 @@ package io.stargate.sgv2.jsonapi.api.model.command.clause.filter;
  * operators, will add it as we support them
  */
 public enum ValueComparisonOperator implements FilterOperator {
-  EQ("$eq");
+  EQ("$eq"),
+  IN("$in");
   /*GT("$gt"),
   GTE("$gte"),
   LT("$lt"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializer.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.smallrye.config.SmallRyeConfig;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.ArrayComparisonOperator;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.ComparisonExpression;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.ElementComparisonOperator;
@@ -27,14 +28,16 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 /** {@link StdDeserializer} for the {@link FilterClause}. */
 public class FilterClauseDeserializer extends StdDeserializer<FilterClause> {
-
   private DocumentConfig documentConfig;
 
   public FilterClauseDeserializer() {
     super(FilterClause.class);
+    SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+    documentConfig = config.getConfigMapping(DocumentConfig.class);
   }
 
   /**
@@ -87,9 +90,10 @@ public class FilterClauseDeserializer extends StdDeserializer<FilterClause> {
               throw new JsonApiException(
                   ErrorCode.INVALID_FILTER_EXPRESSION, "$in operator must have at least one value");
             }
-            if (list.size() > 100) {
+            if (list.size() > documentConfig.defaultPageSize()) {
               throw new JsonApiException(
-                  ErrorCode.INVALID_FILTER_EXPRESSION, "$in operator must have at most 100 values");
+                  ErrorCode.INVALID_FILTER_EXPRESSION,
+                  "$in operator must have at most " + documentConfig.defaultPageSize() + " values");
             }
           } else {
             throw new JsonApiException(

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -33,6 +33,8 @@ public enum ErrorCode {
 
   SHRED_DOC_LIMIT_VIOLATION("Document size limitation violated"),
 
+  INVALID_FILTER_EXPRESSION("Invalid filter expression"),
+
   UNSUPPORTED_FILTER_DATA_TYPE("Unsupported filter data type"),
 
   UNSUPPORTED_FILTER_OPERATION("Unsupported filter operator"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
@@ -44,7 +44,7 @@ public interface ReadOperation extends Operation {
    * Default implementation to query and parse the result set
    *
    * @param queryExecutor
-   * @param query
+   * @param queries - Multiple queries only in case of in condition on _id filter
    * @param pagingState
    * @param readDocument This flag is set to false if the read is done to just identify the document
    *     id and tx_id to perform another DML operation
@@ -53,14 +53,19 @@ public interface ReadOperation extends Operation {
    */
   default Uni<FindResponse> findDocument(
       QueryExecutor queryExecutor,
-      QueryOuterClass.Query query,
+      List<QueryOuterClass.Query> queries,
       String pagingState,
       int pageSize,
       boolean readDocument,
       ObjectMapper objectMapper,
-      DocumentProjector projection) {
-    return queryExecutor
-        .executeRead(query, Optional.ofNullable(pagingState), pageSize)
+      DocumentProjector projection,
+      int limit) {
+
+    return Multi.createFrom()
+        .items(queries.stream())
+        .onItem()
+        .transformToUniAndMerge(
+            query -> queryExecutor.executeRead(query, Optional.ofNullable(pagingState), pageSize))
         .onItem()
         .transform(
             rSet -> {
@@ -88,6 +93,35 @@ public interface ReadOperation extends Operation {
                 documents.add(document);
               }
               return new FindResponse(documents, extractPagingStateFromResultSet(rSet));
+            })
+        .collect()
+        .asList()
+        .onItem()
+        .transform(
+            list -> {
+              // Merge all find responses
+              List<ReadDocument> documents = new ArrayList<>();
+              String tempPagingState = null;
+              if (limit == 1) {
+                // In case of findOne limit will be 1 return one document. Need to do it to support
+                // `in` operator
+                for (FindResponse response : list) {
+                  if (!response.docs().isEmpty()) {
+                    documents.add(response.docs().get(0));
+                    break;
+                  }
+                }
+              } else {
+                // paging can be handling if run as single query, but for now we will just return
+                // the
+                // first page
+                for (FindResponse response : list) {
+                  documents.addAll(response.docs());
+                  // picking the last paging state
+                  tempPagingState = response.pagingState();
+                }
+              }
+              return new FindResponse(documents, tempPagingState);
             });
   }
 
@@ -95,7 +129,7 @@ public interface ReadOperation extends Operation {
    * This method reads upto system fixed limit
    *
    * @param queryExecutor
-   * @param query
+   * @param queries
    * @param pageSize
    * @param objectMapper
    * @param comparator -
@@ -109,7 +143,7 @@ public interface ReadOperation extends Operation {
    */
   default Uni<FindResponse> findOrderDocument(
       QueryExecutor queryExecutor,
-      QueryOuterClass.Query query,
+      List<QueryOuterClass.Query> queries,
       int pageSize,
       ObjectMapper objectMapper,
       Comparator<ReadDocument> comparator,
@@ -120,18 +154,24 @@ public interface ReadOperation extends Operation {
       DocumentProjector projection) {
     final AtomicInteger documentCounter = new AtomicInteger(0);
     final JsonNodeFactory nodeFactory = objectMapper.getNodeFactory();
-    return Multi.createBy()
-        .repeating()
-        .uni(
-            () -> new AtomicReference<String>(null),
-            stateRef -> {
-              return queryExecutor
-                  .executeRead(query, Optional.ofNullable(stateRef.get()), pageSize)
-                  .onItem()
-                  .invoke(rs -> stateRef.set(extractPagingStateFromResultSet(rs)));
-            })
-        // Read document while pagingState exists, limit for read is set at updateLimit +1
-        .whilst(resultSet -> extractPagingStateFromResultSet(resultSet) != null)
+    return Multi.createFrom()
+        .items(queries.stream())
+        .onItem()
+        .transformToMultiAndMerge(
+            q ->
+                Multi.createBy()
+                    .repeating()
+                    .uni(
+                        () -> new AtomicReference<String>(null),
+                        stateRef -> {
+                          return queryExecutor
+                              .executeRead(q, Optional.ofNullable(stateRef.get()), pageSize)
+                              .onItem()
+                              .invoke(rs -> stateRef.set(extractPagingStateFromResultSet(rs)));
+                        })
+                    // Read document while pagingState exists, limit for read is set at updateLimit
+                    // +1
+                    .whilst(resultSet -> extractPagingStateFromResultSet(resultSet) != null))
         .onItem()
         .transformToUniAndMerge(
             resultSet -> {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
@@ -114,9 +114,8 @@ public interface ReadOperation extends Operation {
                   }
                 }
               } else {
-                // paging can be handling if run as single query, but for now we will just return
-                // the
-                // first page
+                // pagination is handled only when single query is run(non `in` filter), so here
+                // paging state of the last query is returned
                 for (FindResponse response : list) {
                   documents.addAll(response.docs());
                   // picking the last paging state

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
@@ -44,11 +44,13 @@ public interface ReadOperation extends Operation {
    * Default implementation to query and parse the result set
    *
    * @param queryExecutor
-   * @param queries - Multiple queries only in case of in condition on _id filter
+   * @param queries - Multiple queries only in case of `in` condition on `_id` field
    * @param pagingState
    * @param readDocument This flag is set to false if the read is done to just identify the document
    *     id and tx_id to perform another DML operation
    * @param objectMapper
+   * @param projection
+   * @param limit - How many documents to return
    * @return
    */
   default Uni<FindResponse> findDocument(
@@ -129,7 +131,7 @@ public interface ReadOperation extends Operation {
    * This method reads upto system fixed limit
    *
    * @param queryExecutor
-   * @param queries
+   * @param queries Multiple queries only in case of `in` condition on `_id` field
    * @param pageSize
    * @param objectMapper
    * @param comparator -

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
@@ -119,7 +119,7 @@ public record FindOperation(
     // COUNT is not supported
     switch (readType) {
       case SORTED_DOCUMENT -> {
-        List<QueryOuterClass.Query> queries = buildSortedSelectQuery(additionalIdFilter);
+        List<QueryOuterClass.Query> queries = buildSortedSelectQueries(additionalIdFilter);
         return findOrderDocument(
             queryExecutor,
             queries,
@@ -133,7 +133,7 @@ public record FindOperation(
             projection());
       }
       case DOCUMENT, KEY -> {
-        List<QueryOuterClass.Query> queries = buildSelectQuery(additionalIdFilter);
+        List<QueryOuterClass.Query> queries = buildSelectQueries(additionalIdFilter);
         return findDocument(
             queryExecutor,
             queries,
@@ -164,7 +164,7 @@ public record FindOperation(
     ObjectNode rootNode = objectMapper().createObjectNode();
     DocumentId documentId = null;
     for (DBFilterBase filter : filters) {
-      if (filter instanceof DBFilterBase.IDFilter idFilter) {
+      if (filter instanceof DBFilterBase.IDFilter idFilter && idFilter.canAddField()) {
         documentId = idFilter.values.get(0);
         rootNode.putIfAbsent(filter.getPath(), filter.asJson(objectMapper().getNodeFactory()));
       } else {
@@ -189,7 +189,7 @@ public record FindOperation(
    * @return Returns a list of queries, where a query is built using element returned by the
    *     buildConditions method.
    */
-  private List<QueryOuterClass.Query> buildSelectQuery(DBFilterBase.IDFilter additionalIdFilter) {
+  private List<QueryOuterClass.Query> buildSelectQueries(DBFilterBase.IDFilter additionalIdFilter) {
     List<List<BuiltCondition>> conditions = buildConditions(additionalIdFilter);
     List<QueryOuterClass.Query> queries = new ArrayList<>(conditions.size());
     conditions.forEach(
@@ -212,7 +212,7 @@ public record FindOperation(
    * @return Returns a list of queries, where a query is built using element returned by the
    *     buildConditions method.
    */
-  private List<QueryOuterClass.Query> buildSortedSelectQuery(
+  private List<QueryOuterClass.Query> buildSortedSelectQueries(
       DBFilterBase.IDFilter additionalIdFilter) {
     List<List<BuiltCondition>> conditions = buildConditions(additionalIdFilter);
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/matcher/FilterableResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/matcher/FilterableResolver.java
@@ -32,6 +32,7 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
   private final FilterMatchRules<T> matchRules = new FilterMatchRules<>();
 
   private static final Object ID_GROUP = new Object();
+  private static final Object ID_GROUP_IN = new Object();
 
   private static final Object DYNAMIC_TEXT_GROUP = new Object();
   private static final Object DYNAMIC_NUMBER_GROUP = new Object();
@@ -53,12 +54,20 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
         .capture(ID_GROUP)
         .compareValues("_id", EnumSet.of(ValueComparisonOperator.EQ), JsonType.DOCUMENT_ID);
 
+    matchRules
+        .addMatchRule(this::findById, FilterMatcher.MatchStrategy.STRICT)
+        .matcher()
+        .capture(ID_GROUP_IN)
+        .compareValues("_id", EnumSet.of(ValueComparisonOperator.IN), JsonType.ARRAY);
+
     // NOTE - can only do eq ops on fields until SAI changes
     matchRules
         .addMatchRule(this::findDynamic, FilterMatcher.MatchStrategy.GREEDY)
         .matcher()
         .capture(ID_GROUP)
         .compareValues("_id", EnumSet.of(ValueComparisonOperator.EQ), JsonType.DOCUMENT_ID)
+        .capture(ID_GROUP_IN)
+        .compareValues("_id", EnumSet.of(ValueComparisonOperator.IN), JsonType.ARRAY)
         .capture(DYNAMIC_NUMBER_GROUP)
         .compareValues("*", EnumSet.of(ValueComparisonOperator.EQ), JsonType.NUMBER)
         .capture(DYNAMIC_TEXT_GROUP)
@@ -94,6 +103,16 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
                   new DBFilterBase.IDFilter(
                       DBFilterBase.IDFilter.Operator.EQ, expression.value())));
     }
+
+    final CaptureGroup<List<DocumentId>> idsGroup =
+        (CaptureGroup<List<DocumentId>>) captures.getGroupIfPresent(ID_GROUP_IN);
+    if (idsGroup != null) {
+      idsGroup.consumeAllCaptures(
+          expression ->
+              filters.add(
+                  new DBFilterBase.IDFilter(
+                      DBFilterBase.IDFilter.Operator.IN, expression.value())));
+    }
     return filters;
   }
 
@@ -112,7 +131,17 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
           expression ->
               filters.add(
                   new DBFilterBase.IDFilter(
-                      DBFilterBase.IDFilter.Operator.EQ, expression.value())));
+                      DBFilterBase.IDFilter.Operator.EQ, List.of(expression.value()))));
+    }
+
+    final CaptureGroup<List<DocumentId>> idsGroup =
+        (CaptureGroup<List<DocumentId>>) captures.getGroupIfPresent(ID_GROUP_IN);
+    if (idsGroup != null) {
+      idsGroup.consumeAllCaptures(
+          expression ->
+              filters.add(
+                  new DBFilterBase.IDFilter(
+                      DBFilterBase.IDFilter.Operator.IN, expression.value())));
     }
 
     final CaptureGroup<String> textGroup =

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
@@ -330,7 +330,11 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$in operator must have at most 100 values");
+                assertThat(t.getMessage())
+                    .isEqualTo(
+                        "$in operator must have at most "
+                            + documentConfig.defaultPageSize()
+                            + " values");
               });
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
@@ -176,7 +176,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$all operator must have array ");
+                assertThat(t.getMessage()).isEqualTo("$all operator must have array value");
               });
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
@@ -15,6 +15,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.JsonType;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.ValueComparisonOperation;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.ValueComparisonOperator;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import io.stargate.sgv2.jsonapi.service.bridge.config.DocumentConfig;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import java.math.BigDecimal;
 import java.util.LinkedHashMap;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 public class FilterClauseDeserializerTest {
 
   @Inject ObjectMapper objectMapper;
+  @Inject DocumentConfig documentConfig;
 
   @Nested
   class Deserialize {
@@ -176,7 +178,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$all operator must have array value");
+                assertThat(t.getMessage()).isEqualTo("$all operator must have `ARRAY` value");
               });
     }
 
@@ -298,7 +300,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage()).isEqualTo("$in operator must have array");
+                assertThat(t.getMessage()).isEqualTo("$in operator must have `ARRAY`");
               });
     }
 
@@ -313,6 +315,22 @@ public class FilterClauseDeserializerTest {
           .satisfies(
               t -> {
                 assertThat(t.getMessage()).isEqualTo("$in operator must have at least one value");
+              });
+    }
+
+    @Test
+    public void mustHandleInArrayWithBigArray() throws Exception {
+      // String array with 100 unique numbers
+      String json =
+          """
+        {"_id" : {"$in": ["0","1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30","31","32","33","34","35","36","37","38","39","40","41","42","43","44","45","46","47","48","49","50","51","52","53","54","55","56","57","58","59","60","61","62","63","64","65","66","67","68","69","70","71","72","73","74","75","76","77","78","79","80","81","82","83","84","85","86","87","88","89","90","91","92","93","94","95","96","97","98","99","100"]}}
+       """;
+      Throwable throwable = catchThrowable(() -> objectMapper.readValue(json, FilterClause.class));
+      assertThat(throwable)
+          .isInstanceOf(JsonApiException.class)
+          .satisfies(
+              t -> {
+                assertThat(t.getMessage()).isEqualTo("$in operator must have at most 100 values");
               });
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountIntegrationTest.java
@@ -299,7 +299,7 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("errors[0].message", is("$exists operator supports only true"));
+          .body("errors[1].message", is("$exists operator supports only true"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountIntegrationTest.java
@@ -299,7 +299,7 @@ public class CountIntegrationTest extends CollectionResourceBaseIntegrationTest 
           .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
           .then()
           .statusCode(200)
-          .body("errors[0].message", is("$exists is supported only with true option"));
+          .body("errors[0].message", is("$exists operator supports only true"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -228,7 +228,33 @@ public class FindIntegrationTest extends CollectionResourceBaseIntegrationTest {
           .body("data.docs", hasSize(2))
           .body("status", is(nullValue()))
           .body("errors", is(nullValue()))
-          .body("data.docs[0]", containsInAnyOrder(expected1, expected2));
+          .body("data.docs", containsInAnyOrder(expected1, expected2));
+    }
+
+    @Test
+    public void inConditionWithOtherCondition() {
+      String json =
+          """
+        {
+          "find": {
+            "filter" : {"_id" : {"$in": ["doc1", "doc4"]}, "username" : "user1" }
+          }
+        }
+        """;
+      String expected1 = "{\"_id\":\"doc1\", \"username\":\"user1\", \"active_user\":true}";
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, keyspaceId.asInternal(), collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.count", is(1))
+          .body("data.docs", hasSize(1))
+          .body("status", is(nullValue()))
+          .body("errors", is(nullValue()))
+          .body("data.docs[0]", jsonEquals(expected1));
     }
 
     @Test
@@ -251,7 +277,7 @@ public class FindIntegrationTest extends CollectionResourceBaseIntegrationTest {
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors[1].message", is("$in operator must have at least one value"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 
     @Test
@@ -274,7 +300,7 @@ public class FindIntegrationTest extends CollectionResourceBaseIntegrationTest {
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors[1].message", is("$in operator must have array"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 
     @Test
@@ -297,7 +323,7 @@ public class FindIntegrationTest extends CollectionResourceBaseIntegrationTest {
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors[1].message", is("Can use $in operator only on _id field"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 
     @Test
@@ -486,7 +512,7 @@ public class FindIntegrationTest extends CollectionResourceBaseIntegrationTest {
           .then()
           .statusCode(200)
           .body("errors[1].message", is("$exists operator supports only true"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -228,7 +228,7 @@ public class FindIntegrationTest extends CollectionResourceBaseIntegrationTest {
           .body("data.docs", hasSize(2))
           .body("status", is(nullValue()))
           .body("errors", is(nullValue()))
-          .body("data.docs", containsInAnyOrder(expected1, expected2));
+          .body("data.docs", containsInAnyOrder(jsonEquals(expected1), jsonEquals(expected2)));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -299,7 +299,7 @@ public class FindIntegrationTest extends CollectionResourceBaseIntegrationTest {
           .then()
           .statusCode(200)
           .body("errors", is(notNullValue()))
-          .body("errors[1].message", is("$in operator must have array"))
+          .body("errors[1].message", is("$in operator must have `ARRAY`"))
           .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
@@ -307,7 +307,7 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors[1].message", is("$in operator must have at least one value"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 
     @Test
@@ -330,7 +330,7 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors[1].message", is("$in operator must have array"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 
     @Test
@@ -353,7 +353,7 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors[1].message", is("Can use $in operator only on _id field"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 
     @Test
@@ -535,7 +535,7 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
           .body("errors[1].message", is("$exists operator supports only true"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 
     @Test
@@ -635,7 +635,7 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
           .body("errors[1].message", is("$all operator must have array value"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 
     @Test
@@ -710,10 +710,8 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .statusCode(200)
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
-          .body(
-              "errors[0].message",
-              is("Filter type not supported, unable to resolve to a filtering strategy"))
-          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[0].message", is("$size operator must have integer"))
+          .body("errors[1].exceptionClass", is("JsonApiException"));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
@@ -710,7 +710,7 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .statusCode(200)
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
-          .body("errors[0].message", is("$size operator must have integer"))
+          .body("errors[1].message", is("$size operator must have integer"))
           .body("errors[1].exceptionClass", is("JsonApiException"));
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
@@ -329,7 +329,7 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .then()
           .statusCode(200)
           .body("errors", is(notNullValue()))
-          .body("errors[1].message", is("$in operator must have array"))
+          .body("errors[1].message", is("$in operator must have `ARRAY`"))
           .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 
@@ -634,7 +634,7 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .statusCode(200)
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
-          .body("errors[1].message", is("$all operator must have array value"))
+          .body("errors[1].message", is("$all operator must have `ARRAY` value"))
           .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 


### PR DESCRIPTION
**What this PR does**:
`$in` support only for `_id` field
**Which issue(s) this PR fixes**:
Fixes #346 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
