### PR TITLE
Reduce logging of known+handled cases

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/CommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/CommandProcessor.java
@@ -62,19 +62,21 @@ public class CommandProcessor {
               return operation.execute(queryExecutor);
             })
 
-        // handler failures here
+        // handle failures here
         .onFailure()
         .recoverWithItem(
             t -> {
-              logger.warn(
-                  "The command {} failed with exception", command.getClass().getSimpleName(), t);
               // DocsException is supplier of the CommandResult
               // so simply return
               if (t instanceof JsonApiException jsonApiException) {
+                // Note: JsonApiException means that JSON API itself handled the situation
+                // (created, or wrapped the exception) -- should not be logged (have already
+                // been logged if necessary)
                 return jsonApiException;
               }
-
-              // otherwise use generic for now
+              // But other exception types are unexpected, so log for now
+              logger.warn(
+                  "Command '{}' failed with exception", command.getClass().getSimpleName(), t);
               return new ThrowableCommandResultSupplier(t);
             })
 


### PR DESCRIPTION
**What this PR does**:

Excessive logging noticed during unit test run; client-side problems (like invalid operation parameters caught by validation) were being logged at warning level, along with full stack trace.
This PR removes logging in case of known handled exception (JsonApiException) and only log otherwise unhandled cases.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
