### PR TITLE
Fixes #365: indicate max docs, actual docs inserted in error (fail) message

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/validation/MaxInsertManyDocumentsValidation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/validation/MaxInsertManyDocumentsValidation.java
@@ -22,6 +22,17 @@ public class MaxInsertManyDocumentsValidation
   /** {@inheritDoc} */
   @Override
   public boolean isValid(List<JsonNode> value, ConstraintValidatorContext context) {
-    return null != value && value.size() <= config.get().maxDocumentInsertCount();
+    final int max = config.get().maxDocumentInsertCount();
+    if (null != value && value.size() > max) {
+      context
+          .buildConstraintViolationWithTemplate(
+              String.format(
+                  "%s (%d vs %d)",
+                  context.getDefaultConstraintMessageTemplate(), value.size(), max))
+          .addConstraintViolation()
+          .disableDefaultConstraintViolation();
+      return false;
+    }
+    return true;
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommandTest.java
@@ -93,7 +93,7 @@ class InsertManyCommandTest {
       assertThat(result)
           .isNotEmpty()
           .extracting(ConstraintViolation::getMessage)
-          .contains("amount of documents to insert is over the max limit");
+          .contains("amount of documents to insert is over the max limit (3 vs 2)");
     }
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Adds `" (<actual docs to insert> vs <max docs to insert>)"` in error message when validating number of documents to insert, so caller gets indication of what limit was vioated.

**Which issue(s) this PR fixes**:
Fixes #365

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
