### PR TITLE
performance test workflow improvements

### DIFF
--- a/.github/workflows/performance-testing.yaml
+++ b/.github/workflows/performance-testing.yaml
@@ -59,6 +59,8 @@ jobs:
           - test: http-jsonapi-keyvalue
             keyspace: 'jsonapi_keyvalue'
 
+          - test: http-jsonapi-search-filter-sort
+            keyspace: 'jsonapi_keyvalue'
     steps:
       # force checkout of main branch so we get a SHA that will have a corresponding docker image tag in ECR
       - uses: actions/checkout@v3
@@ -114,9 +116,10 @@ jobs:
       # Run test after first obtaining an auth token
       - name: Run NoSQLBench Test
         run: |
+          DOCSCOUNT=${{ inputs.docscount != null && inputs.docscount || '1000000' }}          
+          CONNECTIONS=${{ inputs.connections != null && inputs.connections || '20' }}          
           cd nosqlbench
-          export AUTH_TOKEN=$(curl -s -X POST 'http://localhost:8081/v1/auth' -H 'Content-Type: application/json' --data-raw '{"username": "cassandra", "password": "cassandra"}' | jq -r '.authToken')
-          ../nb5 -v --report-csv-to logs --log-histograms logs/hdr_metrics.log ${{ matrix.test }} jsonapi_host=localhost auth_token=$AUTH_TOKEN docscount=${{ inputs.docscount }} connections=${{ inputs.connections }}
+          ../nb5 -v --report-csv-to logs --log-histograms logs/hdr_metrics.log ${{ matrix.test }} jsonapi_host=localhost docscount=$DOCSCOUNT connections=$CONNECTIONS
 
       # Simple approach measuring size of data directory
       - name: Collect Data Size Stats

--- a/.github/workflows/performance-testing.yaml
+++ b/.github/workflows/performance-testing.yaml
@@ -60,7 +60,7 @@ jobs:
             keyspace: 'jsonapi_keyvalue'
 
           - test: http-jsonapi-search-filter-sort
-            keyspace: 'jsonapi_keyvalue'
+            keyspace: 'jsonapi_search_filter_sort'
     steps:
       # force checkout of main branch so we get a SHA that will have a corresponding docker image tag in ECR
       - uses: actions/checkout@v3

--- a/.github/workflows/performance-testing.yaml
+++ b/.github/workflows/performance-testing.yaml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         type: [ java, native ]
 
-        test: [ http-jsonapi-crud-basic, http-jsonapi-keyvalue ]
+        test: [ http-jsonapi-crud-basic, http-jsonapi-keyvalue, http-jsonapi-search-filter-sort ]
 
         include:
           - type: java

--- a/nosqlbench/http-jsonapi-crud-basic.yaml
+++ b/nosqlbench/http-jsonapi-crud-basic.yaml
@@ -1,4 +1,4 @@
-min_version: "5.17.1"
+min_version: "5.17.3"
 
 # nb5 -v run driver=http yaml=http-jsonapi-crud-basic jsonapi_host=my_jsonapi_host auth_token=$AUTH_TOKEN
 

--- a/nosqlbench/http-jsonapi-crud-basic.yaml
+++ b/nosqlbench/http-jsonapi-crud-basic.yaml
@@ -1,6 +1,7 @@
 min_version: "5.17.3"
 
-# nb5 -v run driver=http yaml=http-jsonapi-crud-basic jsonapi_host=my_jsonapi_host auth_token=$AUTH_TOKEN
+# Example command line (when Stargate is running on localhost):
+# nb5 -v http-jsonapi-crud-basic jsonapi_host=localhost docscount=20000 threads=20
 
 description: >2
   This workload emulates CRUD operations for the Stargate JSON API.

--- a/nosqlbench/http-jsonapi-crud-dataset.yaml
+++ b/nosqlbench/http-jsonapi-crud-dataset.yaml
@@ -1,4 +1,4 @@
-min_version: "5.17.1"
+min_version: "5.17.3"
 
 description: >2
   This workload emulates CRUD operations for the Stargate Documents API.

