### PR TITLE
Add "query_timestamp_values" column in Collections, update shredder

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -35,6 +35,8 @@ public enum ErrorCode {
 
   SHRED_DOC_LIMIT_VIOLATION("Document size limitation violated"),
 
+  SHRED_BAD_EJSON_VALUE("Bad EJSON value"),
+
   INVALID_FILTER_EXPRESSION("Invalid filter expression"),
 
   UNSUPPORTED_FILTER_DATA_TYPE("Unsupported filter data type"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -46,6 +46,7 @@ public record CreateCollectionOperation(CommandContext commandContext, String na
             + "    query_bool_values   map<text, tinyint>,"
             + "    query_dbl_values    map<text, decimal>,"
             + "    query_text_values   map<text, text>, "
+            + "    query_timestamp_values map<text, timestamp>, "
             + "    query_null_values   set<text>,     "
             + "    PRIMARY KEY (key))";
     return QueryOuterClass.Query.newBuilder()
@@ -110,6 +111,13 @@ public record CreateCollectionOperation(CommandContext commandContext, String na
     statements.add(
         QueryOuterClass.Query.newBuilder()
             .setCql(String.format(textQuery, table, keyspace, table))
+            .build());
+
+    String timestampQuery =
+        "CREATE CUSTOM INDEX IF NOT EXISTS %s_query_timestamp_values ON \"%s\".\"%s\" (entries(query_timestamp_values)) USING 'StorageAttachedIndex'";
+    statements.add(
+        QueryOuterClass.Query.newBuilder()
+            .setCql(String.format(timestampQuery, table, keyspace, table))
             .build());
 
     String nullQuery =

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/model/JsonapiTableMatcher.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/model/JsonapiTableMatcher.java
@@ -26,6 +26,7 @@ public class JsonapiTableMatcher implements Predicate<Schema.CqlTable> {
             .or(new CqlColumnMatcher.Map("query_bool_values", Basic.VARCHAR, Basic.TINYINT))
             .or(new CqlColumnMatcher.Map("query_dbl_values", Basic.VARCHAR, Basic.DECIMAL))
             .or(new CqlColumnMatcher.Map("query_text_values", Basic.VARCHAR, Basic.VARCHAR))
+            .or(new CqlColumnMatcher.Map("query_timestamp_values", Basic.VARCHAR, Basic.TIMESTAMP))
             .or(new CqlColumnMatcher.Set("query_null_values", Basic.VARCHAR));
   }
 
@@ -56,7 +57,7 @@ public class JsonapiTableMatcher implements Predicate<Schema.CqlTable> {
     }
 
     List<QueryOuterClass.ColumnSpec> columns = cqlTable.getColumnsList();
-    if (columns.size() != 11 || !columns.stream().allMatch(columnsPredicate)) {
+    if (columns.size() != 12 || !columns.stream().allMatch(columnsPredicate)) {
       return false;
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/ShredListener.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/ShredListener.java
@@ -9,7 +9,11 @@ import java.math.BigDecimal;
  * processing. Callbacks are called in document order when traversing the input document.
  */
 public interface ShredListener {
-  void shredObject(JsonPath path, ObjectNode obj);
+  /**
+   * @return Whether to traverse contents or not: if {@code true} traverse contents, if {@code
+   *     false} do not proceed further.
+   */
+  boolean shredObject(JsonPath path, ObjectNode obj);
 
   void shredArray(JsonPath path, ArrayNode arr);
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -144,8 +144,9 @@ public class Shredder {
     final JsonPath path = pathBuilder.build();
     if (value.isObject()) {
       ObjectNode ob = (ObjectNode) value;
-      callback.shredObject(path, ob);
-      traverseObject(ob, callback, pathBuilder.nestedObjectBuilder());
+      if (callback.shredObject(path, ob)) {
+        traverseObject(ob, callback, pathBuilder.nestedObjectBuilder());
+      }
     } else if (value.isArray()) {
       ArrayNode arr = (ArrayNode) value;
       callback.shredArray(path, arr);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/AtomicValue.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/AtomicValue.java
@@ -1,6 +1,7 @@
 package io.stargate.sgv2.jsonapi.service.shredding.model;
 
 import java.math.BigDecimal;
+import java.util.Date;
 
 /**
  * Simple immutable value container class used when shredding documents, to contain "full" value as
@@ -23,6 +24,11 @@ public record AtomicValue(DocValueType type, String typedFullValue, DocValueHash
   public static AtomicValue forNumber(BigDecimal num) {
     // For Numbers just make sure not to use Engineering notation:
     return create(DocValueType.NUMBER, num.toPlainString());
+  }
+
+  public static AtomicValue forTimestamp(Date dt) {
+    // Long-value of timestamp still fits without truncation
+    return create(DocValueType.TIMESTAMP, String.valueOf(dt.getTime()));
   }
 
   static AtomicValue create(DocValueType type, String fullValue) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/AtomicValues.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/AtomicValues.java
@@ -1,8 +1,17 @@
 package io.stargate.sgv2.jsonapi.service.shredding.model;
 
 import java.math.BigDecimal;
+import java.util.Date;
 import java.util.HashMap;
 
+/**
+ * Simple per-shred-operation data structure for reusing already constructed {@link AtomicValue}
+ * representations; this avoids hash recalculations and since values are retained anyway by caller
+ * does not add significant memory retention (even for short term).
+ *
+ * <p>Note that maximum size not used because reuse/caching does not extend across shredding calls;
+ * only values within a single document are reused.
+ */
 public class AtomicValues {
   final HashMap<Object, AtomicValue> seenValues = new HashMap<>();
 
@@ -19,6 +28,15 @@ public class AtomicValues {
     AtomicValue atomic = seenValues.get(value);
     if (atomic == null) {
       atomic = AtomicValue.forNumber(value);
+      seenValues.put(value, atomic);
+    }
+    return atomic;
+  }
+
+  public AtomicValue timestampValue(Date value) {
+    AtomicValue atomic = seenValues.get(value);
+    if (atomic == null) {
+      atomic = AtomicValue.forTimestamp(value);
       seenValues.put(value, atomic);
     }
     return atomic;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocValueHasher.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocValueHasher.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.math.BigDecimal;
+import java.util.Date;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -64,6 +65,10 @@ public class DocValueHasher {
 
   public AtomicValue stringValue(String str) {
     return atomics.stringValue(str);
+  }
+
+  public AtomicValue timestampValue(Date dt) {
+    return atomics.timestampValue(dt);
   }
 
   public DocValueHash arrayHash(ArrayNode n) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocValueType.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocValueType.java
@@ -16,7 +16,9 @@ public enum DocValueType {
   BOOLEAN('B', true),
   NUMBER('N', true),
   NULL('Z', true),
-  STRING('S', true);
+  STRING('S', true),
+
+  TIMESTAMP('T', true);
 
   private final char prefix;
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/WritableShreddedDocument.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/WritableShreddedDocument.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.service.shredding.JsonPath;
 import io.stargate.sgv2.jsonapi.service.shredding.ShredListener;
+import io.stargate.sgv2.jsonapi.util.JsonUtil;
 import java.math.BigDecimal;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -33,6 +35,7 @@ public record WritableShreddedDocument(
     Map<JsonPath, Boolean> queryBoolValues,
     Map<JsonPath, BigDecimal> queryNumberValues,
     Map<JsonPath, String> queryTextValues,
+    Map<JsonPath, Date> queryTimestampValues,
     Set<JsonPath> queryNullValues) {
   public static Builder builder(DocValueHasher hasher, DocumentId id, UUID txID, String docJson) {
     return new Builder(hasher, id, txID, docJson);
@@ -65,6 +68,7 @@ public record WritableShreddedDocument(
     private Map<JsonPath, Boolean> queryBoolValues;
     private Map<JsonPath, BigDecimal> queryNumberValues;
     private Map<JsonPath, String> queryTextValues;
+    private Map<JsonPath, Date> queryTimestampValues;
     private Set<JsonPath> queryNullValues;
 
     public Builder(DocValueHasher hasher, DocumentId id, UUID txID, String docJson) {
@@ -94,6 +98,7 @@ public record WritableShreddedDocument(
           _nonNull(queryBoolValues),
           _nonNull(queryNumberValues),
           _nonNull(queryTextValues),
+          _nonNull(queryTimestampValues),
           _nonNull(queryNullValues));
     }
 
@@ -112,13 +117,29 @@ public record WritableShreddedDocument(
      */
 
     @Override
-    public void shredObject(JsonPath path, ObjectNode obj) {
-      addKey(path);
+    public boolean shredObject(JsonPath path, ObjectNode obj) {
+      // Either Sub-doc or EJSON-encoded Date/time value:
+      Date dtValue = JsonUtil.extractEJsonDate(obj);
+      if (dtValue != null) {
+        shredDateTime(path, dtValue);
+        return false; // We are done
+      }
 
+      addKey(path);
       if (subDocEquals == null) {
         subDocEquals = new HashMap<>();
       }
       subDocEquals.put(path, hasher.hash(obj).hash());
+      return true; // proceed to shred individual entries too
+    }
+
+    private void shredDateTime(JsonPath path, Date dtValue) {
+      addKey(path);
+      if (queryTimestampValues == null) {
+        queryTimestampValues = new HashMap<>();
+      }
+      queryTimestampValues.put(path, dtValue);
+      addArrayContains(path, hasher.timestampValue(dtValue).hash());
     }
 
     @Override

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/WritableShreddedDocument.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/WritableShreddedDocument.java
@@ -118,11 +118,11 @@ public record WritableShreddedDocument(
 
     @Override
     public boolean shredObject(JsonPath path, ObjectNode obj) {
-      // Either Sub-doc or EJSON-encoded Date/time value:
+      // Either Sub-doc or EJSON-encoded Date/timestamp value:
       Date dtValue = JsonUtil.extractEJsonDate(obj);
       if (dtValue != null) {
-        shredDateTime(path, dtValue);
-        return false; // We are done
+        shredTimestamp(path, dtValue);
+        return false; // we are done
       }
 
       addKey(path);
@@ -133,7 +133,7 @@ public record WritableShreddedDocument(
       return true; // proceed to shred individual entries too
     }
 
-    private void shredDateTime(JsonPath path, Date dtValue) {
+    private void shredTimestamp(JsonPath path, Date dtValue) {
       addKey(path);
       if (queryTimestampValues == null) {
         queryTimestampValues = new HashMap<>();

--- a/src/main/java/io/stargate/sgv2/jsonapi/util/JsonUtil.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/util/JsonUtil.java
@@ -3,11 +3,14 @@ package io.stargate.sgv2.jsonapi.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 
 public class JsonUtil {
+  public static final String EJSON_VALUE_KEY_DATE = "$date";
+
   /**
    * Method that compares to JSON values for equality using Mongo semantics which are otherwise same
    * as for JSON but additionally require exact ordering of Object (sub-document) values.
@@ -57,5 +60,23 @@ public class JsonUtil {
     }
     // For other nodes default equals() works fine:
     return Objects.equals(node1, node2);
+  }
+
+  /**
+   * Helper method that will see if given {@link JsonNode} is an EJSON-encoded "Date" (aka
+   * Timestamp) value and if so, constructs and returns matching {@link java.util.Date} value. See
+   * {@href https://docs.meteor.com/api/ejson.html} for details on encoded value.
+   *
+   * @param json JSON value to check
+   * @return
+   */
+  public static Date extractEJsonDate(JsonNode json) {
+    if (json.isObject() && json.size() == 1) {
+      JsonNode value = json.path(EJSON_VALUE_KEY_DATE);
+      if (value.isIntegralNumber() && value.canConvertToLong()) {
+        return new Date(value.longValue());
+      }
+    }
+    return null;
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
@@ -84,6 +84,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
             + "    query_bool_values   map<text, tinyint>,"
             + "    query_dbl_values    map<text, decimal>,"
             + "    query_text_values   map<text, text>, "
+            + "    query_timestamp_values map<text, timestamp>, "
             + "    query_null_values   set<text>,     "
             + "    PRIMARY KEY (key))";
     queries.add(create.formatted(namespace, collection));
@@ -110,6 +111,9 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
             .formatted(collection, namespace, collection));
     queries.add(
         "CREATE CUSTOM INDEX IF NOT EXISTS %s_query_text_values ON \"%s\".\"%s\" (entries(query_text_values)) USING 'StorageAttachedIndex'"
+            .formatted(collection, namespace, collection));
+    queries.add(
+        "CREATE CUSTOM INDEX IF NOT EXISTS %s_query_timestamp_values ON \"%s\".\"%s\" (entries(query_timestamp_values)) USING 'StorageAttachedIndex'"
             .formatted(collection, namespace, collection));
     queries.add(
         "CREATE CUSTOM INDEX IF NOT EXISTS %s_query_null_values ON \"%s\".\"%s\" (query_null_values) USING 'StorageAttachedIndex'"

--- a/src/test/java/io/stargate/sgv2/jsonapi/util/JsonUtilTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/util/JsonUtilTest.java
@@ -1,12 +1,16 @@
 package io.stargate.sgv2.jsonapi.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import java.io.IOException;
+import java.util.Date;
 import javax.inject.Inject;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -17,7 +21,7 @@ public class JsonUtilTest {
   @Inject ObjectMapper mapper;
 
   @Nested
-  class EqualityTests {
+  class Equality {
     @Test
     public void testScalarOrderedEquality() {
       assertThat(equalsOrdered("1", "1")).isTrue();
@@ -67,6 +71,47 @@ public class JsonUtilTest {
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
+    }
+  }
+
+  @Nested
+  class EJSON {
+    @Test
+    public void maybeEJSONValue() throws Exception {
+      // First valid one
+      assertThat(JsonUtil.looksLikeEJsonValue(mapper.readTree("{\"$date\":123}"))).isTrue();
+
+      // And then invalid but not too obviously so (unrecognized, wrong value type);
+      // ones that "should be" EJSON values and are not legit JSON API values otherwise
+      assertThat(JsonUtil.looksLikeEJsonValue(mapper.readTree("{\"$unknown\":123}"))).isTrue();
+      assertThat(JsonUtil.looksLikeEJsonValue(mapper.readTree("{\"$date\": false}"))).isTrue();
+
+      // But also things that are not
+      assertThat(JsonUtil.looksLikeEJsonValue(mapper.readTree("{\"$date\":123, \"x\":3}")))
+          .isFalse();
+      assertThat(JsonUtil.looksLikeEJsonValue(mapper.readTree("\"$date\""))).isFalse();
+      assertThat(JsonUtil.looksLikeEJsonValue(mapper.readTree("123456789"))).isFalse();
+    }
+
+    @Test
+    public void validEJSONDate() {
+      ObjectNode ob = mapper.createObjectNode();
+      final long ts = 123456L;
+      ob.put("$date", ts);
+      Date dt = JsonUtil.extractEJsonDate(ob, "/");
+      assertThat(dt).isEqualTo(new Date(ts));
+    }
+
+    @Test
+    public void invalidEJSONDate() {
+      ObjectNode ob = mapper.createObjectNode();
+      ob.put("$date", "foobar");
+      Throwable t = catchThrowable(() -> JsonUtil.extractEJsonDate(ob, "/"));
+      assertThat(t)
+          .isNotNull()
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_EJSON_VALUE)
+          .hasMessage(
+              "Bad EJSON value: Date ($date) needs to have NUMBER value, has STRING (path '/')");
     }
   }
 }


### PR DESCRIPTION
**What this PR does**:

Adds `query_timestamp_values` columns and will populate it via shredder. Also includes hash value addition for Date/Time values.

Note that this is just the first small part of full Date/Time handling (see #362 for full scope)

**Which issue(s) this PR fixes**:
Fixes #370

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
