### PR TITLE
Fix #408: validate characters of document field names

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
@@ -1,12 +1,18 @@
 package io.stargate.sgv2.jsonapi.config.constants;
 
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.JsonType;
+import java.util.regex.Pattern;
 
 public interface DocumentConstants {
   /** Names of "special" fields in Documents */
   interface Fields {
     /** Primary key for Documents stored; has special handling for many operations. */
     String DOC_ID = "_id";
+
+    // Current definition of valid JSON API names: note that this only validates
+    // characters, not length limits (nor empty nor "too long" allowed but validated
+    // separately)
+    Pattern VALID_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_]*");
   }
 
   interface KeyTypeId {

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -37,6 +37,8 @@ public enum ErrorCode {
 
   SHRED_DOC_LIMIT_VIOLATION("Document size limitation violated"),
 
+  SHRED_DOC_KEY_NAME_VIOLATION("Document key name constraints violated"),
+
   SHRED_BAD_EJSON_VALUE("Bad EJSON value"),
 
   INVALID_FILTER_EXPRESSION("Invalid filter expression"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -248,7 +248,7 @@ public class Shredder {
     if (!DocumentConstants.Fields.VALID_NAME_PATTERN.matcher(key).matches()) {
       // Special names are accepted in some cases: for now only one such case for
       // Date values -- if more needed, will refactor. But for now inline:
-      if (JsonUtil.EJSON_VALUE_KEY_DATE.equals(key) && value.isIntegralNumber()) {
+      if (JsonUtil.EJSON_VALUE_KEY_DATE.equals(key) && value.isValueNode()) {
         ; // Fine, looks like legit Date value
       } else {
         throw new JsonApiException(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -229,17 +229,27 @@ public class Shredder {
     var it = objectValue.fields();
     while (it.hasNext()) {
       var entry = it.next();
-      final String key = entry.getKey();
-      if (key.length() > documentLimits.maxPropertyNameLength()) {
-        throw new JsonApiException(
-            ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-            String.format(
-                "%s: Property name length (%d) exceeds maximum allowed (%s)",
-                ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-                key.length(),
-                limits.maxPropertyNameLength()));
-      }
+      validateObjectKey(limits, entry.getKey());
       validateDocValue(limits, entry.getValue(), depth);
+    }
+  }
+
+  private void validateObjectKey(DocumentLimitsConfig limits, String key) {
+    if (key.length() > documentLimits.maxPropertyNameLength()) {
+      throw new JsonApiException(
+          ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
+          String.format(
+              "%s: Property name length (%d) exceeds maximum allowed (%s)",
+              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
+              key.length(),
+              limits.maxPropertyNameLength()));
+    }
+    if (!DocumentConstants.Fields.VALID_NAME_PATTERN.matcher(key).matches()) {
+      throw new JsonApiException(
+          ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION,
+          String.format(
+              "%s: Property name ('%s') contains character(s) not allowed",
+              ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION.getMessage(), key));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -16,6 +16,8 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @QuarkusTest
 @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
@@ -205,11 +207,11 @@ public class ShredderDocLimitsTest {
                   + ")");
     }
 
-    @Test
-    public void catchInvalidNames() {
+    @ParameterizedTest
+    @ValueSource(strings = {"$function", "dot.ted", "index[1]"})
+    public void catchInvalidFieldName(String invalidName) {
       final ObjectNode doc = objectMapper.createObjectNode();
       doc.put("_id", 123);
-      final String invalidName = "$date"; // property names must not start with $
       doc.put(invalidName, 123456);
 
       Exception e = catchException(() -> shredder.shred(doc));
@@ -219,7 +221,9 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              "Document key name constraints violated: Property name ('$date') contains character(s) not allowed");
+              "Document key name constraints violated: Property name ('"
+                  + invalidName
+                  + "') contains character(s) not allowed");
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
@@ -43,7 +43,7 @@ public class ShredderTest {
                       { "_id" : "abc",
                         "name" : "Bob",
                         "values" : [ 1, 2 ],
-                        "[extra.stuff]" : true,
+                        "extra_stuff" : true,
                         "nullable" : null
                       }
                       """;
@@ -57,7 +57,7 @@ public class ShredderTest {
               JsonPath.from("values"),
               JsonPath.from("values.0", true),
               JsonPath.from("values.1", true),
-              JsonPath.from("[extra.stuff]"),
+              JsonPath.from("extra_stuff"),
               JsonPath.from("nullable"));
 
       // First verify paths
@@ -76,7 +76,7 @@ public class ShredderTest {
               "name SBob",
               "values N1",
               "values N2",
-              "[extra.stuff] B1",
+              "extra_stuff B1",
               "nullable Z",
               "values.0 N1",
               "values.1 N2");
@@ -90,7 +90,7 @@ public class ShredderTest {
 
       // Then atomic value containers
       assertThat(doc.queryBoolValues())
-          .isEqualTo(Collections.singletonMap(JsonPath.from("[extra.stuff]"), Boolean.TRUE));
+          .isEqualTo(Collections.singletonMap(JsonPath.from("extra_stuff"), Boolean.TRUE));
       Map<JsonPath, BigDecimal> expNums = new LinkedHashMap<>();
       expNums.put(JsonPath.from("values.0", true), BigDecimal.valueOf(1));
       expNums.put(JsonPath.from("values.1", true), BigDecimal.valueOf(2));
@@ -271,8 +271,8 @@ public class ShredderTest {
 
       assertThat(t)
           .isNotNull()
-          .hasMessage("Bad EJSON value: unrecognized type '$unknownType' (path 'value')")
-          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_EJSON_VALUE);
+          .hasMessageStartingWith("Document key name constraints violated")
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION);
     }
   }
 


### PR DESCRIPTION
**What this PR does**:

Adds simple regexp-based validation for field names of document, enforced during shredding

**Which issue(s) this PR fixes**:
Fixes #408

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
