### PR TITLE
Fix #372: add tests to verify $date-value updates work as-is

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/UpdateClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/UpdateClauseDeserializerTest.java
@@ -123,5 +123,26 @@ public class UpdateClauseDeserializerTest {
       UpdateClause updateClause = objectMapper.readValue(json, UpdateClause.class);
       assertThat(updateClause.buildOperations()).hasSize(1).contains(operation);
     }
+
+    @Test
+    public void mustHandleDate() throws Exception {
+      String json =
+          """
+                {"$set" : {"dateType": {"$date": 123456}}}
+                """;
+      final UpdateOperation operation =
+          SetOperation.constructSet(
+              (ObjectNode)
+                  objectMapper.readTree(
+                      """
+                              {
+                                "dateType": {
+                                  "$date": 123456
+                                }
+                              }
+                              """));
+      UpdateClause updateClause = objectMapper.readValue(json, UpdateClause.class);
+      assertThat(updateClause.buildOperations()).hasSize(1).contains(operation);
+    }
   }
 }


### PR DESCRIPTION
**What this PR does**:

Adds tests (unit, integration) to verify that Date-valued fields can be updated.

**Which issue(s) this PR fixes**:
Fixes #372

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
