### PR TITLE
Count operation - fix to use count(1) instead of count("key") 

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/CountOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/CountOperation.java
@@ -35,7 +35,7 @@ public record CountOperation(CommandContext commandContext, List<DBFilterBase> f
     }
     return new QueryBuilder()
         .select()
-        .count("key")
+        .count()
         .as("count")
         .from(commandContext.namespace(), commandContext.collection())
         .where(conditions)

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
@@ -39,7 +39,7 @@ public class CountOperationTest extends AbstractValidatingStargateBridgeTest {
     @Test
     public void countWithNoFilter() {
       String collectionReadCql =
-          "SELECT COUNT(key) AS count FROM \"%s\".\"%s\"".formatted(KEYSPACE_NAME, COLLECTION_NAME);
+          "SELECT COUNT(1) AS count FROM \"%s\".\"%s\"".formatted(KEYSPACE_NAME, COLLECTION_NAME);
 
       ValidatingStargateBridge.QueryAssert candidatesAssert =
           withQuery(collectionReadCql)
@@ -77,7 +77,7 @@ public class CountOperationTest extends AbstractValidatingStargateBridgeTest {
     @Test
     public void countWithDynamic() {
       String collectionReadCql =
-          "SELECT COUNT(key) AS count FROM \"%s\".\"%s\" WHERE array_contains CONTAINS ?"
+          "SELECT COUNT(1) AS count FROM \"%s\".\"%s\" WHERE array_contains CONTAINS ?"
               .formatted(KEYSPACE_NAME, COLLECTION_NAME);
 
       ValidatingStargateBridge.QueryAssert candidatesAssert =
@@ -123,7 +123,7 @@ public class CountOperationTest extends AbstractValidatingStargateBridgeTest {
     @Test
     public void countWithDynamicNoMatch() {
       String collectionReadCql =
-          "SELECT COUNT(key) AS count FROM \"%s\".\"%s\" WHERE array_contains CONTAINS ?"
+          "SELECT COUNT(1) AS count FROM \"%s\".\"%s\" WHERE array_contains CONTAINS ?"
               .formatted(KEYSPACE_NAME, COLLECTION_NAME);
 
       ValidatingStargateBridge.QueryAssert candidatesAssert =
@@ -172,7 +172,7 @@ public class CountOperationTest extends AbstractValidatingStargateBridgeTest {
       RuntimeException failure = new RuntimeException("Ivan fails the test.");
 
       String collectionReadCql =
-          "SELECT COUNT(key) AS count FROM \"%s\".\"%s\"".formatted(KEYSPACE_NAME, COLLECTION_NAME);
+          "SELECT COUNT(1) AS count FROM \"%s\".\"%s\"".formatted(KEYSPACE_NAME, COLLECTION_NAME);
 
       ValidatingStargateBridge.QueryAssert candidatesAssert =
           withQuery(collectionReadCql)


### PR DESCRIPTION

**What this PR does**:
Count operation - fix to use count(1) instead of count("key") 
**Which issue(s) this PR fixes**:
Fixes #424 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
