### PR TITLE
Refactored FindOperation constructor usage

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
@@ -90,21 +90,15 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(true))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.IDFilter(
                       DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"))),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
+
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 3);
       Supplier<CommandResult> execute =
           operation
@@ -168,21 +162,15 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(true))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.IDFilter(
                       DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"))),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
+
       DeleteOperation operation =
           DeleteOperation.deleteOneAndReturn(
               COMMAND_CONTEXT, findOperation, 3, DocumentProjector.identityProjector());
@@ -287,21 +275,19 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(true))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.sortedSingle(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.TextFilter(
                       "status", DBFilterBase.MapFilterBase.Operator.EQ, "active")),
               DocumentProjector.identityProjector(),
-              null,
-              1,
               2,
               ReadType.SORTED_DOCUMENT,
               objectMapper,
               List.of(new FindOperation.OrderBy("username", true)),
               0,
-              3,
-              false);
+              3);
+
       DeleteOperation operation =
           DeleteOperation.deleteOneAndReturn(
               COMMAND_CONTEXT, findOperation, 3, DocumentProjector.identityProjector());
@@ -405,21 +391,19 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(true))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.sortedSingle(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.TextFilter(
                       "status", DBFilterBase.MapFilterBase.Operator.EQ, "active")),
               DocumentProjector.identityProjector(),
-              null,
-              1,
               2,
               ReadType.SORTED_DOCUMENT,
               objectMapper,
               List.of(new FindOperation.OrderBy("username", false)),
               0,
-              3,
-              false);
+              3);
+
       DeleteOperation operation =
           DeleteOperation.deleteOneAndReturn(
               COMMAND_CONTEXT, findOperation, 3, DocumentProjector.identityProjector());
@@ -465,21 +449,14 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of());
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.IDFilter(
                       DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"))),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 3);
       Supplier<CommandResult> execute =
@@ -540,21 +517,14 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(true))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 3);
 
       Supplier<CommandResult> execute =
@@ -653,21 +623,14 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(true))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 2);
 
       Supplier<CommandResult> execute =
@@ -768,21 +731,14 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(false))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 2);
 
       Supplier<CommandResult> execute =
@@ -877,21 +833,14 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(false))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 2);
 
       Supplier<CommandResult> execute =
@@ -969,7 +918,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(true))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.TextFilter(
@@ -979,11 +928,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               3,
               2,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 2, 3);
 
       Supplier<CommandResult> execute =
@@ -1059,7 +1004,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(true))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.TextFilter(
@@ -1069,11 +1014,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               3,
               1,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 2, 3);
 
       Supplier<CommandResult> execute =
@@ -1155,7 +1096,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(true))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.TextFilter(
@@ -1165,11 +1106,8 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               3,
               1,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
+
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 2, 3);
 
       Supplier<CommandResult> execute =
@@ -1220,21 +1158,15 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of());
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.TextFilter(
                       "username", DBFilterBase.MapFilterBase.Operator.EQ, "user1")),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
+
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 3);
 
       Supplier<CommandResult> execute =
@@ -1348,7 +1280,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(false))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.TextFilter(
@@ -1358,11 +1290,8 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               3,
               3,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
+
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 2, 3);
 
       Supplier<CommandResult> execute =
@@ -1527,7 +1456,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               .returning(List.of(List.of(Values.of(false))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.TextFilter(
@@ -1537,11 +1466,8 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
               3,
               3,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
+
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 2, 3);
 
       Supplier<CommandResult> execute =

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -99,7 +99,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                           Values.of(doc2))));
 
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(),
               DocumentProjector.identityProjector(),
@@ -107,11 +107,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               20,
               20,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -215,7 +211,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               DBFilterBase.IDFilter.Operator.IN,
               List.of(DocumentId.fromString("doc1"), DocumentId.fromString("doc2")));
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
@@ -223,11 +219,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               2,
               2,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -254,7 +246,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
       DBFilterBase.IDFilter filter =
           new DBFilterBase.IDFilter(DBFilterBase.IDFilter.Operator.IN, List.of());
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
@@ -262,11 +254,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               2,
               2,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -369,7 +357,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
       DBFilterBase.TextFilter textFilter =
           new DBFilterBase.TextFilter("username", DBFilterBase.TextFilter.Operator.EQ, "user1");
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(filter, textFilter),
               DocumentProjector.identityProjector(),
