### PR TITLE
Add initial handling of Date type as Document id

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/JsonType.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/JsonType.java
@@ -6,6 +6,7 @@ public enum JsonType {
   NUMBER,
   STRING,
   NULL,
+  DATE,
   SUB_DOC,
   ARRAY,
   // DOCUMENT_ID represent the _id field type which is union of String, Number, Boolean and Null

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/JsonType.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/JsonType.java
@@ -6,9 +6,14 @@ public enum JsonType {
   NUMBER,
   STRING,
   NULL,
+  /** Stored as a special EJSON-encoded JSON Object (1 entry with key "$date") */
   DATE,
+  /** JSON Objects other than EJSON-encoded special types */
   SUB_DOC,
   ARRAY,
-  // DOCUMENT_ID represent the _id field type which is union of String, Number, Boolean and Null
+  /**
+   * DOCUMENT_ID represents the _id field type which is union of String, Number, Boolean, Date and
+   * Null (separate type due to use as Cassandra partition key; tuple of TINYINT and String)
+   */
   DOCUMENT_ID
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
@@ -1,7 +1,6 @@
 package io.stargate.sgv2.jsonapi.config.constants;
 
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.JsonType;
-import java.util.Map;
 
 public interface DocumentConstants {
   /** Names of "special" fields in Documents */
@@ -22,21 +21,15 @@ public interface DocumentConstants {
     int TYPE_ID_NULL = 4;
     int TYPE_ID_DATE = 5;
 
-    Map<Integer, JsonType> keyIDMap =
-        Map.of(
-            TYPE_ID_STRING,
-            JsonType.STRING,
-            TYPE_ID_NUMBER,
-            JsonType.NUMBER,
-            TYPE_ID_BOOLEAN,
-            JsonType.BOOLEAN,
-            TYPE_ID_NULL,
-            JsonType.NULL,
-            TYPE_ID_DATE,
-            JsonType.DATE);
-
     static JsonType getJsonType(int typeId) {
-      return keyIDMap.get(typeId);
+      return switch (typeId) {
+        case TYPE_ID_STRING -> JsonType.STRING;
+        case TYPE_ID_NUMBER -> JsonType.NUMBER;
+        case TYPE_ID_BOOLEAN -> JsonType.BOOLEAN;
+        case TYPE_ID_NULL -> JsonType.NULL;
+        case TYPE_ID_DATE -> JsonType.DATE;
+        default -> throw new IllegalArgumentException("Invalid Type Id: " + typeId);
+      };
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
@@ -20,6 +20,7 @@ public interface DocumentConstants {
     int TYPE_ID_NUMBER = 2;
     int TYPE_ID_BOOLEAN = 3;
     int TYPE_ID_NULL = 4;
+    int TYPE_ID_DATE = 5;
 
     Map<Integer, JsonType> keyIDMap =
         Map.of(
@@ -30,7 +31,9 @@ public interface DocumentConstants {
             TYPE_ID_BOOLEAN,
             JsonType.BOOLEAN,
             TYPE_ID_NULL,
-            JsonType.NULL);
+            JsonType.NULL,
+            TYPE_ID_DATE,
+            JsonType.DATE);
 
     static JsonType getJsonType(int typeId) {
       return keyIDMap.get(typeId);

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
@@ -28,7 +28,7 @@ public interface DocumentConstants {
         case TYPE_ID_BOOLEAN -> JsonType.BOOLEAN;
         case TYPE_ID_NULL -> JsonType.NULL;
         case TYPE_ID_DATE -> JsonType.DATE;
-        default -> throw new IllegalArgumentException("Invalid Type Id: " + typeId);
+        default -> null;
       };
     }
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DBFilterBase.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DBFilterBase.java
@@ -14,6 +14,7 @@ import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocValueHasher;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
+import io.stargate.sgv2.jsonapi.util.JsonUtil;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
@@ -491,9 +492,7 @@ public abstract class DBFilterBase implements Supplier<BuiltCondition> {
     } else if (value instanceof Boolean) {
       return nodeFactory.booleanNode((Boolean) value);
     } else if (value instanceof Date) {
-      final ObjectNode objectNode = nodeFactory.objectNode();
-      objectNode.put("$date", ((Date) value).getTime());
-      return objectNode;
+      return JsonUtil.createEJSonDate(nodeFactory, (Date) value);
     } else if (value instanceof List) {
       List<Object> listValues = (List<Object>) value;
       final ArrayNode arrayNode = nodeFactory.arrayNode(listValues.size());

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocumentId.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocumentId.java
@@ -271,7 +271,8 @@ public interface DocumentId {
 
     @Override
     public Object value() {
-      return new Date(key());
+      // Important! Need to serialize as EJSON Encoded representation for use by Jackson
+      return JsonUtil.createEJSonDateAsMap(key());
     }
 
     @Override

--- a/src/main/java/io/stargate/sgv2/jsonapi/util/JsonUtil.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/util/JsonUtil.java
@@ -132,4 +132,8 @@ public class JsonUtil {
     json.put(EJSON_VALUE_KEY_DATE, timestamp);
     return json;
   }
+
+  public static Map<String, Object> createEJSonDateAsMap(long timestamp) {
+    return Map.of(EJSON_VALUE_KEY_DATE, timestamp);
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/util/JsonUtil.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/util/JsonUtil.java
@@ -1,6 +1,7 @@
 package io.stargate.sgv2.jsonapi.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeCreator;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
@@ -124,5 +125,11 @@ public class JsonUtil {
       }
     }
     return null;
+  }
+
+  public static ObjectNode createEJSonDate(JsonNodeCreator f, long timestamp) {
+    ObjectNode json = f.objectNode();
+    json.put(EJSON_VALUE_KEY_DATE, timestamp);
+    return json;
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/util/JsonUtil.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/util/JsonUtil.java
@@ -127,6 +127,10 @@ public class JsonUtil {
     return null;
   }
 
+  public static ObjectNode createEJSonDate(JsonNodeCreator f, Date date) {
+    return createEJSonDate(f, date.getTime());
+  }
+
   public static ObjectNode createEJSonDate(JsonNodeCreator f, long timestamp) {
     ObjectNode json = f.objectNode();
     json.put(EJSON_VALUE_KEY_DATE, timestamp);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -29,8 +29,6 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
   //  - test names
   //  - order annotations
   //  - format json
-  //  - errors field check
-  //  - empty options test
 
   @Nested
   @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -38,7 +36,7 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
     @Test
     @Order(1)
     public void setUp() {
-      String json =
+      insert(
           """
             {
               "insertOne": {
@@ -50,10 +48,9 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
                 }
               }
             }
-          """;
+          """);
 
-      insert(json);
-      json =
+      insert(
           """
             {
               "insertOne": {
@@ -69,11 +66,9 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
                 }
               }
             }
-          """;
+          """);
 
-      insert(json);
-
-      json =
+      insert(
           """
             {
               "insertOne": {
@@ -85,11 +80,9 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
                 }
               }
             }
-          """;
+          """);
 
-      insert(json);
-
-      json =
+      insert(
           """
             {
               "insertOne": {
@@ -99,11 +92,9 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
                 }
               }
             }
-          """;
+          """);
 
-      insert(json);
-
-      json =
+      insert(
           """
             {
               "insertOne": {
@@ -114,9 +105,19 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
                 }
               }
             }
-          """;
+          """);
 
-      insert(json);
+      insert(
+          """
+            {
+              "insertOne": {
+                "document": {
+                  "_id": {"$date": 6},
+                  "username": "user6"
+                }
+              }
+            }
+          """);
     }
 
     private void insert(String json) {
@@ -149,7 +150,7 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .then()
           .statusCode(200)
           .body("errors", is(nullValue()))
-          .body("data.count", is(5));
+          .body("data.count", is(6));
     }
 
     @Test
@@ -190,6 +191,36 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           """;
       String expected =
           "{\"_id\":\"doc1\", \"username\":\"user1\", \"active_user\":true, \"date\" : {\"$date\": 1672531200000}}";
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("errors", is(nullValue()))
+          .body("data.count", is(1))
+          .body("data.docs[0]", jsonEquals(expected));
+    }
+
+    @Test
+    public void byDateId() {
+      String json =
+          """
+                {
+                  "find": {
+                    "filter" : {"_id" : {"$date": 6 }}
+                  }
+                }
+              """;
+      String expected =
+          """
+            {
+              "_id": {"$date": 6},
+              "username": "user6"
+            }
+            """;
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -149,7 +149,8 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("errors", is(nullValue()));
+          .body("errors", is(nullValue()))
+          .body("data.docs", hasSize(6));
     }
 
     @Test
@@ -198,7 +199,8 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .then()
           .statusCode(200)
           .body("errors", is(nullValue()))
-          .body("data.docs[0]", jsonEquals(expected));
+          .body("data.docs[0]", jsonEquals(expected))
+          .body("data.docs", hasSize(1));
     }
 
     @Test
@@ -227,8 +229,8 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .then()
           .statusCode(200)
           .body("errors", is(nullValue()))
-          .body("data.count", is(1))
-          .body("data.docs[0]", jsonEquals(expected));
+          .body("data.docs[0]", jsonEquals(expected))
+          .body("data.docs", hasSize(1));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -92,7 +92,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
     }
 
     @Test
-    public void insertDocumentWithDate() {
+    public void insertDocumentWithDateValue() {
       String json =
           """
         {
@@ -146,6 +146,63 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .statusCode(200)
           .body("data.docs[0]", jsonEquals(expected))
           .body("errors", is(nullValue()));
+    }
+
+    @Test
+    public void insertDocumentWithDateDocId() {
+      String json =
+          """
+            {
+              "insertOne": {
+                "document": {
+                  "_id": {"$date": 1672531200000},
+                  "username": "doc_date_user4",
+                  "status": false
+                }
+              }
+            }
+            """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.insertedIds[0]", jsonEquals("{\"$date\":1672531200000}"))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
+
+      String expected =
+          """
+            {
+              "_id": {"$date": 1672531200000},
+              "username": "doc_date_user4",
+              "status": false
+            }
+            """;
+
+      String query_json =
+          """
+            {
+              "find": {
+                "filter" : {"_id" : {"$date": 1672531200000}}
+              }
+            }
+            """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(query_json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("errors", is(nullValue()))
+          .body("data.docs[0]", jsonEquals(expected));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -155,7 +155,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
             {
               "insertOne": {
                 "document": {
-                  "_id": {"$date": 1672531200000},
+                  "_id": {"$date": 1672539900000},
                   "username": "doc_date_user4",
                   "status": false
                 }
@@ -171,14 +171,14 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("status.insertedIds[0]", jsonEquals("{\"$date\":1672531200000}"))
+          .body("status.insertedIds[0]", jsonEquals("{\"$date\":1672539900000}"))
           .body("data", is(nullValue()))
           .body("errors", is(nullValue()));
 
       String expected =
           """
             {
-              "_id": {"$date": 1672531200000},
+              "_id": {"$date": 1672539900000},
               "username": "doc_date_user4",
               "status": false
             }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -188,7 +188,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           """
             {
               "find": {
-                "filter" : {"_id" : {"$date": 1672531200000}}
+                "filter" : {"_id" : {"$date": 1672539900000}}
               }
             }
             """;

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
@@ -298,7 +298,7 @@ public class ShredderTest {
       assertThat(t)
           .isNotNull()
           .hasMessage(
-              "Bad type for '_id' property: Document Id must be a JSON String, Number, Boolean or NULL instead got ARRAY")
+              "Bad type for '_id' property: Document Id must be a JSON String, Number, Boolean, EJSON-Encoded Date Object or NULL instead got ARRAY")
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_DOCID_TYPE);
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocumentIdTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocumentIdTest.java
@@ -1,12 +1,19 @@
 package io.stargate.sgv2.jsonapi.service.shredding.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.math.BigDecimal;
+import java.util.Date;
 import org.junit.jupiter.api.Test;
 
 public class DocumentIdTest {
+  private final ObjectMapper mapper = new ObjectMapper();
+
   @Test
   public void testBasicEquality() {
     assertThat(DocumentId.fromBoolean(true)).isEqualTo(DocumentId.fromBoolean(true));
@@ -14,15 +21,97 @@ public class DocumentIdTest {
     assertThat(DocumentId.fromNumber(new BigDecimal("10.25")))
         .isEqualTo(DocumentId.fromNumber(new BigDecimal("10.25")));
     assertThat(DocumentId.fromString("abc")).isEqualTo(DocumentId.fromString("abc"));
+
+    Date dt = new Date(123456789L);
+    assertThat(DocumentId.fromTimestamp(dt)).isEqualTo(DocumentId.fromTimestamp(dt));
   }
 
   @Test
   public void testAsJson() {
-    final ObjectMapper mapper = new ObjectMapper();
     assertThat(DocumentId.fromBoolean(true).asJson(mapper).toString()).isEqualTo("true");
     assertThat(DocumentId.fromNull().asJson(mapper).toString()).isEqualTo("null");
     assertThat(DocumentId.fromNumber(new BigDecimal("10.25")).asJson(mapper).toString())
         .isEqualTo("10.25");
     assertThat(DocumentId.fromString("abc").asJson(mapper).toString()).isEqualTo("\"abc\"");
+    assertThat(DocumentId.fromTimestamp(new Date(123456789L)).asJson(mapper).toString())
+        .isEqualTo("{\"$date\":123456789}");
+  }
+
+  @Test
+  public void testFromJson() throws Exception {
+    assertThat(DocumentId.fromJson(mapper.readTree("true")))
+        .isEqualTo(DocumentId.fromBoolean(true));
+    assertThat(DocumentId.fromJson(mapper.readTree("null"))).isEqualTo(DocumentId.fromNull());
+    assertThat(DocumentId.fromJson(mapper.readTree("1.25")))
+        .isEqualTo(DocumentId.fromNumber(new BigDecimal("1.25")));
+    assertThat(DocumentId.fromJson(mapper.readTree("\"xyz\"")))
+        .isEqualTo(DocumentId.fromString("xyz"));
+    assertThat(DocumentId.fromJson(mapper.readTree("{\"$date\":123456789}")))
+        .isEqualTo(DocumentId.fromTimestamp(123456789L));
+  }
+
+  @Test
+  public void testFromDatabaseValid() {
+    assertThat(DocumentId.fromDatabase(DocumentConstants.KeyTypeId.TYPE_ID_BOOLEAN, "true"))
+        .isEqualTo(DocumentId.fromBoolean(true));
+    assertThat(DocumentId.fromDatabase(DocumentConstants.KeyTypeId.TYPE_ID_NULL, ""))
+        .isEqualTo(DocumentId.fromNull());
+    assertThat(DocumentId.fromDatabase(DocumentConstants.KeyTypeId.TYPE_ID_NUMBER, "1.25"))
+        .isEqualTo(DocumentId.fromNumber(new BigDecimal("1.25")));
+    assertThat(DocumentId.fromDatabase(DocumentConstants.KeyTypeId.TYPE_ID_STRING, "xyz"))
+        .isEqualTo(DocumentId.fromString("xyz"));
+    assertThat(DocumentId.fromDatabase(DocumentConstants.KeyTypeId.TYPE_ID_DATE, "123456789"))
+        .isEqualTo(DocumentId.fromTimestamp(123456789L));
+  }
+
+  @Test
+  public void testFromDatabaseInvalid() throws Exception {
+    Exception e =
+        catchException(
+            () -> {
+              DocumentId.fromDatabase(99, "abc");
+            });
+    assertThat(e)
+        .isNotNull()
+        .isInstanceOf(JsonApiException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_DOCID_TYPE)
+        .hasMessageStartingWith(
+            "Bad type for '_id' property: Document Id must be a JSON String(1), Number(2), Boolean(3), NULL(4) or Date(5) instead got 99");
+
+    e =
+        catchException(
+            () -> {
+              DocumentId.fromDatabase(DocumentConstants.KeyTypeId.TYPE_ID_BOOLEAN, "abc");
+            });
+    assertThat(e)
+        .isNotNull()
+        .isInstanceOf(JsonApiException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_DOCID_TYPE)
+        .hasMessageStartingWith(
+            "Bad type for '_id' property: Document Id type Boolean stored as invalid String 'abc' (must be 'true' or 'false')");
+
+    e =
+        catchException(
+            () -> {
+              DocumentId.fromDatabase(DocumentConstants.KeyTypeId.TYPE_ID_NUMBER, "abc");
+            });
+    assertThat(e)
+        .isNotNull()
+        .isInstanceOf(JsonApiException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_DOCID_TYPE)
+        .hasMessageStartingWith(
+            "Bad type for '_id' property: Document Id type Number stored as invalid String 'abc' (not a valid Number)");
+
+    e =
+        catchException(
+            () -> {
+              DocumentId.fromDatabase(DocumentConstants.KeyTypeId.TYPE_ID_DATE, "abc");
+            });
+    assertThat(e)
+        .isNotNull()
+        .isInstanceOf(JsonApiException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_DOCID_TYPE)
+        .hasMessageStartingWith(
+            "Bad type for '_id' property: Document Id type Date stored as invalid String 'abc' (needs to be Number)");
   }
 }


### PR DESCRIPTION
**What this PR does**:

Adds support for EJSON-encoded Date values as typed Document Ids (`_id`).

**Which issue(s) this PR fixes**:
Fixes #371

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
