### PR TITLE
Extended the commands that supports sort clause to also support vector search

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolver.java
@@ -50,6 +50,19 @@ public class DeleteOneCommandResolver extends FilterableResolver<DeleteOneComman
   private FindOperation getFindOperation(CommandContext commandContext, DeleteOneCommand command) {
     List<DBFilterBase> filters = resolve(commandContext, command);
     final SortClause sortClause = command.sortClause();
+
+    float[] vector = SortClauseUtil.resolveVsearch(sortClause);
+
+    if (vector != null) {
+      return FindOperation.vsearchSingle(
+          commandContext,
+          filters,
+          DocumentProjector.identityProjector(),
+          ReadType.KEY,
+          objectMapper,
+          vector);
+    }
+
     List<FindOperation.OrderBy> orderBy = SortClauseUtil.resolveOrderBy(sortClause);
     // If orderBy present
     if (orderBy != null) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolver.java
@@ -53,6 +53,19 @@ public class FindOneAndDeleteCommandResolver extends FilterableResolver<FindOneA
       CommandContext commandContext, FindOneAndDeleteCommand command) {
     List<DBFilterBase> filters = resolve(commandContext, command);
     final SortClause sortClause = command.sortClause();
+
+    float[] vector = SortClauseUtil.resolveVsearch(sortClause);
+
+    if (vector != null) {
+      return FindOperation.vsearchSingle(
+          commandContext,
+          filters,
+          DocumentProjector.identityProjector(),
+          ReadType.DOCUMENT,
+          objectMapper,
+          vector);
+    }
+
     List<FindOperation.OrderBy> orderBy = SortClauseUtil.resolveOrderBy(sortClause);
     // If orderBy present
     if (orderBy != null) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolver.java
@@ -71,6 +71,19 @@ public class FindOneAndReplaceCommandResolver extends FilterableResolver<FindOne
       CommandContext commandContext, FindOneAndReplaceCommand command) {
     List<DBFilterBase> filters = resolve(commandContext, command);
     final SortClause sortClause = command.sortClause();
+
+    float[] vector = SortClauseUtil.resolveVsearch(sortClause);
+
+    if (vector != null) {
+      return FindOperation.vsearchSingle(
+          commandContext,
+          filters,
+          DocumentProjector.identityProjector(),
+          ReadType.DOCUMENT,
+          objectMapper,
+          vector);
+    }
+
     List<FindOperation.OrderBy> orderBy = SortClauseUtil.resolveOrderBy(sortClause);
     // If orderBy present
     if (orderBy != null) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
@@ -72,6 +72,18 @@ public class FindOneAndUpdateCommandResolver extends FilterableResolver<FindOneA
       CommandContext commandContext, FindOneAndUpdateCommand command) {
     List<DBFilterBase> filters = resolve(commandContext, command);
     final SortClause sortClause = command.sortClause();
+    float[] vector = SortClauseUtil.resolveVsearch(sortClause);
+
+    if (vector != null) {
+      return FindOperation.vsearchSingle(
+          commandContext,
+          filters,
+          DocumentProjector.identityProjector(),
+          ReadType.DOCUMENT,
+          objectMapper,
+          vector);
+    }
+
     List<FindOperation.OrderBy> orderBy = SortClauseUtil.resolveOrderBy(sortClause);
     // If orderBy present
     if (orderBy != null) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateOneCommandResolver.java
@@ -69,6 +69,19 @@ public class UpdateOneCommandResolver extends FilterableResolver<UpdateOneComman
   private FindOperation getFindOperation(CommandContext commandContext, UpdateOneCommand command) {
     List<DBFilterBase> filters = resolve(commandContext, command);
     final SortClause sortClause = command.sortClause();
+
+    float[] vector = SortClauseUtil.resolveVsearch(sortClause);
+
+    if (vector != null) {
+      return FindOperation.vsearchSingle(
+          commandContext,
+          filters,
+          DocumentProjector.identityProjector(),
+          ReadType.DOCUMENT,
+          objectMapper,
+          vector);
+    }
+
     List<FindOperation.OrderBy> orderBy = SortClauseUtil.resolveOrderBy(sortClause);
     // If orderBy present
     if (orderBy != null) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -748,4 +748,194 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
               is(ErrorCode.UNSUPPORTED_UPDATE_FOR_VECTOR.getMessage() + ": " + "$push"));
     }
   }