@@ -377,11 +365,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               2,
               2,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -485,7 +469,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               DBFilterBase.IDFilter.Operator.IN,
               List.of(DocumentId.fromString("doc1"), DocumentId.fromString("doc2")));
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
@@ -493,11 +477,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               1,
               2,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -564,19 +544,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -630,7 +603,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
@@ -638,11 +611,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               1,
               1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -706,19 +675,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
       DBFilterBase.TextFilter filter =
           new DBFilterBase.TextFilter("username", DBFilterBase.MapFilterBase.Operator.EQ, "user1");
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -786,19 +748,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           new DBFilterBase.BoolFilter(
               "registration_active", DBFilterBase.MapFilterBase.Operator.EQ, true);
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -869,19 +824,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           new DBFilterBase.DateFilter(
               "date_field", DBFilterBase.MapFilterBase.Operator.EQ, new Date(1672531200000L));
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -945,19 +893,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
 
       DBFilterBase.ExistsFilter filter = new DBFilterBase.ExistsFilter("registration_active", true);
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -1025,19 +966,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               new DBFilterBase.AllFilter(new DocValueHasher(), "tags", "tag1"),
               new DBFilterBase.AllFilter(new DocValueHasher(), "tags", "tag2"));
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               filters,
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -1102,7 +1036,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
 
       DBFilterBase.SizeFilter filter = new DBFilterBase.SizeFilter("tags", 2);
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
@@ -1110,11 +1044,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               1,
               1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -1181,19 +1111,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
       DBFilterBase.ArrayEqualsFilter filter =
           new DBFilterBase.ArrayEqualsFilter(new DocValueHasher(), "tags", List.of("tag1", "tag2"));
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -1261,19 +1184,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           new DBFilterBase.SubDocEqualsFilter(
               new DocValueHasher(), "sub_doc", Map.of("col", "val"));
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Supplier<CommandResult> execute =
           operation
@@ -1332,19 +1248,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation operation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       Throwable failure =
           operation
@@ -1516,7 +1425,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                           Values.NULL)));
 
       FindOperation operation =
-          new FindOperation(
+          FindOperation.sorted(
               COMMAND_CONTEXT,
               List.of(),
               DocumentProjector.identityProjector(),
@@ -1527,8 +1436,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               objectMapper,
               List.of(new FindOperation.OrderBy("username", true)),
               0,
-              20,
-              false);
+              20);
 
       Supplier<CommandResult> execute =
           operation
@@ -1730,7 +1638,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                           Values.of(1672531600000L))));
 
       FindOperation operation =
-          new FindOperation(
+          FindOperation.sorted(
               COMMAND_CONTEXT,
               List.of(),
               DocumentProjector.identityProjector(),
@@ -1741,8 +1649,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               objectMapper,
               List.of(new FindOperation.OrderBy("sort_date", true)),
               0,
-              20,
-              false);
+              20);
 
       Supplier<CommandResult> execute =
           operation
@@ -1925,7 +1832,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                           Values.NULL)));
 
       FindOperation operation =
-          new FindOperation(
+          FindOperation.sorted(
               COMMAND_CONTEXT,
               List.of(),
               DocumentProjector.identityProjector(),
@@ -1936,8 +1843,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               objectMapper,
               List.of(new FindOperation.OrderBy("username", true)),
               5,
-              20,
-              false);
+              20);
 
       Supplier<CommandResult> execute =
           operation
@@ -2118,7 +2024,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                           Values.NULL)));
 
       FindOperation operation =
-          new FindOperation(
+          FindOperation.sorted(
               COMMAND_CONTEXT,
               List.of(),
               DocumentProjector.identityProjector(),
@@ -2129,8 +2035,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
               objectMapper,
               List.of(new FindOperation.OrderBy("username", false)),
               0,
-              20,
-              false);
+              20);
 
       Supplier<CommandResult> execute =
           operation