--- a/nosqlbench/http-jsonapi-keyvalue.yaml
+++ b/nosqlbench/http-jsonapi-keyvalue.yaml
@@ -1,4 +1,4 @@
-min_version: "5.17.1"
+min_version: "5.17.3"
 
 description: >2
   This workload emulates a key-value data model and access patterns.

--- a/nosqlbench/http-jsonapi-keyvalue.yaml
+++ b/nosqlbench/http-jsonapi-keyvalue.yaml
@@ -1,5 +1,8 @@
 min_version: "5.17.3"
 
+# Example command line (when Stargate is running on localhost):
+# nb5 -v http-jsonapi-keyvalue jsonapi_host=localhost docscount=20000 threads=20
+
 description: >2
   This workload emulates a key-value data model and access patterns.
   This should be identical to the cql variant except for:

--- a/nosqlbench/http-jsonapi-search-advanced.yaml
+++ b/nosqlbench/http-jsonapi-search-advanced.yaml
@@ -21,19 +21,18 @@ description: >2
 # complex3: (match1 LTE 0 AND match2 EQ "true") OR (match2 EQ "false" AND match3 EQ true)
 scenarios:
   default:
-    schema:             run driver=http tags==phase:schema threads==<<threads:1>> cycles==UNDEF
-    rampup:
-      write:            run driver=http tags==name:"rampup-put.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) docpadding=TEMPLATE(docpadding,0) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
-      read:             run driver=http tags==phase:"rampup-get.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    main:
-      all:               run driver=http tags==block:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-      get-in:            run driver=http tags==name:main-get-in,filter:in cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-      get-not-in:        run driver=http tags==name:main-get-not-in cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-      get-mem-and:       run driver=http tags==name:main-get-mem-and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-      get-mem-or:        run driver=http tags==name:main-get-mem-or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-      get-complex1:      run driver=http tags==name:main-get-complex1 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-      get-complex2:      run driver=http tags==name:main-get-complex2 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-      get-complex3:      run driver=http tags==name:main-get-complex3 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    schema: run driver=http tags==phase:schema threads==<<threads:1>> cycles==UNDEF
+    rampup-write: run driver=http tags==name:"rampup-put.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) docpadding=TEMPLATE(docpadding,0) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
+    rampup-read: run driver=http tags==phase:"rampup-get.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    main: run driver=http tags==block:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  get:
+    get-in: run driver=http tags==name:main-get-in,filter:in cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-not-in:        run driver=http tags==name:main-get-not-in cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-mem-and:       run driver=http tags==name:main-get-mem-and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-mem-or:        run driver=http tags==name:main-get-mem-or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-complex1:      run driver=http tags==name:main-get-complex1 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-complex2:      run driver=http tags==name:main-get-complex2 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-complex3:      run driver=http tags==name:main-get-complex3 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
 
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer

--- a/nosqlbench/http-jsonapi-search-advanced.yaml
+++ b/nosqlbench/http-jsonapi-search-advanced.yaml
@@ -1,4 +1,4 @@
-min_version: "5.17.1"
+min_version: "5.17.3"
 
 description: >2
   This workload emulates advanced search filter combinations for the Stargate Documents API.

--- a/nosqlbench/http-jsonapi-search-advanced.yaml
+++ b/nosqlbench/http-jsonapi-search-advanced.yaml
@@ -21,18 +21,18 @@ description: >2
 # complex3: (match1 LTE 0 AND match2 EQ "true") OR (match2 EQ "false" AND match3 EQ true)
 scenarios:
   default:
-    schema: run driver=http tags==phase:schema threads==<<threads:1>> cycles==UNDEF
-    rampup-write: run driver=http tags==name:"rampup-put.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) docpadding=TEMPLATE(docpadding,0) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
-    rampup-read: run driver=http tags==phase:"rampup-get.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    schema: run driver=http tags==block:schema threads==<<threads:1>> cycles==UNDEF
+    rampup-write: run driver=http tags==name:"rampup--rampup-put.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) docpadding=TEMPLATE(docpadding,0) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
+    rampup-read: run driver=http tags==name:"rampup--rampup-get.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
     main: run driver=http tags==block:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
   get:
