### PR TITLE
Change backend for ITs from `persistence-dse-6.8` to `persistence-dse-next` (pre-7.0)

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -109,6 +109,6 @@ jobs:
           COORD_IMAGE: index.docker.io/stargateio/coordinator-dse-next
           # ^^^ 24-Jul-2023, tatu: Temporary issues wrt ECR, need to use dockerhub instead
           #COORD_IMAGE: 237073351946.dkr.ecr.us-east-1.amazonaws.com/stargateio/coordinator-dse-next
-          TEST_REGEX: '!JsonApiGrpcRetryPolicyBridgeTest'
+          TEST_REGEX: '*'
         run: |
           ./mvnw -B -ntp clean verify -DskipUnitTests -Dit.test=$TEST_REGEX -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ github.sha }} -Dstargate.int-test.coordinator.image=$COORD_IMAGE ${{ matrix.profile }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -109,6 +109,6 @@ jobs:
           COORD_IMAGE: index.docker.io/stargateio/coordinator-dse-next
           # ^^^ 24-Jul-2023, tatu: Temporary issues wrt ECR, need to use dockerhub instead
           #COORD_IMAGE: 237073351946.dkr.ecr.us-east-1.amazonaws.com/stargateio/coordinator-dse-next
-          TEST_REGEX: '*'
+          TEST_REGEX: '!JsonApiGrpcRetryPolicyBridgeTest'
         run: |
           ./mvnw -B -ntp clean verify -DskipUnitTests -Dit.test=$TEST_REGEX -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ github.sha }} -Dstargate.int-test.coordinator.image=$COORD_IMAGE ${{ matrix.profile }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -109,6 +109,5 @@ jobs:
           COORD_IMAGE: index.docker.io/stargateio/coordinator-dse-next
           # ^^^ 24-Jul-2023, tatu: Temporary issues wrt ECR, need to use dockerhub instead
           #COORD_IMAGE: 237073351946.dkr.ecr.us-east-1.amazonaws.com/stargateio/coordinator-dse-next
-          TEST_REGEX: '*'
         run: |
-          ./mvnw -B -ntp clean verify -DskipUnitTests -Dit.test=$TEST_REGEX -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ github.sha }} -Dstargate.int-test.coordinator.image=$COORD_IMAGE ${{ matrix.profile }}
+          ./mvnw -B -ntp clean verify -DskipUnitTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ github.sha }} -Dstargate.int-test.coordinator.image=$COORD_IMAGE ${{ matrix.profile }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -106,9 +106,9 @@ jobs:
       # run the int tests
       - name: Integration Test
         env:
-          COORD_IMAGE: index.docker.io/stargateio/coordinator-dse-68
+          COORD_IMAGE: index.docker.io/stargateio/coordinator-dse-next
           # ^^^ 24-Jul-2023, tatu: Temporary issues wrt ECR, need to use dockerhub instead
-          #COORD_IMAGE: 237073351946.dkr.ecr.us-east-1.amazonaws.com/stargateio/coordinator-dse-68
-          TEST_REGEX: '!VectorSearchIntegrationTest*,!JsonApiGrpcRetryPolicyBridgeTest'
+          #COORD_IMAGE: 237073351946.dkr.ecr.us-east-1.amazonaws.com/stargateio/coordinator-dse-next
+          TEST_REGEX: '*'
         run: |
           ./mvnw -B -ntp clean verify -DskipUnitTests -Dit.test=$TEST_REGEX -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ github.sha }} -Dstargate.int-test.coordinator.image=$COORD_IMAGE ${{ matrix.profile }}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <skipITs>false</skipITs>
     <!-- Integration test props -->
     <!-- When updating please change defaults in the DseTestResource class -->
-    <stargate.int-test.cassandra.image>datastax/dse-next</stargate.int-test.cassandra.image>
+    <stargate.int-test.cassandra.image>stargateio/dse-next</stargate.int-test.cassandra.image>
     <stargate.int-test.cassandra.image-tag>4.0.7-0acaae364c19</stargate.int-test.cassandra.image-tag>
     <stargate.int-test.coordinator.image>stargateio/coordinator-dse-next</stargate.int-test.coordinator.image>
     <stargate.int-test.coordinator.image-tag>v${stargate.version}</stargate.int-test.coordinator.image-tag>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.stargate</groupId>
     <artifactId>sgv2-api-parent</artifactId>
