### PR TITLE
closes #414: adapts java args for docker-comspose

### DIFF
--- a/docker-compose/docker-compose-dev-mode.yml
+++ b/docker-compose/docker-compose-dev-mode.yml
@@ -10,7 +10,7 @@ services:
       - "8081:8081"
     mem_limit: 2G
     environment:
-      - JAVA_OPTS="-Xmx2G"
+      - JAVA_OPTS="-Xmx1536M"
       - CLUSTER_NAME=dse-${DSETAG}-cluster
       - CLUSTER_VERSION=6.8
       - DSE=1
@@ -35,6 +35,9 @@ services:
       - "8181:8181"
     mem_limit: 2G
     environment:
+      - JAVA_MAX_MEM_RATIO=75
+      - JAVA_INITIAL_MEM_RATIO=50
+      - GC_CONTAINER_OPTIONS=-XX:+UseG1GC
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
       - QUARKUS_GRPC_CLIENTS_BRIDGE_PORT=8091
       - QUARKUS_HTTP_ACCESS_LOG_ENABLED=${REQUESTLOG}

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -7,8 +7,7 @@ services:
       - stargate
     mem_limit: 2G
     environment:
-      - HEAP_NEWSIZE=128M
-      - MAX_HEAP_SIZE=1024M
+      - MAX_HEAP_SIZE=1536M
       - CLUSTER_NAME=dse-${DSETAG}-cluster
       - DC=dc1
       - RACK=rack1
@@ -28,8 +27,7 @@ services:
       dse-1:
         condition: service_healthy
     environment:
-      - HEAP_NEWSIZE=128M
-      - MAX_HEAP_SIZE=1024M
+      - MAX_HEAP_SIZE=1536M
       - SEEDS=dse-1
       - CLUSTER_NAME=dse-${DSETAG}-cluster
       - DC=dc1
@@ -50,8 +48,7 @@ services:
       dse-2:
         condition: service_healthy
     environment:
-      - HEAP_NEWSIZE=128M
-      - MAX_HEAP_SIZE=1024M
+      - MAX_HEAP_SIZE=1536M
       - SEEDS=dse-1
       - CLUSTER_NAME=dse-${DSETAG}-cluster
       - DC=dc1
@@ -74,7 +71,7 @@ services:
       - "8081:8081"
     mem_limit: 2G
     environment:
-      - JAVA_OPTS="-Xmx2G"
+      - JAVA_OPTS="-Xmx1536M"
       - CLUSTER_NAME=dse-${DSETAG}-cluster
       - CLUSTER_VERSION=6.8
       - DSE=1
@@ -99,6 +96,9 @@ services:
       - "8181:8181"
     mem_limit: 2G
     environment:
+      - JAVA_MAX_MEM_RATIO=75
+      - JAVA_INITIAL_MEM_RATIO=50
+      - GC_CONTAINER_OPTIONS=-XX:+UseG1GC
       - QUARKUS_GRPC_CLIENTS_BRIDGE_HOST=coordinator
       - QUARKUS_GRPC_CLIENTS_BRIDGE_PORT=8091
       - QUARKUS_HTTP_ACCESS_LOG_ENABLED=${REQUESTLOG}


### PR DESCRIPTION
**What this PR does**:
Fixes memory java args in the docker-compose files:

* remove low new heap size for the dse
* set reasonable heap maximum sizes for all JVMs on a 2G container mem limit

After updates:

#### DSE
> -XX:+AlwaysPreTouch -XX:CICompilerCount=4 -XX:CompileCommandFile=/opt/dse/resources/cassandra/conf/hotspot_compiler -XX:ConcGCThreads=3 -XX:+DebugNonSafepoints -XX:G1HeapRegionSize=1048576 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:GCLogFileSize=10485760 -XX:GuaranteedSafepointInterval=300000 -XX:+HeapDumpOnOutOfMemoryError -XX:InitialHeapSize=1610612736 -XX:+ManagementServer -XX:MarkStackSize=4194304 -XX:MaxDirectMemorySize=15892217856 -XX:MaxGCPauseMillis=500 -XX:MaxHeapSize=1610612736 -XX:MaxNewSize=965738496 -XX:MinHeapDeltaBytes=1048576 -XX:NumberOfGCLogFiles=10 -XX:OnOutOfMemoryError=kill -9 %p -XX:+ParallelRefProcEnabled -XX:+PrintGC -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintHeapAtGC -XX:+PrintPromotionFailure -XX:+PrintTenuringDistribution -XX:+ResizeTLAB -XX:-RestrictContended -XX:StringTableSize=1000003 -XX:ThreadPriorityPolicy=42 -XX:ThreadStackSize=256 -XX:+UnlockDiagnosticVMOptions -XX:-UseBiasedLocking -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseG1GC -XX:+UseGCLogFileRotation -XX:-UseNUMA -XX:+UseTLAB -XX:+UseThreadPriorities

#### Coordinator
> java -server -Xmx1536M -Dcassandra.libjemalloc=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 -Dstargate.libdir=./stargate-lib -Djava.awt.headless=true -jar ./stargate-lib/stargate-starter-2.0.12.jar --cluster-name dse-6.8.34-cluster --cluster-version 6.8 --listen 192.168.48.2 --dc dc1 --rack rack1 --dse --enable-auth --developer-mode


#### JSON API
> -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Xms768m -Xmx1536m -XX:+UseG1GC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError 


**Which issue(s) this PR fixes**:
Fixes #414