-    get-in: run driver=http tags==name:main-get-in,filter:in cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-not-in:        run driver=http tags==name:main-get-not-in cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-mem-and:       run driver=http tags==name:main-get-mem-and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-mem-or:        run driver=http tags==name:main-get-mem-or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-complex1:      run driver=http tags==name:main-get-complex1 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-complex2:      run driver=http tags==name:main-get-complex2 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-complex3:      run driver=http tags==name:main-get-complex3 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-in: run driver=http tags==name:main--main-get-in,filter:in cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-not-in: run driver=http tags==name:main--main-get-not-in cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-mem-and: run driver=http tags==name:main--main-get-mem-and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-mem-or: run driver=http tags==name:main--main-get-mem-or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-complex1: run driver=http tags==name:main--main-get-complex1 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-complex2: run driver=http tags==name:main--main-get-complex2 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-complex3: run driver=http tags==name:main--main-get-complex3 cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
 
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer

--- a/nosqlbench/http-jsonapi-search-advanced.yaml
+++ b/nosqlbench/http-jsonapi-search-advanced.yaml
@@ -1,5 +1,10 @@
 min_version: "5.17.3"
 
+# TODO: This workload relies on features that are not yet implemented in the JSON API
+
+# Example command line (when Stargate is running on localhost):
+# nb5 -v http-jsonapi-search-advanced jsonapi_host=localhost docscount=20000 threads=20
+
 description: >2
   This workload emulates advanced search filter combinations for the Stargate Documents API.
   During the rampup phase, it generates documents, writes them to a table, and then warms up the search paths.

--- a/nosqlbench/http-jsonapi-search-basic.yaml
+++ b/nosqlbench/http-jsonapi-search-basic.yaml
@@ -11,15 +11,15 @@ description: >2
 scenarios:
   default:
     schema: run driver=http tags==block:schema threads==<<threads:1>> cycles==UNDEF
-    rampup-write: run driver=http tags==block:"rampup-put.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) docpadding=TEMPLATE(docpadding,0) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
-    rampup-read: run driver=http tags==block:"rampup-get.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    rampup-write: run driver=http tags==name:"rampup--rampup-put.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) docpadding=TEMPLATE(docpadding,0) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
+    rampup-read: run driver=http tags==name:"rampup--rampup-get.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
     main: run driver=http tags==block:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
   get:
-    get-eq: run driver=http tags==block:main-get-eq,filter:eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-lt: run driver=http tags==block:main-get-lt cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-and: run driver=http tags==block:main-get-and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-or: run driver=http tags==block:main-get-or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-or-single-match: run driver=http tags==block:main-get-or-single-match cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-eq: run driver=http tags==name:main--main-get-eq,filter:eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-lt: run driver=http tags==name:main--main-get-lt cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-and: run driver=http tags==name:main--main-get-and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-or: run driver=http tags==name:main--main-get-or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-or-single-match: run driver=http tags==name:main--main-get-or-single-match cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
 
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer

--- a/nosqlbench/http-jsonapi-search-basic.yaml
+++ b/nosqlbench/http-jsonapi-search-basic.yaml
@@ -7,17 +7,18 @@ description: >2
   Note that jsonapi_port should reflect the port where the Docs API is exposed (defaults to 8181).
 
 scenarios:
-  schema: run driver=http tags==block:schema threads==<<threads:1>> cycles==UNDEF
-  rampup:
-    write: run driver=http tags==block:"rampup-put.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) docpadding=TEMPLATE(docpadding,0) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
-    read: run driver=http tags==block:"rampup-get.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-  main:
-    all: run driver=http tags==block:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-eq: run driver=http tags==block:main-get-eq,filter:eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-lt: run driver=http tags==block:main-get-lt cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-and: run driver=http tags==block:main-get-and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-or: run driver=http tags==block:main-get-or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    get-or-single-match: run driver=http tags==block:main-get-or-single-match cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  default:
+    schema: run driver=http tags==block:schema threads==<<threads:1>> cycles==UNDEF
+    rampup:
+      write: run driver=http tags==block:"rampup-put.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) docpadding=TEMPLATE(docpadding,0) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
+      read: run driver=http tags==block:"rampup-get.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    main:
+      all: run driver=http tags==block:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+      get-eq: run driver=http tags==block:main-get-eq,filter:eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+      get-lt: run driver=http tags==block:main-get-lt cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+      get-and: run driver=http tags==block:main-get-and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+      get-or: run driver=http tags==block:main-get-or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+      get-or-single-match: run driver=http tags==block:main-get-or-single-match cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
 
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer

