### PR TITLE
update parent workflow for 2.1.x event

### DIFF
--- a/.github/workflows/update-parent-version.yaml
+++ b/.github/workflows/update-parent-version.yaml
@@ -2,15 +2,15 @@
 name: Update Parent Version
 
 # runs on
-# * stargate v2 release event
+# * stargate v2.1 release event
 # * manual trigger
 on:
   repository_dispatch:
-    types: [ stargate-v2-release ]
+    types: [ stargate-v21-release ]
   workflow_dispatch:
     inputs:
       version:
-        description: 'Stargate version to update, for example `v2.0.9`.'
+        description: 'Stargate version to update, for example `v2.1.0`.'
         required: true
         type: string
 


### PR DESCRIPTION
Since we updated JSON API to work against Stargate v2.1, we also need to update the automated workflow `update-parent-version.yaml`. The Stargate repo publishes a different event for v2.1 called `stargate-v21-release`.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