-    <version>2.1.0-ALPHA-4</version>
+    <version>2.1.0-ALPHA-5</version>
   </parent>
   <artifactId>sgv2-jsonapi</artifactId>
   <version>1.0.0-ALPHA-11-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <!-- Integration test props -->
     <!-- When updating please change defaults in the DseTestResource class -->
     <stargate.int-test.cassandra.image>stargateio/dse-next</stargate.int-test.cassandra.image>
-    <stargate.int-test.cassandra.image-tag>4.0.7-0acaae364c19</stargate.int-test.cassandra.image-tag>
+    <stargate.int-test.cassandra.image-tag>4.0.7-336cdd7405ee</stargate.int-test.cassandra.image-tag>
     <stargate.int-test.coordinator.image>stargateio/coordinator-dse-next</stargate.int-test.coordinator.image>
     <stargate.int-test.coordinator.image-tag>v${stargate.version}</stargate.int-test.coordinator.image-tag>
     <stargate.int-test.cluster.name>dse-next-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,13 @@
     <skipITs>false</skipITs>
     <!-- Integration test props -->
     <!-- When updating please change defaults in the DseTestResource class -->
-    <stargate.int-test.cassandra.image>datastax/dse-server</stargate.int-test.cassandra.image>
-    <stargate.int-test.cassandra.image-tag>6.8.36</stargate.int-test.cassandra.image-tag>
-    <stargate.int-test.coordinator.image>stargateio/coordinator-dse-68</stargate.int-test.coordinator.image>
+    <stargate.int-test.cassandra.image>datastax/dse-next</stargate.int-test.cassandra.image>
+    <stargate.int-test.cassandra.image-tag>4.0.7-0acaae364c19</stargate.int-test.cassandra.image-tag>
+    <stargate.int-test.coordinator.image>stargateio/coordinator-dse-next</stargate.int-test.coordinator.image>
     <stargate.int-test.coordinator.image-tag>v${stargate.version}</stargate.int-test.coordinator.image-tag>
-    <stargate.int-test.cluster.name>dse-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
-    <stargate.int-test.cluster.version>6.8</stargate.int-test.cluster.version>
-    <stargate.int-test.cluster.dse>true</stargate.int-test.cluster.dse>
+    <stargate.int-test.cluster.name>dse-next-${stargate.int-test.cassandra.image-tag}-cluster</stargate.int-test.cluster.name>
+    <stargate.int-test.cluster.persistence>persistence-dse-next</stargate.int-test.cluster.persistence>
+    <stargate.int-test.cluster.dse>false</stargate.int-test.cluster.dse>
     <stargate.int-test.cassandra.auth-enabled>true</stargate.int-test.cassandra.auth-enabled>
   </properties>
   <dependencyManagement>

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -71,7 +71,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                   "_id": "1",
                   "name": "Coded Cleats",
                   "description": "ChatGPT integrated sneakers that talk to you",
-                  "$vector": [0.1, 0.15, 0.3, 0.12, 0.05]
+                  "$vector": [0.12, 0.15, 0.32, 0.12, 0.05]
               }
            }
         }
@@ -103,7 +103,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           "_id": "1",
           "name": "Coded Cleats",
           "description": "ChatGPT integrated sneakers that talk to you",
-          "$vector": [0.1, 0.15, 0.3, 0.12, 0.05]
+          "$vector": [0.12, 0.15, 0.32, 0.12, 0.05]
         }
         """;
 
@@ -256,13 +256,13 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                   "_id": "2",
                   "name": "Logic Layers",
                   "description": "An AI quilt to help you sleep forever",
-                  "$vector": [0.45, 0.09, 0.01, 0.2, 0.11]
+                  "$vector": [0.45, 0.09, 0.01, 0.25, 0.11]
                 },
                 {
                   "_id": "3",
                   "name": "Vision Vector Frame",
                   "description": "Vision Vector Frame', 'A deep learning display that controls your mood",
-                  "$vector": [0.1, 0.05, 0.08, 0.3, 0.6]
+                  "$vector": [0.12, 0.05, 0.08, 0.32, 0.6]
                 }
               ]
            }
@@ -296,7 +296,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
             "_id": "2",
             "name": "Logic Layers",
             "description": "An AI quilt to help you sleep forever",
-            "$vector": [0.45, 0.09, 0.01, 0.2, 0.11]
+            "$vector": [0.45, 0.09, 0.01, 0.25, 0.11]
         }
         """;
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -71,7 +71,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                   "_id": "1",
                   "name": "Coded Cleats",
                   "description": "ChatGPT integrated sneakers that talk to you",