--- a/nosqlbench/http-jsonapi-search-basic.yaml
+++ b/nosqlbench/http-jsonapi-search-basic.yaml
@@ -11,16 +11,15 @@ description: >2
 scenarios:
   default:
     schema: run driver=http tags==block:schema threads==<<threads:1>> cycles==UNDEF
-    rampup:
-      write: run driver=http tags==block:"rampup-put.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) docpadding=TEMPLATE(docpadding,0) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
-      read: run driver=http tags==block:"rampup-get.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-    main:
-      all: run driver=http tags==block:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-      get-eq: run driver=http tags==block:main-get-eq,filter:eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-      get-lt: run driver=http tags==block:main-get-lt cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-      get-and: run driver=http tags==block:main-get-and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-      get-or: run driver=http tags==block:main-get-or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
-      get-or-single-match: run driver=http tags==block:main-get-or-single-match cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    rampup-write: run driver=http tags==block:"rampup-put.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) docpadding=TEMPLATE(docpadding,0) match-ratio=TEMPLATE(match-ratio,0.01) threads=<<threads:auto>> errors=timer,warn
+    rampup-read: run driver=http tags==block:"rampup-get.*" cycles===TEMPLATE(rampup-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    main: run driver=http tags==block:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+  get:
+    get-eq: run driver=http tags==block:main-get-eq,filter:eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-lt: run driver=http tags==block:main-get-lt cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-and: run driver=http tags==block:main-get-and cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-or: run driver=http tags==block:main-get-or cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
+    get-or-single-match: run driver=http tags==block:main-get-or-single-match cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) page-size=TEMPLATE(page-size,3) fields=TEMPLATE(fields,%5b%5d) threads=<<threads:auto>> errors=timer,warn
 
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer

--- a/nosqlbench/http-jsonapi-search-basic.yaml
+++ b/nosqlbench/http-jsonapi-search-basic.yaml
@@ -1,5 +1,7 @@
 min_version: "5.17.3"
 
+# TODO: This workload relies on features that are not yet implemented in the JSON API
+
 description: >2
   This workload emulates basic search operations for the Stargate Documents API.
   During the rampup phase, it generates documents, writes them to a table, and then warms up the search paths.

--- a/nosqlbench/http-jsonapi-search-basic.yaml
+++ b/nosqlbench/http-jsonapi-search-basic.yaml
@@ -1,4 +1,4 @@
-min_version: "5.17.1"
+min_version: "5.17.3"
 
 description: >2
   This workload emulates basic search operations for the Stargate Documents API.

--- a/nosqlbench/http-jsonapi-search-filter-sort.yaml
+++ b/nosqlbench/http-jsonapi-search-filter-sort.yaml
@@ -1,6 +1,6 @@
 min_version: "5.17.3"
 
-# nb5 -v run driver=http yaml=http-jsonapi_crud_advanced jsonapi_host=my_jsonapi_host auth_token=$AUTH_TOKEN
+# nb5 -v run driver=http yaml=http-jsonapi_search_filter_sort jsonapi_host=my_jsonapi_host auth_token=$AUTH_TOKEN
 
 description: |
   This workload emulates search, filter and sort operations for the Stargate JSON API.
@@ -70,13 +70,13 @@ blocks:
         body: |
           {
             "createNamespace": {
-              "name": "<<namespace:jsonapi_crud_advanced>>"
+              "name": "<<namespace:jsonapi_search_filter_sort>>"
             }
           }
 
       delete-collection:
         method: POST
-        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_crud_advanced>>
+        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_search_filter_sort>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "{token}"
@@ -91,7 +91,7 @@ blocks:
 
       create-collection:
         method: POST
-        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_crud_advanced>>
+        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_search_filter_sort>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "{token}"
@@ -110,7 +110,7 @@ blocks:
       write-document:
         space: "{space}"
         method: POST
