### PR TITLE
update workflows to reference coordinator-dse-next image

### DIFF
--- a/.github/workflows/performance-testing.yaml
+++ b/.github/workflows/performance-testing.yaml
@@ -97,8 +97,8 @@ jobs:
           docker pull ${{ secrets.ECR_REPOSITORY }}/stargateio/${{ matrix.docker-image }}:$JSONTAG
           docker image tag ${{ secrets.ECR_REPOSITORY }}/stargateio/${{ matrix.docker-image }}:$JSONTAG stargateio/${{ matrix.docker-image }}:$JSONTAG
           SGTAG="$(./mvnw -f . help:evaluate -Dexpression=stargate.int-test.coordinator.image-tag -q -DforceStdout)"
-          docker pull ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-68:$SGTAG
-          docker image tag ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-68:$SGTAG stargateio/coordinator-dse-68:$SGTAG
+          docker pull ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-next:$SGTAG
+          docker image tag ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-next:$SGTAG stargateio/coordinator-dse-next:$SGTAG
           cd docker-compose
           ./start_dse_next_dev_mode.sh ${{ matrix.docker-flags }} -j $JSONTAG -t $SGTAG
 

--- a/.github/workflows/postman-docker.yaml
+++ b/.github/workflows/postman-docker.yaml
@@ -53,8 +53,8 @@ jobs:
           docker pull ${{ secrets.ECR_REPOSITORY }}/stargateio/jsonapi:$JSONTAG
           docker image tag ${{ secrets.ECR_REPOSITORY }}/stargateio/jsonapi:$JSONTAG stargateio/jsonapi:$JSONTAG
           SGTAG="$(./mvnw -f . help:evaluate -Dexpression=stargate.int-test.coordinator.image-tag -q -DforceStdout)"
-          docker pull ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-68:$SGTAG
-          docker image tag ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-68:$SGTAG stargateio/coordinator-dse-68:$SGTAG
+          docker pull ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-next:$SGTAG
+          docker image tag ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-next:$SGTAG stargateio/coordinator-dse-next:$SGTAG
           cd docker-compose
           ./start_dse_next_dev_mode.sh -j $JSONTAG -t $SGTAG
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Note that this project uses Java 17, please ensure that you have the target JDK 
 
 You can run your application in dev mode that enables live coding using:
 ```shell script
-docker run -d --rm -e CLUSTER_NAME=dse-cluster -e CLUSTER_VERSION=6.8 -e ENABLE_AUTH=true -e DEVELOPER_MODE=true -e DS_LICENSE=accept -e DSE=true -p 8081:8081 -p 8091:8091 -p 9042:9042 stargateio/coordinator-dse-68:v2
+docker run -d --rm -e CLUSTER_NAME=dse-cluster -e CLUSTER_VERSION=6.8 -e ENABLE_AUTH=true -e DEVELOPER_MODE=true -e DS_LICENSE=accept -e DSE=true -p 8081:8081 -p 8091:8091 -p 9042:9042 stargateio/coordinator-dse-next:v2
 
 ./mvnw compile quarkus:dev
 ```


### PR DESCRIPTION
Follow up to #484, a few references in GitHub Action workflows to `coordinator-dse-68` were missed, these need to be changed to `coordinator-dse-next`.

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
