### PR TITLE
Allow bigger arrays for vector embeddings

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -59,8 +59,9 @@ public interface DocumentLimitsConfig {
 
   /**
    * @return Maximum length of Vector ($vector) array JSON API allows -- NOTE: backend data store
-   *     likely limits length to a lower value; but we want to prevent handling of huge arrays
-   *     before trying to pass them to DB.
+   *     may limit length to a lower value; but we want to prevent handling of huge arrays before
+   *     trying to pass them to DB. Or, conversely, if data store does not limit length, to impose
+   *     something reasonable from JSON API perspective (for service-protection reasons).
    */
   @Positive
   @WithDefault("16000")

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -63,6 +63,6 @@ public interface DocumentLimitsConfig {
    *     before trying to pass them to DB.
    */
   @Positive
-  @WithDefault("8000")
+  @WithDefault("16000")
   int maxVectorEmbeddingLength();
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -56,4 +56,13 @@ public interface DocumentLimitsConfig {
   @Positive
   @WithDefault("100")
   int maxArrayLength();
+
+  /**
+   * @return Maximum length of Vector ($vector) array JSON API allows -- NOTE: backend data store
+   *     likely limits length to a lower value; but we want to prevent handling of huge arrays
+   *     before trying to pass them to DB.
+   */
+  @Positive
+  @WithDefault("8000")
+  int maxVectorEmbeddingLength();
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -84,7 +84,9 @@ public enum ErrorCode {
 
   VECTOR_SEARCH_USAGE_ERROR("Vector search can't be used with other sort clause"),
 
-  VECTOR_SEARCH_NOT_SUPPORTED("Vector search is not enabled for the collection ");
+  VECTOR_SEARCH_NOT_SUPPORTED("Vector search is not enabled for the collection "),
+
+  VECTOR_SEARCH_FIELD_TOO_BIG("Vector embedding field '$vector' length too big");
 
   private final String message;
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -231,26 +231,28 @@ public class Shredder {
     ++depth;
     validateDocDepth(limits, depth);
 
-    // One special case: vector embeddings
-    if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(referringPropertyName)) {
-      if (arrayValue.size() > limits.maxVectorEmbeddingLength()) {
+    if (arrayValue.size() > limits.maxArrayLength()) {
+      // One special case: vector embeddings allow larger size
+      if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(referringPropertyName)) {
+        if (arrayValue.size() > limits.maxVectorEmbeddingLength()) {
+          throw new JsonApiException(
+              ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
+              String.format(
+                  "%s: number of elements Vector embedding ('%s') has (%d) exceeds maximum allowed (%s)",
+                  ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
+                  referringPropertyName,
+                  arrayValue.size(),
+                  limits.maxVectorEmbeddingLength()));
+        }
+      } else {
         throw new JsonApiException(
             ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
             String.format(
-                "%s: number of elements Vector embedding ('%s') has (%d) exceeds maximum allowed (%s)",
+                "%s: number of elements an Array has (%d) exceeds maximum allowed (%s)",
                 ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-                referringPropertyName,
                 arrayValue.size(),
-                limits.maxVectorEmbeddingLength()));
+                limits.maxArrayLength()));
       }
-    } else if (arrayValue.size() > limits.maxArrayLength()) {
-      throw new JsonApiException(
-          ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-          String.format(
-              "%s: number of elements an Array has (%d) exceeds maximum allowed (%s)",
-              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-              arrayValue.size(),
-              limits.maxArrayLength()));
     }
 
     for (JsonNode element : arrayValue) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -212,24 +212,38 @@ public class Shredder {
     }
 
     // Second: traverse to check for other constraints
-    validateObjectValue(limits, doc, 0);
+    validateObjectValue(limits, null, doc, 0);
   }
 
-  private void validateDocValue(DocumentLimitsConfig limits, JsonNode value, int depth) {
+  private void validateDocValue(
+      DocumentLimitsConfig limits, String referringPropertyName, JsonNode value, int depth) {
     if (value.isObject()) {
-      validateObjectValue(limits, value, depth);
+      validateObjectValue(limits, referringPropertyName, value, depth);
     } else if (value.isArray()) {
-      validateArrayValue(limits, value, depth);
+      validateArrayValue(limits, referringPropertyName, value, depth);
     } else if (value.isTextual()) {
       validateStringValue(limits, value);
     }
   }
 
-  private void validateArrayValue(DocumentLimitsConfig limits, JsonNode arrayValue, int depth) {
+  private void validateArrayValue(
+      DocumentLimitsConfig limits, String referringPropertyName, JsonNode arrayValue, int depth) {
     ++depth;
     validateDocDepth(limits, depth);
 
-    if (arrayValue.size() > limits.maxArrayLength()) {
+    // One special case: vector embeddings
+    if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(referringPropertyName)) {
+      if (arrayValue.size() > limits.maxVectorEmbeddingLength()) {
+        throw new JsonApiException(
+            ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
+            String.format(
+                "%s: number of elements Vector embedding ('%s') has (%d) exceeds maximum allowed (%s)",
+                ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
+                referringPropertyName,
+                arrayValue.size(),
+                limits.maxArrayLength()));
+      }
+    } else if (arrayValue.size() > limits.maxArrayLength()) {
       throw new JsonApiException(
           ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
           String.format(
@@ -240,11 +254,12 @@ public class Shredder {
     }
 
     for (JsonNode element : arrayValue) {
-      validateDocValue(limits, element, depth);
+      validateDocValue(limits, null, element, depth);
     }
   }
 
-  private void validateObjectValue(DocumentLimitsConfig limits, JsonNode objectValue, int depth) {
+  private void validateObjectValue(
+      DocumentLimitsConfig limits, String referringPropertyName, JsonNode objectValue, int depth) {
     ++depth;
     validateDocDepth(limits, depth);
 
@@ -262,7 +277,7 @@ public class Shredder {
     while (it.hasNext()) {
       var entry = it.next();
       validateObjectKey(limits, entry.getKey(), entry.getValue(), depth);
-      validateDocValue(limits, entry.getValue(), depth);
+      validateDocValue(limits, entry.getKey(), entry.getValue(), depth);
     }
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -241,7 +241,7 @@ public class Shredder {
                 ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
                 referringPropertyName,
                 arrayValue.size(),
-                limits.maxArrayLength()));
+                limits.maxVectorEmbeddingLength()));
       }
     } else if (arrayValue.size() > limits.maxArrayLength()) {
       throw new JsonApiException(

--- a/src/main/java/io/stargate/sgv2/jsonapi/util/SortClauseUtil.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/util/SortClauseUtil.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 public class SortClauseUtil {
   public static List<FindOperation.OrderBy> resolveOrderBy(SortClause sortClause) {
     if (sortClause == null || sortClause.sortExpressions().isEmpty()) return null;
-    if (hasSortClause(sortClause)) return null;
+    if (hasVsearchClause(sortClause)) return null;
     return sortClause.sortExpressions().stream()
         .map(
             sortExpression ->
@@ -19,13 +19,13 @@ public class SortClauseUtil {
 
   public static float[] resolveVsearch(SortClause sortClause) {
     if (sortClause == null || sortClause.sortExpressions().isEmpty()) return null;
-    if (hasSortClause(sortClause)) {
+    if (hasVsearchClause(sortClause)) {
       return sortClause.sortExpressions().stream().findFirst().get().vector();
     }
     return null;
   }
 
-  private static boolean hasSortClause(SortClause sortClause) {
+  private static boolean hasVsearchClause(SortClause sortClause) {
     return sortClause.sortExpressions().stream()
         .findFirst()
         .get()

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -67,6 +67,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .body("status.ok", is(1));
     }
 
+    @Test
     public void happyPathVectorSearchDefaultFunction() {
       String json =
           """

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -44,18 +44,18 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void happyPathVectorSearch() {
       String json =
           """
-        {
-          "createCollection": {
-            "name" : "my_collection",
-            "options": {
-              "vector": {
-                "size": 5,
-                "function": "cosine"
-              }
-            }
-          }
-        }
-        """;
+                      {
+                        "createCollection": {
+                          "name" : "my_collection",
+                          "options": {
+                            "vector": {
+                              "size": 5,
+                              "function": "cosine"
+                            }
+                          }
+                        }
+                      }
+                      """;
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -80,17 +80,17 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void insertVectorSearch() {
       String json =
           """
-        {
-           "insertOne": {
-              "document": {
-                  "_id": "1",
-                  "name": "Coded Cleats",
-                  "description": "ChatGPT integrated sneakers that talk to you",
-                  "$vector": [0.25, 0.25, 0.25, 0.25, 0.25]
-              }
-           }
-        }
-        """;
+                      {
+                         "insertOne": {
+                            "document": {
+                                "_id": "1",
+                                "name": "Coded Cleats",
+                                "description": "ChatGPT integrated sneakers that talk to you",
+                                "$vector": [0.25, 0.25, 0.25, 0.25, 0.25]
+                            }
+                         }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -106,21 +106,21 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
 
       json =
           """
-        {
-          "find": {
-            "filter" : {"_id" : "1"}
-          }
-        }
-        """;
+                      {
+                        "find": {
+                          "filter" : {"_id" : "1"}
+                        }
+                      }
+                      """;
       String expected =
           """
-        {
-          "_id": "1",
-          "name": "Coded Cleats",
-          "description": "ChatGPT integrated sneakers that talk to you",
-          "$vector": [0.25, 0.25, 0.25, 0.25, 0.25]
-        }
-        """;
+                      {
+                        "_id": "1",
+                        "name": "Coded Cleats",
+                        "description": "ChatGPT integrated sneakers that talk to you",
+                        "$vector": [0.25, 0.25, 0.25, 0.25, 0.25]
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -138,38 +138,8 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     @Test
     public void insertBigVectorThenSearch() {
       final String vectorStr = buildVectorElements(1, BIG_VECTOR_SIZE);
-      final String vectorDoc =
-          """
-                {
-                    "_id": "bigVector1",
-                    "name": "Victor",
-                    "description": "Big Vectors Rule ok?",
-                    "$vector": [%s]
-                }
-                      """
-              .formatted(vectorStr);
 
-      // First insert a document with a big vector
-
-      given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-          .contentType(ContentType.JSON)
-          .body(
-              """
-            {
-               "insertOne": {
-                  "document": %s
-               }
-            }
-            """
-                  .formatted(vectorDoc))
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, bigVectorCollectionName)
-          .then()
-          .statusCode(200)
-          .body("status.insertedIds[0]", is("bigVector1"))
-          .body("data", is(nullValue()))
-          .body("errors", is(nullValue()));
+      insertBigVectorDoc("bigVector1", "Victor", "Big Vectors Rule ok?", vectorStr);
 
       // Then verify it was inserted correctly
       given()
@@ -177,12 +147,12 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .contentType(ContentType.JSON)
           .body(
               """
-                {
-                  "find": {
-                    "filter" : {"_id" : "bigVector1"}
-                  }
-                }
-                """)
+                              {
+                                "find": {
+                                  "filter" : {"_id" : "bigVector1"}
+                                }
+                              }
+                              """)
           .when()
           .post(CollectionResource.BASE_PATH, namespaceName, bigVectorCollectionName)
           .then()
@@ -197,13 +167,13 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
       final String vectorSearchStr = buildVectorElements(3, BIG_VECTOR_SIZE);
       final String findRequest =
           """
-            {
-              "find": {
-                "sort" : {"$vector" : [%s]},
-                "projection" : {"_id" : 1, "$vector" : 1}
-              }
-            }
-            """
+                      {
+                        "find": {
+                          "sort" : {"$vector" : [%s]},
+                          "projection" : {"_id" : 1, "$vector" : 1}
+                        }
+                      }
+                      """
               .formatted(vectorSearchStr);
 
       given()
@@ -225,16 +195,16 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void insertVectorCollectionWithoutVectorData() {
       String json =
           """
-        {
-           "insertOne": {
-              "document": {
-                  "_id": "10",
-                  "name": "Coded Cleats",
-                  "description": "ChatGPT integrated sneakers that talk to you"
-              }
-           }
-        }
-        """;
+                      {
+                         "insertOne": {
+                            "document": {
+                                "_id": "10",
+                                "name": "Coded Cleats",
+                                "description": "ChatGPT integrated sneakers that talk to you"
+                            }
+                         }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -250,20 +220,20 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
 
       json =
           """
-        {
-          "find": {
-            "filter" : {"_id" : "10"}
-          }
-        }
-        """;
+                      {
+                        "find": {
+                          "filter" : {"_id" : "10"}
+                        }
+                      }
+                      """;
       String expected =
           """
-        {
-          "_id": "10",
-          "name": "Coded Cleats",
-          "description": "ChatGPT integrated sneakers that talk to you"
-        }
-        """;
+                      {
+                        "_id": "10",
+                        "name": "Coded Cleats",
+                        "description": "ChatGPT integrated sneakers that talk to you"
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -281,17 +251,17 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void insertEmptyVectorData() {
       String json =
           """
-        {
-           "insertOne": {
-              "document": {
-                  "_id": "Invalid",
-                  "name": "Coded Cleats",
-                  "description": "ChatGPT integrated sneakers that talk to you",
-                  "$vector": []
-              }
-           }
-        }
-        """;
+                      {
+                         "insertOne": {
+                            "document": {
+                                "_id": "Invalid",
+                                "name": "Coded Cleats",
+                                "description": "ChatGPT integrated sneakers that talk to you",
+                                "$vector": []
+                            }
+                         }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -314,17 +284,17 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void insertInvalidVectorData() {
       String json =
           """
-        {
-           "insertOne": {
-              "document": {
-                  "_id": "Invalid",
-                  "name": "Coded Cleats",
-                  "description": "ChatGPT integrated sneakers that talk to you",
-                  "$vector": [0.11, "abc", true, null]
-              }
-           }
-        }
-        """;
+                      {
+                         "insertOne": {
+                            "document": {
+                                "_id": "Invalid",
+                                "name": "Coded Cleats",
+                                "description": "ChatGPT integrated sneakers that talk to you",
+                                "$vector": [0.11, "abc", true, null]
+                            }
+                         }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -351,25 +321,25 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void insertVectorSearch() {
       String json =
           """
-        {
-           "insertMany": {
-              "documents": [
-                {
-                  "_id": "2",
-                  "name": "Logic Layers",
-                  "description": "An AI quilt to help you sleep forever",
-                  "$vector": [0.25, 0.25, 0.25, 0.25, 0.25]
-                },
-                {
-                  "_id": "3",
-                  "name": "Vision Vector Frame",
-                  "description": "Vision Vector Frame', 'A deep learning display that controls your mood",
-                  "$vector": [0.12, 0.05, 0.08, 0.32, 0.6]
-                }
-              ]
-           }
-        }
-        """;
+                      {
+                         "insertMany": {
+                            "documents": [
+                              {
+                                "_id": "2",
+                                "name": "Logic Layers",
+                                "description": "An AI quilt to help you sleep forever",
+                                "$vector": [0.25, 0.25, 0.25, 0.25, 0.25]
+                              },
+                              {
+                                "_id": "3",
+                                "name": "Vision Vector Frame",
+                                "description": "Vision Vector Frame', 'A deep learning display that controls your mood",
+                                "$vector": [0.12, 0.05, 0.08, 0.32, 0.6]
+                              }
+                            ]
+                         }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -386,21 +356,21 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
 
       json =
           """
-        {
-          "find": {
-            "filter" : {"_id" : "2"}
-          }
-        }
-        """;
+                      {
+                        "find": {
+                          "filter" : {"_id" : "2"}
+                        }
+                      }
+                      """;
       String expected =
           """
-        {
-            "_id": "2",
-            "name": "Logic Layers",
-            "description": "An AI quilt to help you sleep forever",
-            "$vector": [0.25, 0.25, 0.25, 0.25, 0.25]
-        }
-        """;
+                      {
+                          "_id": "2",
+                          "name": "Logic Layers",
+                          "description": "An AI quilt to help you sleep forever",
+                          "$vector": [0.25, 0.25, 0.25, 0.25, 0.25]
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -416,12 +386,13 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
   }
 
   public void insertVectorDocuments() {
-    String json = """
-        {
-          "deleteMany": {
-          }
-        }
-        """;
+    String json =
+        """
+            {
+              "deleteMany": {
+              }
+            }
+            """;
 
     given()
         .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -437,31 +408,31 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
 
     json =
         """
-          {
-             "insertMany": {
-                "documents": [
-                  {
-                    "_id": "1",
-                    "name": "Coded Cleats",
-                    "description": "ChatGPT integrated sneakers that talk to you",
-                    "$vector": [0.1, 0.15, 0.3, 0.12, 0.05]
-                   },
-                   {
-                     "_id": "2",
-                     "name": "Logic Layers",
-                     "description": "An AI quilt to help you sleep forever",
-                     "$vector": [0.45, 0.09, 0.01, 0.2, 0.11]
-                   },
-                   {
-                     "_id": "3",
-                     "name": "Vision Vector Frame",
-                     "description": "Vision Vector Frame', 'A deep learning display that controls your mood",
-                     "$vector": [0.1, 0.05, 0.08, 0.3, 0.6]
-                   }
-                ]
-             }
-          }
-          """;
+                    {
+                       "insertMany": {
+                          "documents": [
+                            {
+                              "_id": "1",
+                              "name": "Coded Cleats",
+                              "description": "ChatGPT integrated sneakers that talk to you",
+                              "$vector": [0.1, 0.15, 0.3, 0.12, 0.05]
+                             },
+                             {
+                               "_id": "2",
+                               "name": "Logic Layers",
+                               "description": "An AI quilt to help you sleep forever",
+                               "$vector": [0.45, 0.09, 0.01, 0.2, 0.11]
+                             },
+                             {
+                               "_id": "3",
+                               "name": "Vision Vector Frame",
+                               "description": "Vision Vector Frame', 'A deep learning display that controls your mood",
+                               "$vector": [0.1, 0.05, 0.08, 0.3, 0.6]
+                             }
+                          ]
+                       }
+                    }
+                    """;
     given()
         .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
         .contentType(ContentType.JSON)
@@ -490,16 +461,16 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void happyPath() {
       String json =
           """
-        {
-          "find": {
-            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
-            "projection" : {"_id" : 1, "$vector" : 1},
-            "options" : {
-                "limit" : 5
-            }
-          }
-        }
-        """;
+                      {
+                        "find": {
+                          "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
+                          "projection" : {"_id" : 1, "$vector" : 1},
+                          "options" : {
+                              "limit" : 5
+                          }
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -523,17 +494,17 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void happyPathWithFilter() {
       String json =
           """
-        {
-          "find": {
-            "filter" : {"_id" : "1"},
-            "projection" : {"_id" : 1, "$vector" : 0},
-            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
-            "options" : {
-                "limit" : 5
-            }
-          }
-        }
-        """;
+                      {
+                        "find": {
+                          "filter" : {"_id" : "1"},
+                          "projection" : {"_id" : 1, "$vector" : 0},
+                          "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
+                          "options" : {
+                              "limit" : 5
+                          }
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -553,16 +524,16 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void happyPathWithEmptyVector() {
       String json =
           """
-        {
-          "find": {
-            "filter" : {"_id" : "1"},
-            "sort" : {"$vector" : []},
-            "options" : {
-                "limit" : 5
-            }
-          }
-        }
-        """;
+                      {
+                        "find": {
+                          "filter" : {"_id" : "1"},
+                          "sort" : {"$vector" : []},
+                          "options" : {
+                              "limit" : 5
+                          }
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -583,16 +554,16 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void happyPathWithInvalidData() {
       String json =
           """
-            {
-              "find": {
-                "filter" : {"_id" : "1"},
-                "sort" : {"$vector" : [0.11, "abc", true]},
-                "options" : {
-                    "limit" : 5
-                }
-              }
-            }
-            """;
+                      {
+                        "find": {
+                          "filter" : {"_id" : "1"},
+                          "sort" : {"$vector" : [0.11, "abc", true]},
+                          "options" : {
+                              "limit" : 5
+                          }
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -623,12 +594,12 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void happyPath() {
       String json =
           """
-        {
-          "findOne": {
-            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
-          }
-        }
-        """;
+                      {
+                        "findOne": {
+                          "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -647,13 +618,13 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void happyPathWithFilter() {
       String json =
           """
-            {
-              "findOne": {
-                "filter" : {"_id" : "1"},
-                "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
-              }
-            }
-            """;
+                      {
+                        "findOne": {
+                          "filter" : {"_id" : "1"},
+                          "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -672,13 +643,13 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void happyPathWithEmptyVector() {
       String json =
           """
-        {
-          "findOne": {
-            "filter" : {"_id" : "1"},
-            "sort" : {"$vector" : []}
-          }
-        }
-        """;
+                      {
+                        "findOne": {
+                          "filter" : {"_id" : "1"},
+                          "sort" : {"$vector" : []}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -699,13 +670,13 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void happyPathWithInvalidData() {
       String json =
           """
-        {
-          "findOne": {
-            "filter" : {"_id" : "1"},
-            "sort" : {"$vector" : [0.11, "abc", true]}
-          }
-        }
-        """;
+                      {
+                        "findOne": {
+                          "filter" : {"_id" : "1"},
+                          "sort" : {"$vector" : [0.11, "abc", true]}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -737,14 +708,14 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void setOperation() {
       String json =
           """
-        {
-          "findOneAndUpdate": {
-            "filter" : {"_id": "2"},
-            "update" : {"$set" : {"$vector" : [0.25, 0.25, 0.25, 0.25, 0.25]}},
-            "options" : {"returnDocument" : "after"}
-          }
-        }
-        """;
+                      {
+                        "findOneAndUpdate": {
+                          "filter" : {"_id": "2"},
+                          "update" : {"$set" : {"$vector" : [0.25, 0.25, 0.25, 0.25, 0.25]}},
+                          "options" : {"returnDocument" : "after"}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -766,14 +737,14 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     public void unsetOperation() {
       String json =
           """
-        {
-          "findOneAndUpdate": {
-            "filter" : {"name": "Coded Cleats"},
-            "update" : {"$unset" : {"$vector" : null}},
-            "options" : {"returnDocument" : "after"}
-          }
-        }
-        """;
+                      {
+                        "findOneAndUpdate": {
+                          "filter" : {"name": "Coded Cleats"},
+                          "update" : {"$unset" : {"$vector" : null}},
+                          "options" : {"returnDocument" : "after"}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -791,18 +762,18 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     public void setOnInsertOperation() {
       String json =
           """
-        {
-          "findOneAndUpdate": {
-            "filter" : {"_id": "11"},
-            "update" : {"$setOnInsert" : {"$vector": [0.11, 0.22, 0.33, 0.44, 0.55]}},
-            "options" : {"returnDocument" : "after", "upsert": true}
-          }
-        }
-        """;
+                      {
+                        "findOneAndUpdate": {
+                          "filter" : {"_id": "11"},
+                          "update" : {"$setOnInsert" : {"$vector": [0.11, 0.22, 0.33, 0.44, 0.55]}},
+                          "options" : {"returnDocument" : "after", "upsert": true}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -821,18 +792,18 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     public void errorOperationForVector() {
       String json =
           """
-        {
-          "findOneAndUpdate": {
-            "filter" : {"_id": "3"},
-            "update" : {"$push" : {"$vector" : 0.33}},
-            "options" : {"returnDocument" : "after"}
-          }
-        }
-        """;
+                      {
+                        "findOneAndUpdate": {
+                          "filter" : {"_id": "3"},
+                          "update" : {"$push" : {"$vector" : 0.33}},
+                          "options" : {"returnDocument" : "after"}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -849,6 +820,85 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
               "errors[0].message",
               is(ErrorCode.UNSUPPORTED_UPDATE_FOR_VECTOR.getMessage() + ": " + "$push"));
     }
+
+    @Test
+    @Order(6)
+    public void setBigVectorOperation() {
+      // First insert without a vector
+      insertBigVectorDoc("bigVectorForSet", "Bob", "Desc for Bob.", null);
+
+      // and verify we have null for it
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                                      {
+                                        "find": {
+                                          "filter" : {"_id" : "bigVectorForSet"}
+                                        }
+                                      }
+                                      """)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, bigVectorCollectionName)
+          .then()
+          .statusCode(200)
+          .body("errors", is(nullValue()))
+          .body("data.documents", hasSize(1))
+          .body("data.documents[0]._id", is("bigVectorForSet"))
+          .body("data.documents[0].$vector", is(nullValue()));
+
+      // then set the vector
+      final String vectorStr = buildVectorElements(7, BIG_VECTOR_SIZE);
+      String json =
+          """
+                      {
+                        "findOneAndUpdate": {
+                          "filter" : {"_id": "bigVectorForSet"},
+                          "update" : {"$set" : {"$vector" : [ %s ]}},
+                          "options" : {"returnDocument" : "after"}
+                        }
+                      }
+                      """
+              .formatted(vectorStr);
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, bigVectorCollectionName)
+          .then()
+          .statusCode(200)
+          .body("status.matchedCount", is(1))
+          .body("status.modifiedCount", is(1))
+          .body("data.document._id", is("bigVectorForSet"))
+          .body("data.document.$vector", is(notNullValue()))
+          .body("data.document.$vector", hasSize(BIG_VECTOR_SIZE))
+          .body("errors", is(nullValue()));
+
+      // and verify it was set to value with expected size
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                        {
+                          "find": {
+                            "filter" : {"_id" : "bigVectorForSet"}
+                          }
+                        }
+                        """)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, bigVectorCollectionName)
+          .then()
+          .statusCode(200)
+          .body("errors", is(nullValue()))
+          .body("data.documents", hasSize(1))
+          .body("data.documents[0]._id", is("bigVectorForSet"))
+          .body("data.documents[0].$vector", is(notNullValue()))
+          .body("data.documents[0].$vector", hasSize(BIG_VECTOR_SIZE));
+    }
   }
 
   @Nested
@@ -861,14 +911,14 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
       insertVectorDocuments();
       String json =
           """
-        {
-          "findOneAndUpdate": {
-            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
-            "update" : {"$set" : {"status" : "active"}},
-            "options" : {"returnDocument" : "after"}
-          }
-        }
-        """;
+                      {
+                        "findOneAndUpdate": {
+                          "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
+                          "update" : {"$set" : {"status" : "active"}},
+                          "options" : {"returnDocument" : "after"}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -891,13 +941,13 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
       insertVectorDocuments();
       String json =
           """
-        {
-          "updateOne": {
-            "update" : {"$set" : {"new_col": "new_val"}},
-            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
-          }
-        }
-        """;
+                      {
+                        "updateOne": {
+                          "update" : {"$set" : {"new_col": "new_val"}},
+                          "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
+                        }
+                      }
+                      """;
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -912,12 +962,12 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .body("errors", is(nullValue()));
       json =
           """
-        {
-          "findOne": {
-            "filter" : {"_id" : "3"}
-          }
-        }
-        """;
+                      {
+                        "findOne": {
+                          "filter" : {"_id" : "3"}
+                        }
+                      }
+                      """;
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -936,14 +986,14 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
       insertVectorDocuments();
       String json =
           """
-        {
-          "findOneAndReplace": {
-            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
-            "replacement" : {"_id" : "3", "username": "user3", "status" : false, "$vector" : [0.12, 0.05, 0.08, 0.32, 0.6]},
-            "options" : {"returnDocument" : "after"}
-          }
-        }
-        """;
+                      {
+                        "findOneAndReplace": {
+                          "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
+                          "replacement" : {"_id" : "3", "username": "user3", "status" : false, "$vector" : [0.12, 0.05, 0.08, 0.32, 0.6]},
+                          "options" : {"returnDocument" : "after"}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -967,14 +1017,14 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
       insertVectorDocuments();
       String json =
           """
-            {
-              "findOneAndReplace": {
-                "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
-                "replacement" : {"_id" : "3", "username": "user3", "status" : false},
-                "options" : {"returnDocument" : "after"}
-              }
-            }
-            """;
+                      {
+                        "findOneAndReplace": {
+                          "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
+                          "replacement" : {"_id" : "3", "username": "user3", "status" : false},
+                          "options" : {"returnDocument" : "after"}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -998,12 +1048,12 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
       insertVectorDocuments();
       String json =
           """
-        {
-          "findOneAndDelete": {
-            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
-          }
-        }
-        """;
+                      {
+                        "findOneAndDelete": {
+                          "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -1026,13 +1076,13 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
       insertVectorDocuments();
       String json =
           """
-        {
-          "deleteOne": {
-            "filter" : {"$vector" : {"$exists" : true}},
-            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
-          }
-        }
-        """;
+                      {
+                        "deleteOne": {
+                          "filter" : {"$vector" : {"$exists" : true}},
+                          "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -1049,12 +1099,12 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
       // ensure find does not find the document
       json =
           """
-        {
-          "findOne": {
-            "filter" : {"_id" : "3"}
-          }
-        }
-        """;
+                      {
+                        "findOne": {
+                          "filter" : {"_id" : "3"}
+                        }
+                      }
+                      """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -1077,24 +1127,60 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
         .contentType(ContentType.JSON)
         .body(
             """
-                  {
-                    "createCollection": {
-                      "name" : "%s",
-                      "options": {
-                        "vector": {
-                          "size": %d,
-                          "function": "cosine"
-                        }
-                      }
-                    }
-                  }
-                  """
+                            {
+                              "createCollection": {
+                                "name" : "%s",
+                                "options": {
+                                  "vector": {
+                                    "size": %d,
+                                    "function": "cosine"
+                                  }
+                                }
+                              }
+                            }
+                            """
                 .formatted(collectionName, vectorSize))
         .when()
         .post(NamespaceResource.BASE_PATH, namespaceName)
         .then()
         .statusCode(200)
         .body("status.ok", is(1));
+  }
+
+  private void insertBigVectorDoc(String id, String name, String description, String vectorStr) {
+    final String vectorDoc =
+        """
+                    {
+                        "_id": "%s",
+                        "name": "%s",
+                        "description": "%s",
+                        "$vector": %s
+                    }
+            """
+            .formatted(
+                id, name, description, (vectorStr == null) ? "null" : "[%s]".formatted(vectorStr));
+
+    // First insert a document with a big vector
+
+    given()
+        .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+        .contentType(ContentType.JSON)
+        .body(
+            """
+                            {
+                               "insertOne": {
+                                  "document": %s
+                               }
+                            }
+                            """
+                .formatted(vectorDoc))
+        .when()
+        .post(CollectionResource.BASE_PATH, namespaceName, bigVectorCollectionName)
+        .then()
+        .statusCode(200)
+        .body("status.insertedIds[0]", is(id))
+        .body("data", is(nullValue()))
+        .body("errors", is(nullValue()));
   }
 
   private static String buildVectorElements(int offset, int count) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -69,29 +69,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
 
     @Test
     public void createBigVectorCollection() {
-      given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-          .contentType(ContentType.JSON)
-          .body(
-              """
-            {
-              "createCollection": {
-                "name" : "%s",
-                "options": {
-                  "vector": {
-                    "size": %d,
-                    "function": "cosine"
-                  }
-                }
-              }
-            }
-            """
-                  .formatted(bigVectorCollectionName, BIG_VECTOR_SIZE))
-          .when()
-          .post(NamespaceResource.BASE_PATH, namespaceName)
-          .then()
-          .statusCode(200)
-          .body("status.ok", is(1));
+      createVectorCollection(namespaceName, bigVectorCollectionName, BIG_VECTOR_SIZE);
     }
   }
 
@@ -1090,6 +1068,33 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .body("status", is(nullValue()))
           .body("errors", is(nullValue()));
     }
+  }
+
+  private static void createVectorCollection(
+      String namespaceName, String collectionName, int vectorSize) {
+    given()
+        .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+        .contentType(ContentType.JSON)
+        .body(
+            """
+                  {
+                    "createCollection": {
+                      "name" : "%s",
+                      "options": {
+                        "vector": {
+                          "size": %d,
+                          "function": "cosine"
+                        }
+                      }
+                    }
+                  }
+                  """
+                .formatted(collectionName, vectorSize))
+        .when()
+        .post(NamespaceResource.BASE_PATH, namespaceName)
+        .then()
+        .statusCode(200)
+        .body("status.ok", is(1));
   }
 
   private static String buildVectorElements(int offset, int count) {


### PR DESCRIPTION
**What this PR does**:

Changes array length validation logic for our vector embedding field and verifies that we use higher configured limit (instead of `100` or so for "regular" arrays use something like `8000` (backend will have lower limit)).
Also need to ensure caller can pass matching vectors for search.

**Which issue(s) this PR fixes**:
Fixes #475

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
