### PR TITLE
Default vector search function name to cosine.

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
@@ -48,6 +48,11 @@ public record CreateCollectionCommand(
                 defaultValue = "cosine",
                 type = SchemaType.STRING,
                 implementation = String.class)
-            String function) {}
+            String function) {
+      public VectorSearchConfig(Integer size, String function) {
+        this.size = size;
+        this.function = function == null ? "cosine" : function;
+      }
+    }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
@@ -41,7 +41,9 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
           ctx,
           command.name(),
           command.options().vector().size(),
-          command.options().vector().function());
+          command.options().vector().function() == null
+              ? "cosine"
+              : command.options().vector().function());
     } else {
       return CreateCollectionOperation.withoutVectorSearch(ctx, command.name());
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
@@ -41,9 +41,7 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
           ctx,
           command.name(),
           command.options().vector().size(),
-          command.options().vector().function() == null
-              ? "cosine"
-              : command.options().vector().function());
+          command.options().vector().function());
     } else {
       return CreateCollectionOperation.withoutVectorSearch(ctx, command.name());
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
@@ -346,6 +346,37 @@ class ObjectMapperConfigurationTest {
                 assertThat(createCollection.options().vector().function()).isEqualTo("cosine");
               });
     }
+
+    @Test
+    public void happyPathVectorSearchDefaultFunction() throws Exception {
+      String json =
+          """
+          {
+            "createCollection": {
+              "name": "some_name",
+              "options": {
+                "vector": {
+                  "size": 5
+                }
+              }
+            }
+          }
+          """;
+
+      Command result = objectMapper.readValue(json, Command.class);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              CreateCollectionCommand.class,
+              createCollection -> {
+                String name = createCollection.name();
+                assertThat(name).isNotNull();
+                assertThat(createCollection.options()).isNotNull();
+                assertThat(createCollection.options().vector()).isNotNull();
+                assertThat(createCollection.options().vector().size()).isEqualTo(5);
+                assertThat(createCollection.options().vector().function()).isEqualTo("cosine");
+              });
+    }
   }
 
   @Nested

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -62,6 +62,32 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .statusCode(200)
           .body("status.ok", is(1));
     }
+
+    @Test
+    public void happyPathVectorSearchDefaultFunction() {
+      String json =
+          """
+        {
+          "createCollection": {
+            "name" : "my_collection_default_function",
+            "options": {
+              "vector": {
+                "size": 5
+              }
+            }
+          }
+        }
+        """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+    }
   }
 
   @Nested

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolverTest.java
@@ -85,5 +85,36 @@ class CreateCollectionCommandResolverTest {
                 assertThat(op.vectorFunction()).isEqualTo("cosine");
               });
     }
+
+    @Test
+    public void happyPathVectorSearchDefaultFunction() throws Exception {
+      String json =
+          """
+        {
+          "createCollection": {
+            "name" : "my_collection",
+            "options": {
+              "vector": {
+                "size": 4
+              }
+            }
+          }
+        }
+        """;
+
+      CreateCollectionCommand command = objectMapper.readValue(json, CreateCollectionCommand.class);
+      Operation result = resolver.resolveCommand(commandContext, command);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              CreateCollectionOperation.class,
+              op -> {
+                assertThat(op.name()).isEqualTo("my_collection");
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.vectorSearch()).isEqualTo(true);
+                assertThat(op.vectorSize()).isEqualTo(4);
+                assertThat(op.vectorFunction()).isEqualTo("cosine");
+              });
+    }
   }
 }


### PR DESCRIPTION
**What this PR does**:
Fixed to use default vector search function name to cosine.
**Which issue(s) this PR fixes**:
Fixes #483 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
