### PR TITLE
Docker compose defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,31 +98,15 @@ They are separated from the unit tests and are running as part of the `integrati
 ./mvnw integration-test
 ```
 
-#### Data store selection
-
-Depending on the active profile, integration tests will target different Cassandra version as the data store.
-The available profiles are:
-
-* `cassandra-40` (enabled by default) - runs integration tests with [Cassandra 4.0](https://cassandra.apache.org/doc/4.0/index.html) as the data store
-* `cassandra-311` - runs integration tests with [Cassandra 3.11](https://cassandra.apache.org/doc/3.11/index.html) as the data store
-* `dse-68` - runs integration tests with [DataStax Enterprise (DSE) 6.8](https://docs.datastax.com/en/dse/6.8/dse-dev/index.html) as the data store
-
-The required profile can be activated using the `-P` option:
-
-```shell script
-./mvnw integration-test -P cassandra-311
-```
-
 #### Running from IDE
 
 Running integration tests from an IDE is supported out of the box.
-The tests will use the Cassandra 4.0 as the data store by default.
+The tests will use the DSE Next as the data store by default.
 Running a test with a different version of the data store or the Stargate coordinator requires changing the run configuration and specifying the following system properties:
 
-* `testing.containers.cassandra-image` - version of the Cassandra docker image to use, for example: `cassandra:4.0.4`
-* `testing.containers.stargate-image` - version of the Stargate coordinator docker image to use, for example: `stargateio/coordinator-4_0:v2.0.0-ALPHA-10-SNAPSHOT` (must be V2 coordinator for the target data store)
-* `testing.containers.cluster-version` - version of the cluster, for example: `4.0` (should be one of `3.11`, `4.0` or `6.8`)
-* `testing.containers.cluster-dse` - optional and only needed if DSE is used
+* `testing.containers.cassandra-image` - version of the Cassandra docker image to use, for example: `stargateio/dse-next:4.0.7-336cdd7405ee`
+* `testing.containers.stargate-image` - version of the Stargate coordinator docker image to use, for example: `stargateio/coordinator-4_0:v2.1` (must be V2.1 coordinator for the target data store)
+* `testing.containers.cluster-dse` - optional and only needed if coordinator is used
 
 #### Executing against a running application
 

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -57,13 +57,15 @@ docker-compose -f docker-compose-dev-mode.yml down
 
 Both convenience scripts support the following options:
 
-* You can specify an image tag (version) of the JSON API using `-t [VERSION]`, or use the `-l` tag to use a locally built image with the latest snapshot version. 
+* You can specify an image tag (version) of the JSON API using `-j [VERSION]`, or use the `-l` tag to use a locally built image with the latest snapshot version. 
 
 * The scripts default to using the Java-based image for JSON API, you can specify to use the native GraalVM based variant using `-n`.
 
 * You can change the default root log level for the JSON API using `-r [LEVEL]` (default `INFO`). Valid values: `ERROR`, `WARN`, `INFO`, `DEBUG`
 
 * You can enable reguest logging for the JSON API using `-q`: if so, each request is logged under category `io.quarkus.http.access-log`
+
+* You can specify an image tag (version) of the Stargate coordinator using `-t [VERSION]`.
 
 ## Notes
 

--- a/docker-compose/start_dse_next.sh
+++ b/docker-compose/start_dse_next.sh
@@ -12,11 +12,16 @@ LOGLEVEL=INFO
 # Default to images used in project integration tests
 DSETAG="$(../mvnw -f .. help:evaluate -Dexpression=stargate.int-test.cassandra.image-tag -q -DforceStdout)"
 SGTAG="$(../mvnw -f .. help:evaluate -Dexpression=stargate.int-test.coordinator.image-tag -q -DforceStdout)"
-JSONTAG="v$(../mvnw -f .. help:evaluate -Dexpression=project.version -q -DforceStdout)"
+
+# Default to latest released version
+JSONTAG="v1"
 JSONIMAGE="stargateio/jsonapi"
 
-while getopts "qnr:t:j:" opt; do
+while getopts "lqnr:t:j:" opt; do
   case $opt in
+    l)
+      JSONTAG="v$(../mvnw -f .. help:evaluate -Dexpression=project.version -q -DforceStdout)"
+      ;;
     j)
       JSONTAG=$OPTARG
       ;;
@@ -34,6 +39,7 @@ while getopts "qnr:t:j:" opt; do
       ;;
     \?)
       echo "Valid options:"
+      echo "  -l - use JSON API Docker image from local build (see project README for build instructions)"
       echo "  -j <tag> - use JSON API Docker image tagged with specified JSON API version (will pull images from Docker Hub if needed)"
       echo "  -n <tag> - use JSON API native image instead of default Java-based image"
       echo "  -t <tag> - use Stargate coordinator Docker image tagged with specified  version (will pull images from Docker Hub if needed)"

--- a/docker-compose/start_dse_next_dev_mode.sh
+++ b/docker-compose/start_dse_next_dev_mode.sh
@@ -12,11 +12,16 @@ LOGLEVEL=INFO
 # Default to images used in project integration tests
 DSETAG="$(../mvnw -f .. help:evaluate -Dexpression=stargate.int-test.cassandra.image-tag -q -DforceStdout)"
 SGTAG="$(../mvnw -f .. help:evaluate -Dexpression=stargate.int-test.coordinator.image-tag -q -DforceStdout)"
-JSONTAG="v$(../mvnw -f .. help:evaluate -Dexpression=project.version -q -DforceStdout)"
+
+# Default to latest released version
+JSONTAG="v1"
 JSONIMAGE="stargateio/jsonapi"
 
-while getopts "qnr:t:j:" opt; do
+while getopts "lqnr:t:j:" opt; do
   case $opt in
+    l)
+      JSONTAG="v$(../mvnw -f .. help:evaluate -Dexpression=project.version -q -DforceStdout)"
+      ;;
     j)
       JSONTAG=$OPTARG
       ;;
@@ -34,6 +39,7 @@ while getopts "qnr:t:j:" opt; do
       ;;
     \?)
       echo "Valid options:"
+      echo "  -l - use JSON API Docker image from local build (see project README for build instructions)"
       echo "  -j <tag> - use JSON API Docker image tagged with specified JSON API version (will pull images from Docker Hub if needed)"
       echo "  -n <tag> - use JSON API native image instead of default Java-based image"
       echo "  -t <tag> - use Stargate coordinator Docker image tagged with specified  version (will pull images from Docker Hub if needed)"

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,6 @@
                 <testing.containers.cassandra-image>${stargate.int-test.cassandra.image}:${stargate.int-test.cassandra.image-tag}</testing.containers.cassandra-image>
                 <testing.containers.stargate-image>${stargate.int-test.coordinator.image}:${stargate.int-test.coordinator.image-tag}</testing.containers.stargate-image>
                 <testing.containers.cluster-name>${stargate.int-test.cluster.name}</testing.containers.cluster-name>
-                <testing.containers.cluster-version>${stargate.int-test.cluster.version}</testing.containers.cluster-version>
                 <testing.containers.cluster-dse>${stargate.int-test.cluster.dse}</testing.containers.cluster-dse>
                 <testing.package.type>${quarkus.package.type}</testing.package.type>
                 <maven.home>${maven.home}</maven.home>


### PR DESCRIPTION
Update docker compose to default to using JSON API image tagged `v1` instead of requiring local build of Docker image
Fixes #489 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
