### PR TITLE
closes #350: errorCode and exceptionClass to be reported always with …

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/JsonApiException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/JsonApiException.java
@@ -43,11 +43,8 @@ public class JsonApiException extends RuntimeException implements Supplier<Comma
       message = errorCode.getMessage();
     }
 
-    // add error code as error field
-    Map<String, Object> fields = Map.of("errorCode", errorCode.name());
-
     // construct and return
-    CommandResult.Error error = new CommandResult.Error(message, fields);
+    CommandResult.Error error = getCommandResultError(message);
 
     // handle cause as well
     Throwable cause = getCause();
@@ -57,6 +54,12 @@ public class JsonApiException extends RuntimeException implements Supplier<Comma
       CommandResult.Error causeError = ThrowableToErrorMapper.getMapperFunction().apply(cause);
       return new CommandResult(List.of(error, causeError));
     }
+  }
+
+  public CommandResult.Error getCommandResultError(String message) {
+    Map<String, Object> fields =
+        Map.of("errorCode", errorCode.name(), "exceptionClass", this.getClass().getSimpleName());
+    return new CommandResult.Error(message, fields);
   }
 
   public ErrorCode getErrorCode() {

--- a/src/main/java/io/stargate/sgv2/jsonapi/util/ExceptionUtil.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/util/ExceptionUtil.java
@@ -2,26 +2,22 @@ package io.stargate.sgv2.jsonapi.util;
 
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import io.stargate.sgv2.jsonapi.exception.mappers.ThrowableToErrorMapper;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class ExceptionUtil {
   public static String getThrowableGroupingKey(Throwable error) {
-    String key = error.getClass().getSimpleName();
-    if (error instanceof JsonApiException jae) key = jae.getErrorCode().name();
-    return key;
+    if (error instanceof JsonApiException jae) {
+      return jae.getErrorCode().name();
+    } else {
+      return error.getClass().getSimpleName();
+    }
   }
 
   public static CommandResult.Error getError(
       String messageTemplate, List<DocumentId> documentIds, Throwable throwable) {
     String message = messageTemplate.formatted(documentIds, throwable.getMessage());
-    Map<String, Object> fields = new HashMap<>();
-    fields.put("exceptionClass", throwable.getClass().getSimpleName());
-    if (throwable instanceof JsonApiException jae) {
-      fields.put("errorCode", jae.getErrorCode().name());
-    }
-    return new CommandResult.Error(message, fields);
+    return ThrowableToErrorMapper.getMapperWithMessageFunction().apply(throwable, message);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -325,7 +325,8 @@ public class FindIntegrationTest extends CollectionResourceBaseIntegrationTest {
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors[1].message", is("$in operator must have `ARRAY`"))
-          .body("errors[1].exceptionClass", is("JsonApiException"));
+          .body("errors[1].exceptionClass", is("JsonApiException"))
+          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test
@@ -348,7 +349,8 @@ public class FindIntegrationTest extends CollectionResourceBaseIntegrationTest {
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors[1].message", is("Can use $in operator only on _id field"))
-          .body("errors[1].exceptionClass", is("JsonApiException"));
+          .body("errors[1].exceptionClass", is("JsonApiException"))
+          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test
@@ -537,7 +539,8 @@ public class FindIntegrationTest extends CollectionResourceBaseIntegrationTest {
           .then()
           .statusCode(200)
           .body("errors[1].message", is("$exists operator supports only true"))
-          .body("errors[1].exceptionClass", is("JsonApiException"));
+          .body("errors[1].exceptionClass", is("JsonApiException"))
+          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
@@ -331,7 +331,8 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors[1].message", is("$in operator must have `ARRAY`"))
-          .body("errors[1].exceptionClass", is("JsonApiException"));
+          .body("errors[1].exceptionClass", is("JsonApiException"))
+          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test
@@ -354,7 +355,8 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors[1].message", is("Can use $in operator only on _id field"))
-          .body("errors[1].exceptionClass", is("JsonApiException"));
+          .body("errors[1].exceptionClass", is("JsonApiException"))
+          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test
@@ -536,7 +538,8 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
           .body("errors[1].message", is("$exists operator supports only true"))
-          .body("errors[1].exceptionClass", is("JsonApiException"));
+          .body("errors[1].exceptionClass", is("JsonApiException"))
+          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test
@@ -636,7 +639,8 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
           .body("errors[1].message", is("$all operator must have `ARRAY` value"))
-          .body("errors[1].exceptionClass", is("JsonApiException"));
+          .body("errors[1].exceptionClass", is("JsonApiException"))
+          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test
@@ -712,7 +716,8 @@ public class FindOneIntegrationTest extends CollectionResourceBaseIntegrationTes
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
           .body("errors[1].message", is("$size operator must have integer"))
-          .body("errors[1].exceptionClass", is("JsonApiException"));
+          .body("errors[1].exceptionClass", is("JsonApiException"))
+          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/exception/JsonApiExceptionTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/exception/JsonApiExceptionTest.java
@@ -25,8 +25,9 @@ class JsonApiExceptionTest {
               error -> {
                 assertThat(error.message()).isEqualTo("The provided command is not implemented.");
                 assertThat(error.fields())
-                    .hasSize(1)
-                    .containsEntry("errorCode", "COMMAND_NOT_IMPLEMENTED");
+                    .hasSize(2)
+                    .containsEntry("errorCode", "COMMAND_NOT_IMPLEMENTED")
+                    .containsEntry("exceptionClass", "JsonApiException");
               });
     }
 
@@ -46,8 +47,9 @@ class JsonApiExceptionTest {
               error -> {
                 assertThat(error.message()).isEqualTo("Custom message is more important.");
                 assertThat(error.fields())
-                    .hasSize(1)
-                    .containsEntry("errorCode", "COMMAND_NOT_IMPLEMENTED");
+                    .hasSize(2)
+                    .containsEntry("errorCode", "COMMAND_NOT_IMPLEMENTED")
+                    .containsEntry("exceptionClass", "JsonApiException");
               });
     }
 
@@ -66,8 +68,9 @@ class JsonApiExceptionTest {
               error -> {
                 assertThat(error.message()).isEqualTo("The provided command is not implemented.");
                 assertThat(error.fields())
-                    .hasSize(1)
-                    .containsEntry("errorCode", "COMMAND_NOT_IMPLEMENTED");
+                    .hasSize(2)
+                    .containsEntry("errorCode", "COMMAND_NOT_IMPLEMENTED")
+                    .containsEntry("exceptionClass", "JsonApiException");
               })
           .anySatisfy(
               error -> {


### PR DESCRIPTION
**What this PR does**:
As discussed in the https://github.com/stargate/jsonapi/issues/350#issuecomment-1513166081 I pushed the implementation that fixes `errorCode` missing. We still need to agree on the handling of the cause and if we do want the error array to include the cause..

**Which issue(s) this PR fixes**:
Fixes #350

**Checklist**
- [x] Agree on cause handling