-                  "$vector": [0.12, 0.15, 0.32, 0.12, 0.05]
+                  "$vector": [0.25, 0.25, 0.25, 0.25, 0.25]
               }
            }
         }
@@ -103,7 +103,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           "_id": "1",
           "name": "Coded Cleats",
           "description": "ChatGPT integrated sneakers that talk to you",
-          "$vector": [0.12, 0.15, 0.32, 0.12, 0.05]
+          "$vector": [0.25, 0.25, 0.25, 0.25, 0.25]
         }
         """;
 
@@ -256,7 +256,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                   "_id": "2",
                   "name": "Logic Layers",
                   "description": "An AI quilt to help you sleep forever",
-                  "$vector": [0.45, 0.09, 0.01, 0.25, 0.11]
+                  "$vector": [0.25, 0.25, 0.25, 0.25, 0.25]
                 },
                 {
                   "_id": "3",
@@ -296,7 +296,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
             "_id": "2",
             "name": "Logic Layers",
             "description": "An AI quilt to help you sleep forever",
-            "$vector": [0.45, 0.09, 0.01, 0.25, 0.11]
+            "$vector": [0.25, 0.25, 0.25, 0.25, 0.25]
         }
         """;
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -39,7 +39,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
             "name" : "my_collection",
             "options": {
               "vector": {
-                "size": 4,
+                "size": 5,
                 "function": "cosine"
               }
             }

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -11,7 +11,7 @@ public class DseTestResource extends StargateTestResource {
 
     if (null == System.getProperty("testing.containers.cassandra-image")) {
       System.setProperty(
-          "testing.containers.cassandra-image", "datastax/dse-next:4.0.7-0acaae364c19");
+          "testing.containers.cassandra-image", "stargateio/dse-next:4.0.7-0acaae364c19");
     }
 
     if (null == System.getProperty("testing.containers.stargate-image")) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -10,19 +10,19 @@ public class DseTestResource extends StargateTestResource {
     super();
 
     if (null == System.getProperty("testing.containers.cassandra-image")) {
-      System.setProperty("testing.containers.cassandra-image", "datastax/dse-server:6.8.36");
+      System.setProperty("testing.containers.cassandra-image", "datastax/dse-next:4.0.7-0acaae364c19");
     }
 
     if (null == System.getProperty("testing.containers.stargate-image")) {
-      System.setProperty("testing.containers.stargate-image", "stargateio/coordinator-dse-68:v2");
+      System.setProperty("testing.containers.stargate-image", "stargateio/coordinator-dse-next:v2.1");
     }
 
-    if (null == System.getProperty("testing.containers.cluster-version")) {
-      System.setProperty("testing.containers.cluster-version", "6.8");
+    if (null == System.getProperty("testing.containers.cluster-persistence")) {
+      System.setProperty("testing.containers.cluster-persistence", "persistence-dse-next");
     }
 
     if (null == System.getProperty("testing.containers.cluster-dse")) {
-      System.setProperty("testing.containers.cluster-dse", "true");
+      System.setProperty("testing.containers.cluster-dse", "false");
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -10,11 +10,13 @@ public class DseTestResource extends StargateTestResource {
     super();
 
     if (null == System.getProperty("testing.containers.cassandra-image")) {
-      System.setProperty("testing.containers.cassandra-image", "datastax/dse-next:4.0.7-0acaae364c19");
+      System.setProperty(
+          "testing.containers.cassandra-image", "datastax/dse-next:4.0.7-0acaae364c19");
     }
 
     if (null == System.getProperty("testing.containers.stargate-image")) {
-      System.setProperty("testing.containers.stargate-image", "stargateio/coordinator-dse-next:v2.1");
+      System.setProperty(
+          "testing.containers.stargate-image", "stargateio/coordinator-dse-next:v2.1");
     }
 
     if (null == System.getProperty("testing.containers.cluster-persistence")) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/testresource/DseTestResource.java
@@ -11,7 +11,7 @@ public class DseTestResource extends StargateTestResource {
 
     if (null == System.getProperty("testing.containers.cassandra-image")) {
       System.setProperty(
-          "testing.containers.cassandra-image", "stargateio/dse-next:4.0.7-0acaae364c19");
+          "testing.containers.cassandra-image", "stargateio/dse-next:4.0.7-336cdd7405ee");
     }
 
     if (null == System.getProperty("testing.containers.stargate-image")) {


### PR DESCRIPTION
**What this PR does**:

Switches CI/ITs to use "dse-next" (vector-enabled) backend

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
