### PR TITLE
Kathirsvn/openapi path fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The extension setups the health endpoints under `/stargate/health`.
 ### `quarkus-smallrye-openapi`
 [Related guide](https://quarkus.io/guides/openapi-swaggerui)
 
-The OpenAPI definitions are generated and available under `/api/docs/openapi` endpoint.
+The OpenAPI definitions are generated and available under `/api/json/openapi` endpoint.
 The [StargateJsonApi](src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java) class defines the `@OpenAPIDefinition` annotation.
 This definition defines the default *SecurityScheme* named `Token`, which expects the header based authentication with the HTTP Header `X-Cassandra-Token`.
 The `info` portions of the Open API definitions are set using the `quarkus.smallrye-openapi.info-` configuration properties.

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,4 +74,4 @@ quarkus:
 
   # adapt path of the open api definitions
   smallrye-openapi:
-    path: /api/docs/openapi
+    path: /api/json/openapi


### PR DESCRIPTION
**What this PR does**:
Fixes an issue where the openapi path `/api/docs/openapi` conflicts, while both the docsapi and jsonapi are deployed in the same environment

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