-        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_crud_advanced>>/<<collection:docs_collection>>
+        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_search_filter_sort>>/<<collection:docs_collection>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "{token}"
@@ -152,7 +152,7 @@ blocks:
       read:
         space: "{space}"
         method: POST
-        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_crud_advanced>>/<<collection:docs_collection>>
+        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_search_filter_sort>>/<<collection:docs_collection>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "{token}"
@@ -173,7 +173,7 @@ blocks:
       main-get-eq:
         space: "{space}"
         method: POST
-        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_crud_advanced>>/<<collection:docs_collection>>
+        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_search_filter_sort>>/<<collection:docs_collection>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "{token}"
@@ -190,7 +190,7 @@ blocks:
       main-get-multiple-condition:
         space: "{space}"
         method: POST
-        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_crud_advanced>>/<<collection:docs_collection>>
+        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_search_filter_sort>>/<<collection:docs_collection>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "{token}"
@@ -209,7 +209,7 @@ blocks:
       main-get-exists:
         space: "{space}"
         method: POST
-        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_crud_advanced>>/<<collection:docs_collection>>
+        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_search_filter_sort>>/<<collection:docs_collection>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "{token}"
@@ -226,7 +226,7 @@ blocks:
       main-get-size:
         space: "{space}"
         method: POST
-        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_crud_advanced>>/<<collection:docs_collection>>
+        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_search_filter_sort>>/<<collection:docs_collection>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "{token}"
@@ -244,7 +244,7 @@ blocks:
       main-get-sort:
         space: "{space}"
         method: POST
-        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_crud_advanced>>/<<collection:docs_collection>>
+        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_search_filter_sort>>/<<collection:docs_collection>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "{token}"
@@ -263,7 +263,7 @@ blocks:
       main-get-sort-options:
         space: "{space}"
         method: POST
-        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_crud_advanced>>/<<collection:docs_collection>>
+        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_search_filter_sort>>/<<collection:docs_collection>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "{token}"
@@ -283,7 +283,7 @@ blocks:
       main-get-projection:
         space: "{space}"
         method: POST
-        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_crud_advanced>>/<<collection:docs_collection>>
+        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_search_filter_sort>>/<<collection:docs_collection>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "{token}"
@@ -302,7 +302,7 @@ blocks:
       main-get-sort-projection:
         space: "{space}"
         method: POST
-        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_crud_advanced>>/<<collection:docs_collection>>
+        uri: <<protocol:http>>://{weighted_hosts}:<<jsonapi_port:8181>><<path_prefix:>>/v1/<<namespace:jsonapi_search_filter_sort>>/<<collection:docs_collection>>
         Accept: "application/json"
         X-Cassandra-Request-Id: "{request_id}"
         X-Cassandra-Token: "{token}"

--- a/nosqlbench/http-jsonapi-search-filter-sort.yaml
+++ b/nosqlbench/http-jsonapi-search-filter-sort.yaml
@@ -1,8 +1,9 @@
 min_version: "5.17.3"
 
-# nb5 -v run driver=http yaml=http-jsonapi_search_filter_sort jsonapi_host=my_jsonapi_host auth_token=$AUTH_TOKEN
+# Example command line (when Stargate is running on localhost):
+# nb5 -v http-jsonapi-search-filter-sort jsonapi_host=localhost docscount=20000 threads=20
 
-description: |
+description: >2
   This workload emulates search, filter and sort operations for the Stargate JSON API.
   It generates a simple JSON document to be used for writes and updates.
   During the main phase it performs various search filters and times their execution.
@@ -11,19 +12,18 @@ description: |
 scenarios:
   default:
     schema: run driver=http tags==block:schema threads==1 cycles==UNDEF
