### PR TITLE
Add logs to json api

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/QueryExecutor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/QueryExecutor.java
@@ -11,10 +11,12 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Base64;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ApplicationScoped
 public class QueryExecutor {
-
+  private static final Logger logger = LoggerFactory.getLogger(QueryExecutor.class);
   private final QueriesConfig queriesConfig;
 
   private final StargateRequestInfo stargateRequestInfo;
@@ -96,6 +98,11 @@ public class QueryExecutor {
             response -> {
               QueryOuterClass.ResultSet resultSet = response.getResultSet();
               return resultSet;
+            })
+        .onFailure()
+        .invoke(
+            failure -> {
+              logger.error("Error on bridge ", failure);
             });
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/CommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/CommandProcessor.java
@@ -12,6 +12,8 @@ import io.stargate.sgv2.jsonapi.service.resolver.CommandResolverService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Processes valid document {@link Command} to read, write, schema change, etc. This is a single
@@ -24,6 +26,8 @@ import java.util.function.Supplier;
  */
 @ApplicationScoped
 public class CommandProcessor {
+
+  private static Logger logger = LoggerFactory.getLogger(CommandProcessor.class);
 
   private final QueryExecutor queryExecutor;
 
@@ -62,6 +66,8 @@ public class CommandProcessor {
         .onFailure()
         .recoverWithItem(
             t -> {
+              logger.warn(
+                  "The command {} failed with exception", command.getClass().getSimpleName(), t);
               // DocsException is supplier of the CommandResult
               // so simply return
               if (t instanceof JsonApiException jsonApiException) {


### PR DESCRIPTION
**What this PR does**:
Added few error and warn logs in Json API.
If request-response need to be printed for debugging it can be done with adding env arguments provided by Quarkus.

**Which issue(s) this PR fixes**:
Fixes #404 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
