### PR TITLE
Added sort option for `deleteOne` and `updateOne` command

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -172,6 +172,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                               "$set": {"location": "New York"},
                               "$push": {"tags": "marathon"}
                           },
+                          "sort" :  {"race.start_date" : 1},
                           "options" : {
                               "upsert" : true
                           }

--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -203,7 +203,8 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                       """
                     {
                       "deleteOne": {
-                          "filter": {"_id": "1"}
+                          "filter": {"_id": "1"},
+                          "sort" : {"race.start_date" : 1}
                       }
                     }
                     """),

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/DeleteOneCommand.java
@@ -7,6 +7,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.Filterable;
 import io.stargate.sgv2.jsonapi.api.model.command.ModifyCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.NoOptionsCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.FilterClause;
+import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -25,5 +26,6 @@ public record DeleteOneCommand(
             implementation = FilterClause.class)
         @Valid
         @JsonProperty("filter")
-        FilterClause filterClause)
+        FilterClause filterClause,
+    @Valid @JsonProperty("sort") SortClause sortClause)
     implements ModifyCommand, NoOptionsCommand, Filterable {}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/UpdateOneCommand.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.stargate.sgv2.jsonapi.api.model.command.Filterable;
 import io.stargate.sgv2.jsonapi.api.model.command.ReadCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.FilterClause;
+import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateClause;
 import javax.annotation.Nullable;
 import javax.validation.Valid;
@@ -18,6 +19,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 public record UpdateOneCommand(
     @Valid @JsonProperty("filter") FilterClause filterClause,
     @NotNull @Valid @JsonProperty("update") UpdateClause updateClause,
+    @Valid @JsonProperty("sort") SortClause sortClause,
     @Nullable Options options)
     implements ReadCommand, Filterable {
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolver.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
+import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteOneCommand;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
@@ -12,6 +13,7 @@ import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
 import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
 import io.stargate.sgv2.jsonapi.service.resolver.model.impl.matcher.FilterableResolver;
+import io.stargate.sgv2.jsonapi.util.SortClauseUtil;
 import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -47,17 +49,35 @@ public class DeleteOneCommandResolver extends FilterableResolver<DeleteOneComman
 
   private FindOperation getFindOperation(CommandContext commandContext, DeleteOneCommand command) {
     List<DBFilterBase> filters = resolve(commandContext, command);
-    return new FindOperation(
-        commandContext,
-        filters,
-        DocumentProjector.identityProjector(),
-        null,
-        1,
-        1,
-        ReadType.KEY,
-        objectMapper,
-        null,
-        0,
-        0);
+    final SortClause sortClause = command.sortClause();
+    List<FindOperation.OrderBy> orderBy = SortClauseUtil.resolveOrderBy(sortClause);
+    // If orderBy present
+    if (orderBy != null) {
+      return FindOperation.sorted(
+          commandContext,
+          filters,
+          DocumentProjector.identityProjector(),
+          null,
+          1,
+          // For in memory sorting we read more data than needed, so defaultSortPageSize like 100
+          operationsConfig.defaultSortPageSize(),
+          ReadType.SORTED_DOCUMENT,
+          objectMapper,
+          orderBy,
+          0,
+          // For in memory sorting if no limit provided in the request will use
+          // documentConfig.defaultPageSize() as limit
+          operationsConfig.maxDocumentSortCount());
+    } else {
+      return FindOperation.unsorted(
+          commandContext,
+          filters,
+          DocumentProjector.identityProjector(),
+          null,
+          1,
+          1,
+          ReadType.KEY,
+          objectMapper);
+    }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
@@ -22,7 +22,6 @@ import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndUpdateCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.InsertManyCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.InsertOneCommand;
-import io.stargate.sgv2.jsonapi.api.model.command.impl.UpdateOneCommand;
 import java.util.List;
 import javax.inject.Inject;
 import org.assertj.core.api.Assertions;
@@ -172,38 +171,6 @@ class ObjectMapperConfigurationTest {
               createCollection -> {
                 String name = createCollection.name();
                 assertThat(name).isNotNull();
-              });
-    }
-  }
-
-  @Nested
-  class UpdateOne {
-    @Test
-    public void happyPath() throws Exception {
-      String json =
-          """
-          {
-            "updateOne": {
-                "filter" : {"username" : "update_user5"},
-                "update" : {"$set" : {"new_col": {"sub_doc_col" : "new_val2"}}},
-                "options" : {}
-              }
-          }
-          """;
-
-      Command result = objectMapper.readValue(json, Command.class);
-
-      assertThat(result)
-          .isInstanceOfSatisfying(
-              UpdateOneCommand.class,
-              updateOneCommand -> {
-                FilterClause filterClause = updateOneCommand.filterClause();
-                assertThat(filterClause).isNotNull();
-                final UpdateClause updateClause = updateOneCommand.updateClause();
-                assertThat(updateClause).isNotNull();
-                assertThat(updateClause.buildOperations()).hasSize(1);
-                final UpdateOneCommand.Options options = updateOneCommand.options();
-                assertThat(options).isNotNull();
               });
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolverTest.java
@@ -146,5 +146,51 @@ public class DeleteOneCommandResolverTest {
                         });
               });
     }
+
+    @Test
+    public void dynamicFilterConditionWithSort() throws Exception {
+      String json =
+          """
+                  {
+                    "deleteOne": {
+                      "filter" : {"col" : "val"},
+                      "sort" : {"sort_col" : 1}
+                    }
+                  }
+                  """;
+
+      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, deleteOneCommand);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              DeleteOperation.class,
+              op -> {
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.deleteLimit()).isEqualTo(1);
+                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
+                assertThat(op.findOperation())
+                    .isInstanceOfSatisfying(
+                        FindOperation.class,
+                        find -> {
+                          DBFilterBase.TextFilter filter =
+                              new DBFilterBase.TextFilter(
+                                  "col", DBFilterBase.MapFilterBase.Operator.EQ, "val");
+
+                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                          assertThat(find.commandContext()).isEqualTo(commandContext);
+                          assertThat(find.pageSize()).isEqualTo(100);
+                          assertThat(find.limit()).isEqualTo(1);
+                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
+                          assertThat(find.filters()).singleElement().isEqualTo(filter);
+                          assertThat(find.orderBy()).hasSize(1);
+                          assertThat(find.orderBy().get(0))
+                              .isEqualTo(new FindOperation.OrderBy("sort_col", true));
+                          assertThat(find.maxSortReadLimit())
+                              .isEqualTo(operationsConfig.maxDocumentSortCount());
+                        });
+              });
+    }
   }
 }


### PR DESCRIPTION
**What this PR does**:
Added sort option for `deleteOne` and `updateOne` command
**Which issue(s) this PR fixes**:
Fixes #396 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
