### PR TITLE
Fix #395: verify that "no options" Commands are not given any options

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/NoOptionsCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/NoOptionsCommand.java
@@ -1,12 +1,27 @@
 package io.stargate.sgv2.jsonapi.api.model.command;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 
 /**
  * Interface that Commands that only take "empty" Command (that is, do not expose options but should
  * allow empty JSON Object nonetheless) should implement. <br>
  * NOTE: if {@code Command} starts accepting options, it should NO LONGER implement this interface
- * as combination will not work (options field will not be deserialized).
+ * as combination will probably not work.
  */
-@JsonIgnoreProperties({"options"})
-public interface NoOptionsCommand {}
+public interface NoOptionsCommand {
+  @JsonProperty("options")
+  default void setOptions(JsonNode value) throws JsonApiException {
+    // Empty JSON Object and null are accepted; anything else failure
+    if (value.isNull() || (value.isObject() && value.isEmpty())) {
+      return;
+    }
+    final String msg =
+        String.format(
+            "%s: %s",
+            ErrorCode.COMMAND_ACCEPTS_NO_OPTIONS.getMessage(), getClass().getSimpleName());
+    throw new JsonApiException(ErrorCode.COMMAND_ACCEPTS_NO_OPTIONS, msg);
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/NoOptionsCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/NoOptionsCommand.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.api.model.command;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 
@@ -11,6 +12,7 @@ import io.stargate.sgv2.jsonapi.exception.JsonApiException;
  * NOTE: if {@code Command} starts accepting options, it should NO LONGER implement this interface
  * as combination will probably not work.
  */
+@RegisterForReflection
 public interface NoOptionsCommand {
   @JsonProperty("options")
   default void setOptions(JsonNode value) throws JsonApiException {

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -6,6 +6,8 @@ public enum ErrorCode {
   /** Command error codes. */
   COMMAND_NOT_IMPLEMENTED("The provided command is not implemented."),
 
+  COMMAND_ACCEPTS_NO_OPTIONS("Command accepts no options"),
+
   CONCURRENCY_FAILURE("Unable to complete transaction due to concurrent transactions"),
 
   DATASET_TOO_BIG("Response data set too big to be sorted, add more filters"),

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -151,6 +152,36 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
           .body("data.document", is(not(nullValue())))
           .body("status", is(nullValue()))
           .body("errors", is(nullValue()));
+    }
+
+    @Test
+    public void noOptionsAllowed() {
+      String json =
+          """
+              {
+                "findOne": {
+                  "options": { "unknown":"value"}
+                }
+              }
+              """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.document", is(nullValue()))
+          .body("status", is(nullValue()))
+          .body("errors", is(notNullValue()))
+          .body("errors", hasSize(2))
+          .body("errors[0].message", is("Command accepts no options: FindOneCommand"))
+          .body("errors[0].exceptionClass", is("JsonMappingException"))
+          .body("errors[1].message", is("Command accepts no options: FindOneCommand"))
+          .body("errors[1].errorCode", is("COMMAND_ACCEPTS_NO_OPTIONS"))
+          .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -288,6 +288,39 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
     }
 
     @Test
+    public void noOptionsAllowed() {
+      String json =
+          """
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": "docWithOptions"
+                  },
+                  "options": {"setting":"abc"}
+                }
+              }
+              """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.document", is(nullValue()))
+          .body("status", is(nullValue()))
+          .body("errors", is(notNullValue()))
+          .body("errors", hasSize(2))
+          .body("errors[0].message", startsWith("Command accepts no options: InsertOneCommand"))
+          .body("errors[0].exceptionClass", is("JsonMappingException"))
+          .body("errors[1].message", startsWith("Command accepts no options: InsertOneCommand"))
+          .body("errors[1].errorCode", is("COMMAND_ACCEPTS_NO_OPTIONS"))
+          .body("errors[1].exceptionClass", is("JsonApiException"));
+    }
+
+    @Test
     public void insertDuplicateDocument() {
       String json =
           """

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneCommandResolverTest.java
@@ -1,9 +1,7 @@
 package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchException;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.Mock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -11,7 +9,6 @@ import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneCommand;
-import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
@@ -196,26 +193,6 @@ public class FindOneCommandResolverTest {
                 assertThat(op.filters()).singleElement().isEqualTo(filter);
                 assertThat(op.singleResponse()).isTrue();
               });
-    }
-
-    // Only "empty" Options allowed, nothing else
-    @Test
-    public void illegalFilterConditionEmptyOptions() throws Exception {
-      String json =
-          """
-              {
-                "findOne": {
-                    "options": {
-                        "noSuchOption": "value"
-                    }
-                }
-              }
-                """;
-
-      Exception e = catchException(() -> objectMapper.readValue(json, FindOneCommand.class));
-      assertThat(e)
-          .isInstanceOf(JsonMappingException.class)
-          .hasMessage(ErrorCode.COMMAND_ACCEPTS_NO_OPTIONS.getMessage() + ": FindOneCommand");
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneCommandResolverTest.java
@@ -1,7 +1,9 @@
 package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.Mock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -9,6 +11,7 @@ import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneCommand;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
@@ -34,12 +37,12 @@ public class FindOneCommandResolverTest {
     public void idFilterCondition() throws Exception {
       String json =
           """
-            {
-              "findOne": {
-                "filter" : {"_id" : "id"}
-              }
-            }
-            """;
+                          {
+                            "findOne": {
+                              "filter" : {"_id" : "id"}
+                            }
+                          }
+                          """;
 
       FindOneCommand command = objectMapper.readValue(json, FindOneCommand.class);
       Operation operation = resolver.resolveCommand(commandContext, command);
@@ -68,13 +71,13 @@ public class FindOneCommandResolverTest {
     public void filterConditionAndSort() throws Exception {
       String json =
           """
-            {
-              "findOne": {
-                "sort" : {"user.name" : 1, "user.age" : -1},
-                "filter" : {"status" : "active"}
-              }
-            }
-            """;
+                          {
+                            "findOne": {
+                              "sort" : {"user.name" : 1, "user.age" : -1},
+                              "filter" : {"status" : "active"}
+                            }
+                          }
+                          """;
 
       FindOneCommand command = objectMapper.readValue(json, FindOneCommand.class);
       Operation operation = resolver.resolveCommand(commandContext, command);
@@ -108,12 +111,41 @@ public class FindOneCommandResolverTest {
     public void noFilterCondition() throws Exception {
       String json =
           """
-            {
-              "findOne": {
+                          {
+                            "findOne": {
 
-              }
-            }
-            """;
+                            }
+                          }
+                          """;
+
+      FindOneCommand command = objectMapper.readValue(json, FindOneCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, command);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              FindOperation.class,
+              op -> {
+                assertThat(op.objectMapper()).isEqualTo(objectMapper);
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.limit()).isEqualTo(1);
+                assertThat(op.pageSize()).isEqualTo(1);
+                assertThat(op.pagingState()).isNull();
+                assertThat(op.readType()).isEqualTo(ReadType.DOCUMENT);
+                assertThat(op.filters()).isEmpty();
+                assertThat(op.singleResponse()).isTrue();
+              });
+    }
+
+    @Test
+    public void noFilterConditionEmptyOptions() throws Exception {
+      String json =
+          """
+                          {
+                            "findOne": {
+                                "options": { }
+                            }
+                          }
+                            """;
 
       FindOneCommand command = objectMapper.readValue(json, FindOneCommand.class);
       Operation operation = resolver.resolveCommand(commandContext, command);
@@ -137,12 +169,12 @@ public class FindOneCommandResolverTest {
     public void dynamicFilterCondition() throws Exception {
       String json =
           """
-            {
-              "findOne": {
-                "filter" : {"col" : "val"}
-              }
-            }
-            """;
+                          {
+                            "findOne": {
+                              "filter" : {"col" : "val"}
+                            }
+                          }
+                          """;
 
       FindOneCommand command = objectMapper.readValue(json, FindOneCommand.class);
       Operation operation = resolver.resolveCommand(commandContext, command);
@@ -164,6 +196,26 @@ public class FindOneCommandResolverTest {
                 assertThat(op.filters()).singleElement().isEqualTo(filter);
                 assertThat(op.singleResponse()).isTrue();
               });
+    }
+
+    // Only "empty" Options allowed, nothing else
+    @Test
+    public void illegalFilterConditionEmptyOptions() throws Exception {
+      String json =
+          """
+              {
+                "findOne": {
+                    "options": {
+                        "noSuchOption": "value"
+                    }
+                }
+              }
+                """;
+
+      Exception e = catchException(() -> objectMapper.readValue(json, FindOneCommand.class));
+      assertThat(e)
+          .isInstanceOf(JsonMappingException.class)
+          .hasMessage(ErrorCode.COMMAND_ACCEPTS_NO_OPTIONS.getMessage() + ": FindOneCommand");
     }
   }
 }


### PR DESCRIPTION
**What this PR does**:

Adds validation for `NoOptionsCommand` so that attempts to send options results in a failure

**Which issue(s) this PR fixes**:
Fixes #395

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
