### PR TITLE
update workflows to reference dse-next backend

### DIFF
--- a/.github/workflows/performance-testing.yaml
+++ b/.github/workflows/performance-testing.yaml
@@ -100,7 +100,7 @@ jobs:
           docker pull ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-68:$SGTAG
           docker image tag ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-68:$SGTAG stargateio/coordinator-dse-68:$SGTAG
           cd docker-compose
-          ./start_dse_68_dev_mode.sh ${{ matrix.docker-flags }} -j $JSONTAG -t $SGTAG
+          ./start_dse_next_dev_mode.sh ${{ matrix.docker-flags }} -j $JSONTAG -t $SGTAG
 
       # Install NB and required library
       # See: https://github.com/AppImage/AppImageKit/wiki/FUSE

--- a/.github/workflows/postman-docker.yaml
+++ b/.github/workflows/postman-docker.yaml
@@ -56,7 +56,7 @@ jobs:
           docker pull ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-68:$SGTAG
           docker image tag ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-68:$SGTAG stargateio/coordinator-dse-68:$SGTAG
           cd docker-compose
-          ./start_dse_68_dev_mode.sh -j $JSONTAG -t $SGTAG
+          ./start_dse_next_dev_mode.sh -j $JSONTAG -t $SGTAG
 
       - name: Install Postman CLI
         run: |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The quickest way to test out the JSON API directly is to start a local copy of t
 
 ```shell
 cd docker-compose
-./start_dse_68_dev_mode.sh
+./start_dse_next_dev_mode.sh
 ```
 
 This starts an instance of the JSON API along with a Stargate coordinator node in "developer mode" (with DataStax Enterprise 6.8 embedded). 


### PR DESCRIPTION
The names of the docker compose start scripts were changed in #476, this PR updates the GitHub Actions workflows to reference the new names.

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