@@ -2208,19 +2113,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       ReadOperation.FindResponse result =
           findOperation
@@ -2284,19 +2182,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       ReadOperation.FindResponse result =
           findOperation
@@ -2358,19 +2249,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
       DBFilterBase.TextFilter filter =
           new DBFilterBase.TextFilter("username", DBFilterBase.MapFilterBase.Operator.EQ, "user1");
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       ReadOperation.FindResponse result =
           findOperation
@@ -2434,19 +2318,12 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
       DBFilterBase.TextFilter filter =
           new DBFilterBase.TextFilter("username", DBFilterBase.MapFilterBase.Operator.EQ, "user1");
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
 
       DBFilterBase.IDFilter idFilter =
           new DBFilterBase.IDFilter(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
@@ -224,19 +224,13 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
     DBFilterBase.TextFilter filter =
         new DBFilterBase.TextFilter("username", DBFilterBase.MapFilterBase.Operator.EQ, "user1");
     FindOperation findOperation =
-        new FindOperation(
+        FindOperation.unsortedSingle(
             COMMAND_CONTEXT,
             List.of(filter),
             DocumentProjector.identityProjector(),
-            null,
-            1,
-            1,
             ReadType.DOCUMENT,
-            objectMapper,
-            null,
-            0,
-            0,
-            false);
+            objectMapper);
+
     DocumentUpdater documentUpdater =
         DocumentUpdater.construct(
             DocumentUpdaterUtils.updateClause(
@@ -430,19 +424,12 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
     DBFilterBase.TextFilter filter =
         new DBFilterBase.TextFilter("username", DBFilterBase.MapFilterBase.Operator.EQ, "user1");
     FindOperation findOperation =
-        new FindOperation(
+        FindOperation.unsortedSingle(
             COMMAND_CONTEXT,
             List.of(filter),
             DocumentProjector.identityProjector(),
-            null,
-            1,
-            1,
             ReadType.DOCUMENT,
-            objectMapper,
-            null,
-            0,
-            0,
-            false);
+            objectMapper);
     DocumentUpdater documentUpdater =
         DocumentUpdater.construct(
             DocumentUpdaterUtils.updateClause(
@@ -645,19 +632,12 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
     DBFilterBase.TextFilter filter =
         new DBFilterBase.TextFilter("username", DBFilterBase.MapFilterBase.Operator.EQ, "user1");
     FindOperation findOperation =
-        new FindOperation(
+        FindOperation.unsortedSingle(
             COMMAND_CONTEXT,
             List.of(filter),
             DocumentProjector.identityProjector(),
-            null,
-            1,
-            1,
             ReadType.DOCUMENT,
-            objectMapper,
-            null,
-            0,
-            0,
-            false);
+            objectMapper);
     DocumentUpdater documentUpdater =
         DocumentUpdater.construct(
             DocumentUpdaterUtils.updateClause(
@@ -921,7 +901,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
     DBFilterBase.TextFilter filter =
         new DBFilterBase.TextFilter("status", DBFilterBase.MapFilterBase.Operator.EQ, "active");
     FindOperation findOperation =
-        new FindOperation(
+        FindOperation.unsorted(
             COMMAND_CONTEXT,
             List.of(filter),
             DocumentProjector.identityProjector(),
@@ -929,11 +909,8 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
             3,
             3,
             ReadType.DOCUMENT,
-            objectMapper,
-            null,
-            0,
-            0,
-            false);
+            objectMapper);
+
     DocumentUpdater documentUpdater =
         DocumentUpdater.construct(
             DocumentUpdaterUtils.updateClause(
@@ -1258,7 +1235,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
     DBFilterBase.TextFilter filter =
         new DBFilterBase.TextFilter("status", DBFilterBase.MapFilterBase.Operator.EQ, "active");
     FindOperation findOperation =
-        new FindOperation(
+        FindOperation.unsorted(
             COMMAND_CONTEXT,
             List.of(filter),
             DocumentProjector.identityProjector(),
@@ -1266,11 +1243,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
             3,
             3,
             ReadType.DOCUMENT,
-            objectMapper,
-            null,
-            0,
-            0,
-            false);
+            objectMapper);
     DocumentUpdater documentUpdater =
         DocumentUpdater.construct(
             DocumentUpdaterUtils.updateClause(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -166,19 +166,13 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
+
       String updateClause =
           """
                    { "$set" : { "name" : "test", "date_val" : {"$date": 1672531200000 } }}
@@ -270,19 +264,13 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
+
       String updateClause =
           """
                        { "$set" : { "username" : "user1" }}
@@ -461,7 +449,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
       DBFilterBase.TextFilter filter =
           new DBFilterBase.TextFilter("filter_me", DBFilterBase.MapFilterBase.Operator.EQ, "happy");
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.sorted(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
@@ -472,8 +460,8 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
               objectMapper,
               List.of(new FindOperation.OrderBy("username", true)),
               0,
-              10000,
-              false);
+              10000);
+
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(
@@ -608,19 +596,13 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
+
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct((ObjectNode) objectMapper.readTree(replacement));
       ReadAndUpdateOperation operation =
@@ -738,19 +720,12 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct((ObjectNode) objectMapper.readTree(replacement));
       ReadAndUpdateOperation operation =
@@ -935,19 +910,16 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
       DBFilterBase.TextFilter filter =
           new DBFilterBase.TextFilter("filter_me", DBFilterBase.MapFilterBase.Operator.EQ, "happy");
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.sortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
               100,
               ReadType.SORTED_DOCUMENT,
               objectMapper,
               List.of(new FindOperation.OrderBy("username", true)),
               0,
-              10000,
-              false);
+              10000);
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct((ObjectNode) objectMapper.readTree(replacement));
       ReadAndUpdateOperation operation =
@@ -1122,19 +1094,17 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
       DBFilterBase.TextFilter filter =
           new DBFilterBase.TextFilter("filter_me", DBFilterBase.MapFilterBase.Operator.EQ, "happy");
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.sortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
               100,
               ReadType.SORTED_DOCUMENT,
               objectMapper,
               List.of(new FindOperation.OrderBy("username", false)),
               0,
-              10000,
-              false);
+              10000);
+
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(
@@ -1248,19 +1218,13 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
+
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(
@@ -1332,19 +1296,12 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(
@@ -1538,7 +1495,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
       DBFilterBase.TextFilter filter =
           new DBFilterBase.TextFilter("status", DBFilterBase.MapFilterBase.Operator.EQ, "active");
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
@@ -1546,11 +1503,8 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
               21,
               20,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
+
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(
@@ -1665,7 +1619,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
@@ -1673,11 +1627,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
               21,
               20,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(
@@ -1745,7 +1695,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
       DBFilterBase.TextFilter filter =
           new DBFilterBase.TextFilter("status", DBFilterBase.MapFilterBase.Operator.EQ, "active");
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsorted(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
@@ -1753,11 +1703,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
               21,
               20,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
@@ -107,21 +107,14 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
               .returning(List.of(List.of(Values.of(true))));
 
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(
                   new DBFilterBase.IDFilter(
                       DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"))),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.KEY,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
       DeleteOperation operation = DeleteOperation.delete(COMMAND_CONTEXT, findOperation, 1, 3);
       Supplier<CommandResult> execute =
           operation
@@ -334,19 +327,12 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
           new DBFilterBase.IDFilter(
               DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("doc1"));
       FindOperation findOperation =
-          new FindOperation(
+          FindOperation.unsortedSingle(
               COMMAND_CONTEXT,
               List.of(filter),
               DocumentProjector.identityProjector(),
-              null,
-              1,
-              1,
               ReadType.DOCUMENT,
-              objectMapper,
-              null,
-              0,
-              0,
-              false);
+              objectMapper);
       DocumentUpdater documentUpdater =
           DocumentUpdater.construct(
               DocumentUpdaterUtils.updateClause(


### PR DESCRIPTION
**What this PR does**:
Refactored usage for FindOperation constructor to static methods.


**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
