### PR TITLE
pull docker image for coordinator from ECR

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -106,8 +106,6 @@ jobs:
       # run the int tests
       - name: Integration Test
         env:
-          COORD_IMAGE: index.docker.io/stargateio/coordinator-dse-next
-          # ^^^ 24-Jul-2023, tatu: Temporary issues wrt ECR, need to use dockerhub instead
-          #COORD_IMAGE: 237073351946.dkr.ecr.us-east-1.amazonaws.com/stargateio/coordinator-dse-next
+          COORD_IMAGE: ${{ secrets.ECR_REPOSITORY }}/stargateio/coordinator-dse-next
         run: |
           ./mvnw -B -ntp clean verify -DskipUnitTests -Dquarkus.container-image.build=true -Dquarkus.container-image.tag=${{ github.sha }} -Dstargate.int-test.coordinator.image=$COORD_IMAGE ${{ matrix.profile }}


### PR DESCRIPTION
Reverts temporary change recently made to CI workflow (under PR #470) to pull coordinator image from Docker Hub. The issue is resolved and we can go back to pulling from ECR

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