-    rampup:
-      write: run driver=http tags==name:"write.*" cycles===TEMPLATE(write-cycles,TEMPLATE(docscount,10000000)) threads=auto errors=timer,warn
-      read: run driver=http tags==block:read cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=auto errors=timer,warn
-    main:
-      all: run driver=http tags==block:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-      get-eq: run driver=http tags==name:main--main-get-eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-      get-multiple-condition: run driver=http tags==name:main--main-get-multiple-condition cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-      get-exists: run driver=http tags==name:main--main-get-exists cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-      get-size: run driver=http tags==name:main--main-get-size cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-      get-sort: run driver=http tags==name:main--main-get-sort cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-      get-sort-options: run driver=http tags==name:main--main-get-sort-options cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-      get-projection: run driver=http tags==name:main--main-get-projection cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-      get-sort-projection: run driver=http tags==name:main--main-get-sort-projection cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+    rampup-write: run driver=http tags==block:write cycles===TEMPLATE(write-cycles,TEMPLATE(docscount,10000000)) threads=auto errors=timer,warn
+    rampup-read: run driver=http tags==block:read cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=auto errors=timer,warn
+    main: run driver=http tags==block:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+  get:
+    get-eq: run driver=http tags==name:main--main-get-eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+    get-multiple-condition: run driver=http tags==name:main--main-get-multiple-condition cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+    get-exists: run driver=http tags==name:main--main-get-exists cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+    get-size: run driver=http tags==name:main--main-get-size cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+    get-sort: run driver=http tags==name:main--main-get-sort cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+    get-sort-options: run driver=http tags==name:main--main-get-sort-options cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+    get-projection: run driver=http tags==name:main--main-get-projection cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+    get-sort-projection: run driver=http tags==name:main--main-get-sort-projection cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
 
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer

--- a/nosqlbench/http-jsonapi-search-filter-sort.yaml
+++ b/nosqlbench/http-jsonapi-search-filter-sort.yaml
@@ -9,20 +9,21 @@ description: |
   Note that jsonapi_port should reflect the port where the JSON API is exposed (defaults to 8181).
 
 scenarios:
-  schema: run driver=http tags==block:schema threads==1 cycles==UNDEF
-  rampup:
-    write: run driver=http tags==name:"write.*" cycles===TEMPLATE(write-cycles,TEMPLATE(docscount,10000000)) threads=auto errors=timer,warn
-    read: run driver=http tags==block:read cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=auto errors=timer,warn
-  main:
-    all: run driver=http tags==block:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-    get-eq: run driver=http tags==name:main--main-get-eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-    get-multiple-condition: run driver=http tags==name:main--main-get-multiple-condition cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-    get-exists: run driver=http tags==name:main--main-get-exists cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-    get-size: run driver=http tags==name:main--main-get-size cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-    get-sort: run driver=http tags==name:main--main-get-sort cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-    get-sort-options: run driver=http tags==name:main--main-get-sort-options cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-    get-projection: run driver=http tags==name:main--main-get-projection cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
-    get-sort-projection: run driver=http tags==name:main--main-get-sort-projection cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+  default:
+    schema: run driver=http tags==block:schema threads==1 cycles==UNDEF
+    rampup:
+      write: run driver=http tags==name:"write.*" cycles===TEMPLATE(write-cycles,TEMPLATE(docscount,10000000)) threads=auto errors=timer,warn
+      read: run driver=http tags==block:read cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=auto errors=timer,warn
+    main:
+      all: run driver=http tags==block:main cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+      get-eq: run driver=http tags==name:main--main-get-eq cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+      get-multiple-condition: run driver=http tags==name:main--main-get-multiple-condition cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+      get-exists: run driver=http tags==name:main--main-get-exists cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+      get-size: run driver=http tags==name:main--main-get-size cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+      get-sort: run driver=http tags==name:main--main-get-sort cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+      get-sort-options: run driver=http tags==name:main--main-get-sort-options cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+      get-projection: run driver=http tags==name:main--main-get-projection cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
+      get-sort-projection: run driver=http tags==name:main--main-get-sort-projection cycles===TEMPLATE(read-cycles,TEMPLATE(docscount,10000000)) threads=<<threads:auto>> errors=timer,warn
 
 bindings:
   # To enable an optional weighted set of hosts in place of a load balancer


### PR DESCRIPTION
Scheduled runs of the performance test workflow do not run correctly due to malformed NoSQLBench command - `inputs` variable is only available for manually triggered workflows.

Also adding the `http_jsonapi_search_filter_sort` test to the list of tests to execute, and other minor improvements to workflows.