+
+  @Nested
+  @Order(1)
+  @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+  class VectorSearchExtendedCommands {
+    @Test
+    @Order(1)
+    public void setUp() {
+      insertVectorDocuments();
+    }
+
+    @Test
+    @Order(2)
+    public void findOneAndUpdate() {
+      String json =
+          """
+        {
+          "findOneAndUpdate": {
+            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
+            "update" : {"$set" : {"status" : "active"}},
+            "options" : {"returnDocument" : "after"}
+          }
+        }
+        """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.document._id", is("3"))
+          .body("data.document.status", is("active"))
+          .body("status.matchedCount", is(1))
+          .body("status.modifiedCount", is(1))
+          .body("errors", is(nullValue()));
+    }
+
+    @Test
+    @Order(3)
+    public void updateOne() {
+      String json =
+          """
+        {
+          "updateOne": {
+            "update" : {"$set" : {"new_col": "new_val"}},
+            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
+          }
+        }
+        """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.matchedCount", is(1))
+          .body("status.modifiedCount", is(1))
+          .body("status.moreData", is(nullValue()))
+          .body("errors", is(nullValue()));
+      json =
+          """
+        {
+          "findOne": {
+            "filter" : {"_id" : "3"}
+          }
+        }
+        """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.document._id", is(3))
+          .body("data.document.new_col", is("new_val"));
+    }
+
+    @Test
+    @Order(3)
+    public void findOneAndReplace() {
+      String json =
+          """
+        {
+          "findOneAndReplace": {
+            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
+            "replacement" : {"_id" : "3", "username": "user3", "status" : false, "$vector" : [0.12, 0.05, 0.08, 0.32, 0.6]},
+            "options" : {"returnDocument" : "after"}
+          }
+        }
+        """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.document._id", is("3"))
+          .body("data.document.$vector", is(notNullValue()))
+          .body("data.document.username", is("user3"))
+          .body("status.matchedCount", is(1))
+          .body("status.modifiedCount", is(1))
+          .body("errors", is(nullValue()));
+    }
+
+    @Test
+    @Order(4)
+    public void findOneAndDelete() {
+      String json =
+          """
+        {
+          "findOneAndDelete": {
+            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
+            "replacement" : {"_id" : "3", "username": "user3", "status" : false, "$vector" : [0.12, 0.05, 0.08, 0.32, 0.6]},
+            "options" : {"returnDocument" : "after"}
+          }
+        }
+        """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.document._id", is("3"))
+          .body("data.document.$vector", is(notNullValue()))
+          .body("data.document.username", is("user3"))
+          .body("status.deletedCount", is(1))
+          .body("errors", is(nullValue()));
+    }
+
+    @Test
+    @Order(5)
+    public void deleteOne() {
+      String json =
+          """
+        {
+          "deleteOne": {
+            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
+          }
+        }
+        """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.deletedCount", is(1))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
+
+      // ensure find does not find the document
+      json =
+          """
+        {
+          "findOne": {
+            "filter" : {"_id" : "2"}
+          }
+        }
+        """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.document", is(nullValue()))
+          .body("status", is(nullValue()))
+          .body("errors", is(nullValue()));
+    }
+  }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -824,7 +824,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("data.document._id", is(3))
+          .body("data.document._id", is("3"))
           .body("data.document.new_col", is("new_val"));
     }
 
@@ -898,8 +898,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           """
         {
           "findOneAndDelete": {
-            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
-            "options" : {"returnDocument" : "after"}
+            "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
           }
         }
         """;
@@ -927,6 +926,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           """
         {
           "deleteOne": {
+            "filter" : {"$vector" : {"$exists" : true}},
             "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]}
           }
         }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -913,7 +913,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .statusCode(200)
           .body("data.document._id", is("3"))
           .body("data.document.$vector", is(notNullValue()))
-          .body("data.document.username", is("user3"))
+          .body("data.document.name", is("Vision Vector Frame"))
           .body("status.deletedCount", is(1))
           .body("errors", is(nullValue()));
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -750,18 +750,13 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
   }
 
   @Nested
-  @Order(1)
+  @Order(7)
   @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
   class VectorSearchExtendedCommands {
     @Test
     @Order(1)
-    public void setUp() {
-      insertVectorDocuments();
-    }
-
-    @Test
-    @Order(2)
     public void findOneAndUpdate() {
+      insertVectorDocuments();
       String json =
           """
         {
@@ -789,8 +784,9 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     }
 
     @Test
