### PR TITLE
`findOneAndUpdate()` and `findOneAndReplace()` to return document when no data change

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.api.v1;
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -175,6 +176,7 @@ public class FindOneAndReplaceIntegrationTest extends AbstractCollectionIntegrat
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("data.docs", hasSize(1))
           .body("data.docs[0]", jsonEquals(document))
           .body("status.matchedCount", is(1))
           .body("status.modifiedCount", is(0))

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
@@ -3,7 +3,6 @@ package io.stargate.sgv2.jsonapi.api.v1;
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -176,7 +175,7 @@ public class FindOneAndReplaceIntegrationTest extends AbstractCollectionIntegrat
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("data.docs", hasSize(0))
+          .body("data.docs[0]", jsonEquals(document))
           .body("status.matchedCount", is(1))
           .body("status.modifiedCount", is(0))
           .body("errors", is(nullValue()));

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateIntegrationTest.java
@@ -88,6 +88,43 @@ public class FindOneAndUpdateIntegrationTest extends AbstractCollectionIntegrati
     }
 
     @Test
+    public void byIdAndSetNoChange() {
+      String document =
+          """
+        {
+          "_id": "doc3",
+          "username": "admin",
+          "active_user" : true
+        }
+        """;
+      insertDoc(document);
+
+      String json =
+          """
+        {
+          "findOneAndUpdate": {
+            "filter" : {"_id" : "doc3"},
+            "sort": { "username": 1 },
+            "update" : {"$set" : {"username": "admin"}},
+            "options": {"returnDocument": "before"}
+          }
+        }
+        """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.docs[0]", jsonEquals(document))
+          .body("status.matchedCount", is(1))
+          .body("status.modifiedCount", is(0))
+          .body("errors", is(nullValue()));
+    }
+
+    @Test
     public void byIdAndSetNotFound() {
       String json =
           """

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateIntegrationTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -118,6 +119,7 @@ public class FindOneAndUpdateIntegrationTest extends AbstractCollectionIntegrati
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("data.docs", hasSize(1))
           .body("data.docs[0]", jsonEquals(document))
           .body("status.matchedCount", is(1))
           .body("status.modifiedCount", is(0))


### PR DESCRIPTION
**What this PR does**:
`findOneAndUpdate()` return document when no data change
**Which issue(s) this PR fixes**:
Fixes #390 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