-    @Order(3)
+    @Order(2)
     public void updateOne() {
+      insertVectorDocuments();
       String json =
           """
         {
@@ -835,6 +831,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     @Test
     @Order(3)
     public void findOneAndReplace() {
+      insertVectorDocuments();
       String json =
           """
         {
@@ -864,13 +861,44 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
 
     @Test
     @Order(4)
+    public void findOneAndReplaceWithoutVector() {
+      insertVectorDocuments();
+      String json =
+          """
+            {
+              "findOneAndReplace": {
+                "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
+                "replacement" : {"_id" : "3", "username": "user3", "status" : false},
+                "options" : {"returnDocument" : "after"}
+              }
+            }
+            """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.document._id", is("3"))
+          .body("data.document.$vector", is(nullValue()))
+          .body("data.document.username", is("user3"))
+          .body("status.matchedCount", is(1))
+          .body("status.modifiedCount", is(1))
+          .body("errors", is(nullValue()));
+    }
+
+    @Test
+    @Order(5)
     public void findOneAndDelete() {
+      insertVectorDocuments();
       String json =
           """
         {
           "findOneAndDelete": {
             "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
-            "replacement" : {"_id" : "3", "username": "user3", "status" : false, "$vector" : [0.12, 0.05, 0.08, 0.32, 0.6]},
             "options" : {"returnDocument" : "after"}
           }
         }
@@ -892,8 +920,9 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     public void deleteOne() {
+      insertVectorDocuments();
       String json =
           """
         {
@@ -920,7 +949,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           """
         {
           "findOne": {
-            "filter" : {"_id" : "2"}
+            "filter" : {"_id" : "3"}
           }
         }
         """;

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolverTest.java
@@ -120,6 +120,49 @@ public class FindOneAndDeleteCommandResolverTest {
     }
 
     @Test
+    public void filterConditionVectorSearch() throws Exception {
+      String json =
+          """
+        {
+          "findOneAndDelete": {
+            "filter" : {"status" : "active"},
+            "sort" : {"$vector" : [0.11, 0.22, 0.33, 0.44]}
+          }
+        }
+        """;
+
+      FindOneAndDeleteCommand command = objectMapper.readValue(json, FindOneAndDeleteCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, command);
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              DeleteOperation.class,
+              op -> {
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.returnDocumentInResponse()).isTrue();
+                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
+                assertThat(op.findOperation())
+                    .isInstanceOfSatisfying(
+                        FindOperation.class,
+                        find -> {
+                          DBFilterBase.TextFilter filter =
+                              new DBFilterBase.TextFilter(
+                                  "status", DBFilterBase.MapFilterBase.Operator.EQ, "active");
+
+                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                          assertThat(find.commandContext()).isEqualTo(commandContext);
+                          assertThat(find.pageSize()).isEqualTo(1);
+                          assertThat(find.limit()).isEqualTo(1);
+                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
+                          assertThat(find.filters()).singleElement().isEqualTo(filter);
+                          assertThat(find.vector()).isNotNull();
+                          assertThat(find.vector()).containsExactly(0.11f, 0.22f, 0.33f, 0.44f);
+                          assertThat(find.singleResponse()).isTrue();
+                        });
+              });
+    }
+
+    @Test
     public void idFilterWithProjection() throws Exception {
       String json =
           """

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolverTest.java
@@ -230,6 +230,71 @@ public class FindOneAndReplaceCommandResolverTest {
     }
 
     @Test
+    public void filterConditionVectorSearch() throws Exception {
+      String json =
+          """
+                {
+                  "findOneAndReplace": {
+                    "filter" : {"status" : "active"},
+                    "sort" : {"$vector" : [0.11,  0.22, 0.33, 0.44]},
+                    "replacement" : {"col1" : "val1", "col2" : "val2"}
+                  }
+                }
+                """;
+
+      FindOneAndReplaceCommand command =
+          objectMapper.readValue(json, FindOneAndReplaceCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, command);
+      String expected = "{\"col1\":\"val1\",\"col2\":\"val2\"}";
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              ReadAndUpdateOperation.class,
+              op -> {
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.returnDocumentInResponse()).isTrue();
+                assertThat(op.returnUpdatedDocument()).isFalse();
+                assertThat(op.upsert()).isFalse();
+                assertThat(op.shredder()).isEqualTo(shredder);
+                assertThat(op.updateLimit()).isEqualTo(1);
+                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
+                assertThat(op.documentUpdater())
+                    .isInstanceOfSatisfying(
+                        DocumentUpdater.class,
+                        replacer -> {
+                          try {
+                            ObjectNode replacement =
+                                (ObjectNode)
+                                    objectMapper.readTree(
+                                        "{\"col1\" : \"val1\", \"col2\" : \"val2\"}");
+                          } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                          }
+                          assertThat(replacer.replaceDocument().toString()).isEqualTo(expected);
+                          assertThat(replacer.replaceDocumentId()).isNull();
+                        });
+                assertThat(op.findOperation())
+                    .isInstanceOfSatisfying(
+                        FindOperation.class,
+                        find -> {
+                          DBFilterBase.TextFilter filter =
+                              new DBFilterBase.TextFilter(
+                                  "status", DBFilterBase.MapFilterBase.Operator.EQ, "active");
+
+                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                          assertThat(find.commandContext()).isEqualTo(commandContext);
+                          assertThat(find.pageSize()).isEqualTo(1);
+                          assertThat(find.limit()).isEqualTo(1);
+                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
+                          assertThat(find.filters()).singleElement().isEqualTo(filter);
+                          assertThat(find.vector()).isNotNull();
+                          assertThat(find.vector()).containsExactly(0.11f, 0.22f, 0.33f, 0.44f);
+                          assertThat(find.singleResponse()).isTrue();
+                        });
+              });
+    }
+
+    @Test
     public void idFilterConditionWithOptions() throws Exception {
       String json =
           """


### PR DESCRIPTION

**What this PR does**:
Extended the commands that supports sort clause to also support vector search

**Which issue(s) this PR fixes**:
Fixes #478 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
