### PR TITLE
Projection clause support for similarity function score

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandContext.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandContext.java
@@ -1,18 +1,24 @@
 package io.stargate.sgv2.jsonapi.api.model.command;
 
+import io.stargate.sgv2.jsonapi.service.bridge.executor.NamespaceCache;
+
 /**
  * Defines the context in which to execute the command.
  *
  * @param namespace The name of the namespace.
  * @param collection The name of the collection.
  */
-public record CommandContext(String namespace, String collection, boolean isVectorEnabled) {
+public record CommandContext(
+    String namespace,
+    String collection,
+    boolean isVectorEnabled,
+    NamespaceCache.CollectionProperty.SimilarityFunction similarityFunction) {
 
   public CommandContext(String namespace, String collection) {
-    this(namespace, collection, false);
+    this(namespace, collection, false, null);
   }
 
-  private static final CommandContext EMPTY = new CommandContext(null, null, false);
+  private static final CommandContext EMPTY = new CommandContext(null, null, false, null);
 
   /**
    * @return Returns empty command context, having both {@link #namespace} and {@link #collection}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandContext.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandContext.java
@@ -7,6 +7,8 @@ import io.stargate.sgv2.jsonapi.service.bridge.executor.NamespaceCache;
  *
  * @param namespace The name of the namespace.
  * @param collection The name of the collection.
+ * @param isVectorEnabled Whether the vector is enabled for the collection
+ * @param similarityFunction The similarity function used for indexing the vector
  */
 public record CommandContext(
     String namespace,

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Projectable.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/Projectable.java
@@ -10,6 +10,10 @@ public interface Projectable {
   JsonNode projectionDefinition();
 
   default DocumentProjector buildProjector() {
-    return DocumentProjector.createFromDefinition(projectionDefinition());
+    return buildProjector(false);
+  }
+
+  default DocumentProjector buildProjector(boolean includeSimilarity) {
+    return DocumentProjector.createFromDefinition(projectionDefinition(), includeSimilarity);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
@@ -50,5 +50,12 @@ public record FindCommand(
               description = "Next page state for pagination.",
               type = SchemaType.STRING,
               implementation = String.class)
-          String pagingState) {}
+          String pagingState,
+
+      // include similarity function score
+      @Schema(
+              description = "Include similarity function score in response.",
+              type = SchemaType.BOOLEAN,
+              implementation = Boolean.class)
+          boolean includeSimilarity) {}
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindOneCommand.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.stargate.sgv2.jsonapi.api.model.command.Filterable;
-import io.stargate.sgv2.jsonapi.api.model.command.NoOptionsCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.Projectable;
 import io.stargate.sgv2.jsonapi.api.model.command.ReadCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.FilterClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
 import jakarta.validation.Valid;
+import javax.annotation.Nullable;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(description = "Command that finds a single JSON document from a collection.")
@@ -17,5 +18,15 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 public record FindOneCommand(
     @Valid @JsonProperty("filter") FilterClause filterClause,
     @JsonProperty("projection") JsonNode projectionDefinition,
-    @Valid @JsonProperty("sort") SortClause sortClause)
-    implements ReadCommand, NoOptionsCommand, Filterable, Projectable {}
+    @Valid @JsonProperty("sort") SortClause sortClause,
+    @Valid @Nullable Options options)
+    implements ReadCommand, Filterable, Projectable {
+  public record Options(
+
+      // include similarity function score
+      @Schema(
+              description = "Include similarity function score in response.",
+              type = SchemaType.BOOLEAN,
+              implementation = Boolean.class)
+          boolean includeSimilarity) {}
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
@@ -148,10 +148,10 @@ public class CollectionResource {
           @Size(min = 1, max = 48)
           String collection) {
     return schemaCache
-        .isVectorEnabled(stargateRequestInfo.getTenantId(), namespace, collection)
+        .getCollectionProperties(stargateRequestInfo.getTenantId(), namespace, collection)
         .onItemOrFailure()
         .transformToUni(
-            (isVectorEnabled, throwable) -> {
+            (collectionProperty, throwable) -> {
               if (throwable != null) {
                 Throwable error = throwable;
                 if (throwable instanceof RuntimeException && throwable.getCause() != null)
@@ -163,7 +163,11 @@ public class CollectionResource {
                 return Uni.createFrom().item(new ThrowableCommandResultSupplier(error));
               } else {
                 CommandContext commandContext =
-                    new CommandContext(namespace, collection, isVectorEnabled);
+                    new CommandContext(
+                        namespace,
+                        collection,
+                        collectionProperty.vectorEnabled(),
+                        collectionProperty.similarityFunction());
 
                 // call processor
                 return meteredCommandProcessor.processCommand(commandContext, command);

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
@@ -15,6 +15,12 @@ public interface DocumentConstants {
     /** Primary key for Documents stored; has special handling for many operations. */
     String VECTOR_EMBEDDING_FIELD = "$vector";
 
+    /** Key for vector function name definition in cql index. */
+    String VECTOR_INDEX_FUNCTION_NAME = "similarity_function";
+
+    /** Field name used in projection clause to get similarity score in response. */
+    String VECTOR_FUNCTION_PROJECTION_FIELD = "$similarity";
+
     // Current definition of valid JSON API names: note that this only validates
     // characters, not length limits (nor empty nor "too long" allowed but validated
     // separately)

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -86,7 +86,7 @@ public enum ErrorCode {
 
   VECTOR_SEARCH_NOT_SUPPORTED("Vector search is not enabled for the collection "),
 
-  VECTOR_SEARCH_INVALID_FUCTION_NAME("Invalid vector search function name"),
+  VECTOR_SEARCH_INVALID_FUCTION_NAME("Invalid vector search function name "),
 
   VECTOR_SEARCH_SIMILARITY_PROJECTION_NOT_SUPPORTED(
       "$similarity projection is not supported for this command"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -86,6 +86,8 @@ public enum ErrorCode {
 
   VECTOR_SEARCH_NOT_SUPPORTED("Vector search is not enabled for the collection "),
 
+  VECTOR_SEARCH_INVALID_FUCTION_NAME("Invalid vector search function name"),
+
   VECTOR_SEARCH_FIELD_TOO_BIG("Vector embedding field '$vector' length too big");
 
   private final String message;

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -88,6 +88,9 @@ public enum ErrorCode {
 
   VECTOR_SEARCH_INVALID_FUCTION_NAME("Invalid vector search function name"),
 
+  VECTOR_SEARCH_SIMILARITY_PROJECTION_NOT_SUPPORTED(
+      "$similarity projection is not supported for this command"),
+
   VECTOR_SEARCH_FIELD_TOO_BIG("Vector embedding field '$vector' length too big");
 
   private final String message;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/NamespaceCache.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/NamespaceCache.java
@@ -63,9 +63,9 @@ public class NamespaceCache {
   private Uni<CollectionProperty> getVectorProperties(String collectionName) {
     return queryExecutor
         .getSchema(namespace, collectionName)
-        .onItemOrFailure()
+        .onItem()
         .transform(
-            (table, error) -> {
+            table -> {
               if (table.isPresent()) {
                 Boolean vectorEnabled =
                     table.get().getColumnsList().stream()

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/NamespaceCache.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/NamespaceCache.java
@@ -125,7 +125,7 @@ public class NamespaceCache {
 
       public static SimilarityFunction fromString(String similarityFunction) {
         if (similarityFunction == null) return UNDEFINED;
-        return switch (similarityFunction) {
+        return switch (similarityFunction.toLowerCase()) {
           case "cosine" -> COSINE;
           case "euclidean" -> EUCLIDEAN;
           case "dot_product" -> DOT_PRODUCT;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/SchemaCache.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/SchemaCache.java
@@ -16,11 +16,11 @@ public class SchemaCache {
   private final Cache<CacheKey, NamespaceCache> schemaCache =
       Caffeine.newBuilder().maximumSize(1000).build();
 
-  public Uni<Boolean> isVectorEnabled(
+  public Uni<NamespaceCache.CollectionProperty> getCollectionProperties(
       Optional<String> tenant, String namespace, String collectionName) {
     final NamespaceCache namespaceCache =
         schemaCache.get(new CacheKey(tenant, namespace), this::addNamespaceCache);
-    return namespaceCache.isVectorEnabled(collectionName);
+    return namespaceCache.getCollectionProperties(collectionName);
   }
 
   private NamespaceCache addNamespaceCache(CacheKey cacheKey) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
@@ -86,7 +86,12 @@ public interface ReadOperation extends Operation {
                   JsonNode root =
                       readDocument ? objectMapper.readTree(Values.string(row.getValues(2))) : null;
                   if (root != null) {
-                    projection.applyProjection(root);
+                    if (projection.doIncludeSimilarityScore()) {
+                      float score = Values.float_(row.getValues(3)); // similarity_score
+                      projection.applyProjection(root, score);
+                    } else {
+                      projection.applyProjection(root, 0);
+                    }
                   }
                   document =
                       ReadDocument.from(
@@ -279,7 +284,7 @@ public interface ReadOperation extends Operation {
                       .map(
                           readDoc -> {
                             JsonNode data = readDoc.docJsonValue().get();
-                            projection.applyProjection(data);
+                            projection.applyProjection(data, 0);
                             return ReadDocument.from(readDoc.id(), readDoc.txnId(), data);
                           })
                       .collect(Collectors.toList());

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
@@ -90,7 +90,7 @@ public interface ReadOperation extends Operation {
                       float score = Values.float_(row.getValues(3)); // similarity_score
                       projection.applyProjection(root, score);
                     } else {
-                      projection.applyProjection(root, 0);
+                      projection.applyProjection(root);
                     }
                   }
                   document =
@@ -284,7 +284,7 @@ public interface ReadOperation extends Operation {
                       .map(
                           readDoc -> {
                             JsonNode data = readDoc.docJsonValue().get();
-                            projection.applyProjection(data, 0);
+                            projection.applyProjection(data);
                             return ReadDocument.from(readDoc.id(), readDoc.txnId(), data);
                           })
                       .collect(Collectors.toList());

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -64,14 +64,14 @@ public class DocumentProjector {
   }
 
   public void applyProjection(JsonNode document) {
-    applyProjection(document, 0.0f);
+    applyProjection(document, null);
   }
 
-  public void applyProjection(JsonNode document, float similarityScore) {
+  public void applyProjection(JsonNode document, Float similarityScore) {
     if (rootLayer == null) { // null -> identity projection (no-op)
       return;
     }
-    if (includeSimilarityScore) {
+    if (includeSimilarityScore && similarityScore != null) {
       ((ObjectNode) document)
           .put(DocumentConstants.Fields.VECTOR_FUNCTION_PROJECTION_FIELD, similarityScore);
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -73,9 +73,7 @@ public class DocumentProjector {
     }
     if (includeSimilarityScore) {
       ((ObjectNode) document)
-          .put(
-              DocumentConstants.Fields.VECTOR_FUNCTION_PROJECTION_FIELD,
-              new BigDecimal(similarityScore));
+          .put(DocumentConstants.Fields.VECTOR_FUNCTION_PROJECTION_FIELD, similarityScore);
     }
     if (inclusion) {
       rootLayer.applyInclusions(document);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolver.java
@@ -45,6 +45,7 @@ public class FindCommandResolver extends FilterableResolver<FindCommand>
     int limit = Integer.MAX_VALUE;
     int skip = 0;
     String pagingState = null;
+    boolean includeSimilarity = false;
 
     // update if options provided
     FindCommand.Options options = command.options();
@@ -56,6 +57,7 @@ public class FindCommandResolver extends FilterableResolver<FindCommand>
         skip = options.skip();
       }
       pagingState = options.pagingState();
+      includeSimilarity = options.includeSimilarity();
     }
 
     // resolve sort clause
@@ -71,7 +73,7 @@ public class FindCommandResolver extends FilterableResolver<FindCommand>
       return FindOperation.vsearch(
           commandContext,
           filters,
-          command.buildProjector(),
+          command.buildProjector(includeSimilarity),
           pagingState,
           limit,
           operationsConfig.defaultPageSize(),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolver.java
@@ -5,6 +5,8 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndReplaceCommand;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
@@ -46,6 +48,12 @@ public class FindOneAndReplaceCommandResolver extends FilterableResolver<FindOne
   public Operation resolveCommand(CommandContext commandContext, FindOneAndReplaceCommand command) {
     FindOperation findOperation = getFindOperation(commandContext, command);
 
+    final DocumentProjector documentProjector = command.buildProjector();
+    if (documentProjector.doIncludeSimilarityScore()) {
+      throw new JsonApiException(
+          ErrorCode.VECTOR_SEARCH_SIMILARITY_PROJECTION_NOT_SUPPORTED,
+          ErrorCode.VECTOR_SEARCH_SIMILARITY_PROJECTION_NOT_SUPPORTED.getMessage());
+    }
     DocumentUpdater documentUpdater = DocumentUpdater.construct(command.replacementDocument());
 
     // resolve options
@@ -62,7 +70,7 @@ public class FindOneAndReplaceCommandResolver extends FilterableResolver<FindOne
         returnUpdatedDocument,
         upsert,
         shredder,
-        command.buildProjector(),
+        documentProjector,
         1,
         operationsConfig.lwt().retries());
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolver.java
@@ -5,6 +5,8 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.sort.SortClause;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndUpdateCommand;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
@@ -46,6 +48,13 @@ public class FindOneAndUpdateCommandResolver extends FilterableResolver<FindOneA
   public Operation resolveCommand(CommandContext commandContext, FindOneAndUpdateCommand command) {
     FindOperation findOperation = getFindOperation(commandContext, command);
 
+    final DocumentProjector documentProjector = command.buildProjector();
+    if (documentProjector.doIncludeSimilarityScore()) {
+      throw new JsonApiException(
+          ErrorCode.VECTOR_SEARCH_SIMILARITY_PROJECTION_NOT_SUPPORTED,
+          ErrorCode.VECTOR_SEARCH_SIMILARITY_PROJECTION_NOT_SUPPORTED.getMessage());
+    }
+
     DocumentUpdater documentUpdater = DocumentUpdater.construct(command.updateClause());
 
     // resolve options
@@ -63,7 +72,7 @@ public class FindOneAndUpdateCommandResolver extends FilterableResolver<FindOneA
         returnUpdatedDocument,
         upsert,
         shredder,
-        command.buildProjector(),
+        documentProjector,
         1,
         operationsConfig.lwt().retries());
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneCommandResolver.java
@@ -43,10 +43,15 @@ public class FindOneCommandResolver extends FilterableResolver<FindOneCommand>
     float[] vector = SortClauseUtil.resolveVsearch(sortClause);
 
     if (vector != null) {
+      FindOneCommand.Options options = command.options();
+      boolean includeSimilarity = false;
+      if (options != null) {
+        includeSimilarity = options.includeSimilarity();
+      }
       return FindOperation.vsearchSingle(
           commandContext,
           filters,
-          command.buildProjector(),
+          command.buildProjector(includeSimilarity),
           ReadType.DOCUMENT,
           objectMapper,
           vector);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
@@ -128,23 +128,27 @@ class ObjectMapperConfigurationTest {
 
     // Only "empty" Options allowed, nothing else
     @Test
-    public void failForNonEmptyOptions() throws Exception {
+    public void findOneWithIncludeSimilarity() throws Exception {
       String json =
           """
-                  {
-                    "findOne": {
-                        "options": {
-                            "noSuchOption": "value"
-                        }
-                    }
-                  }
-                """;
+        {
+          "findOne": {
+              "options": {
+                  "includeSimilarity": true
+              }
+          }
+        }
+        """;
 
-      Exception e = catchException(() -> objectMapper.readValue(json, Command.class));
-      assertThat(e)
-          .isInstanceOf(JsonMappingException.class)
-          .hasMessageStartingWith(
-              ErrorCode.COMMAND_ACCEPTS_NO_OPTIONS.getMessage() + ": FindOneCommand");
+      Command result = objectMapper.readValue(json, Command.class);
+
+      assertThat(result)
+          .isInstanceOfSatisfying(
+              FindOneCommand.class,
+              findOne -> {
+                assertThat(findOne.options()).isNotNull();
+                assertThat(findOne.options().includeSimilarity()).isTrue();
+              });
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommandTest.java
@@ -45,6 +45,32 @@ public class FindCommandTest {
     }
 
     @Test
+    public void includeSimilarityOptionsVectorSearch() throws Exception {
+      String json =
+          """
+        {
+        "find": {
+            "sort" : {"$vector" : [0.11, 0.22, 0.33, 0.44]},
+            "options" : {
+              "includeSimilarity" : true
+            }
+          }
+        }
+        """;
+
+      FindCommand command = objectMapper.readValue(json, FindCommand.class);
+      assertThat(command)
+          .isInstanceOfSatisfying(
+              FindCommand.class,
+              findCommand -> {
+                assertThat(findCommand.options().includeSimilarity()).isTrue();
+              });
+      Set<ConstraintViolation<FindCommand>> result = validator.validate(command);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
     public void invalidOptionsNegativeLimit() throws Exception {
       String json =
           """

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
@@ -4,7 +4,6 @@ import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -156,36 +155,6 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
           .body("data.document", is(not(nullValue())))
           .body("status", is(nullValue()))
           .body("errors", is(nullValue()));
-    }
-
-    @Test
-    public void noOptionsAllowed() {
-      String json =
-          """
-              {
-                "findOne": {
-                  "options": { "unknown":"value"}
-                }
-              }
-              """;
-
-      given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("data.document", is(nullValue()))
-          .body("status", is(nullValue()))
-          .body("errors", is(notNullValue()))
-          .body("errors", hasSize(2))
-          .body("errors[0].message", is("Command accepts no options: FindOneCommand"))
-          .body("errors[0].exceptionClass", is("JsonMappingException"))
-          .body("errors[1].message", is("Command accepts no options: FindOneCommand"))
-          .body("errors[1].errorCode", is("COMMAND_ACCEPTS_NO_OPTIONS"))
-          .body("errors[1].exceptionClass", is("JsonApiException"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -702,7 +702,10 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .statusCode(200)
           .body("status.insertedIds", is(empty()))
           .body("data", is(nullValue()))
-          .body("errors[0].message", startsWith("NOT_FOUND: Keyspace not found"))
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "Failed to insert document with _id 'doc4': INVALID_ARGUMENT: keyspace something_else does not exist"))
           .body("errors[0].exceptionClass", is("StatusRuntimeException"));
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -702,10 +702,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .statusCode(200)
           .body("status.insertedIds", is(empty()))
           .body("data", is(nullValue()))
-          .body(
-              "errors[0].message",
-              startsWith(
-                  "Failed to insert document with _id 'doc4': INVALID_ARGUMENT: keyspace something_else does not exist"))
+          .body("errors[0].message", startsWith("NOT_FOUND: Keyspace not found"))
           .body("errors[0].exceptionClass", is("StatusRuntimeException"));
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -1448,7 +1448,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
               {
                 "find": {
                   "sort" : {"$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]},
-                  "projection" : {"_id" : 1, $similarity : 0},
+                  "projection" : {"_id" : 1, "$similarity" : 0},
                   "options" : {"includeSimilarity" : true}
                 }
               }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -1346,7 +1345,6 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .statusCode(200)
           .body("data.document._id", is("3"))
           .body("data.document.$similarity", notNullValue())
-          .body("data.document.$similarity", lessThanOrEqualTo(1.0))
           .body("errors", is(nullValue()));
     }
 
@@ -1374,9 +1372,12 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .statusCode(200)
           .body("errors", is(nullValue()))
           .body("data.documents", hasSize(3))
-          .body("data.documents[0].$similarity", lessThanOrEqualTo(1.0f))
-          .body("data.documents[1].$similarity", lessThanOrEqualTo(1.0f))
-          .body("data.documents[2].$similarity", lessThanOrEqualTo(1.0f));
+          .body("data.documents[0]._id", is("3"))
+          .body("data.documents[0].$similarity", notNullValue())
+          .body("data.documents[1]._id", is("2"))
+          .body("data.documents[1].$similarity", notNullValue())
+          .body("data.documents[2]._id", is("1"))
+          .body("data.documents[2].$similarity", notNullValue());
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -1462,7 +1462,6 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("errors", is(nullValue()))
           .body("errors", is(notNullValue()))
           .body("errors[0].exceptionClass", is("JsonApiException"))
           .body("errors[0].errorCode", is("UNSUPPORTED_PROJECTION_PARAM"))

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -8,7 +8,7 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -1346,7 +1346,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .statusCode(200)
           .body("data.document._id", is("3"))
           .body("data.document.$similarity", notNullValue())
-          .body("data.document.$similarity", lessThan(1.0))
+          .body("data.document.$similarity", lessThanOrEqualTo(1.0))
           .body("errors", is(nullValue()));
     }
 
@@ -1374,9 +1374,9 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .statusCode(200)
           .body("errors", is(nullValue()))
           .body("data.documents", hasSize(3))
-          .body("data.documents[0].$similarity", lessThan(1.0))
-          .body("data.documents[1].$similarity", lessThan(1.0))
-          .body("data.documents[2].$similarity", lessThan(1.0));
+          .body("data.documents[0].$similarity", lessThanOrEqualTo(1.0f))
+          .body("data.documents[1].$similarity", lessThanOrEqualTo(1.0f))
+          .body("data.documents[2].$similarity", lessThanOrEqualTo(1.0f));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -47,6 +48,13 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
           COLLECTION_NAME,
           true,
           NamespaceCache.CollectionProperty.SimilarityFunction.COSINE);
+
+  private static final CommandContext VECTOR_DOT_PRODUCT_COMMAND_CONTEXT =
+      new CommandContext(
+          KEYSPACE_NAME,
+          COLLECTION_NAME,
+          true,
+          NamespaceCache.CollectionProperty.SimilarityFunction.DOT_PRODUCT);
 
   @Inject QueryExecutor queryExecutor;
   @Inject ObjectMapper objectMapper;
@@ -2434,6 +2442,240 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
       assertThat(result.data().getResponseDocuments())
           .hasSize(2)
           .contains(objectMapper.readTree(doc1), objectMapper.readTree(doc2));
+      assertThat(result.status()).isNullOrEmpty();
+      assertThat(result.errors()).isNullOrEmpty();
+    }
+
+    @Test
+    public void vectorSearchWithSimilarityProjection() throws Exception {
+      String collectionReadCql =
+          "SELECT key, tx_id, doc_json, SIMILARITY_COSINE(query_vector_value, ?) FROM \"%s\".\"%s\" ORDER BY query_vector_value ANN OF ? LIMIT 2"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      String doc1 =
+          """
+            {
+              "_id": "doc1",
+              "username": "user1",
+              "$vector": [0.25, 0.25, 0.25, 0.25]
+            }
+            """;
+      String doc2 =
+          """
+            {
+              "_id": "doc2",
+              "username": "user1",
+              "$vector": [0.35, 0.35, 0.35, 0.35]
+            }
+            """;
+      String doc1Projection =
+          """
+            {
+              "_id": "doc1",
+              "$similarity": 0.75
+            }
+            """;
+      String doc2Projection =
+          """
+            {
+              "_id": "doc2",
+              "$similarity": 0.5
+            }
+            """;
+      ValidatingStargateBridge.QueryAssert candidatesAssert =
+          withQuery(
+                  collectionReadCql,
+                  CustomValueSerializers.getVectorValue(new float[] {0.25f, 0.25f, 0.25f, 0.25f}),
+                  CustomValueSerializers.getVectorValue(new float[] {0.25f, 0.25f, 0.25f, 0.25f}))
+              .withPageSize(2)
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("key")
+                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("tx_id")
+                          .setType(TypeSpecs.UUID)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("doc_json")
+                          .setType(TypeSpecs.VARCHAR)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("SIMILARITY_COSINE(query_vector_value)")
+                          .setType(TypeSpecs.FLOAT)
+                          .build()))
+              .returning(
+                  List.of(
+                      List.of(
+                          Values.of(
+                              CustomValueSerializers.getDocumentIdValue(
+                                  DocumentId.fromString("doc1"))),
+                          Values.of(UUID.randomUUID()),
+                          Values.of(doc1),
+                          Values.of(0.75f)),
+                      List.of(
+                          Values.of(
+                              CustomValueSerializers.getDocumentIdValue(
+                                  DocumentId.fromString("doc2"))),
+                          Values.of(UUID.randomUUID()),
+                          Values.of(doc2),
+                          Values.of(0.50f))));
+
+      DocumentProjector projection =
+          DocumentProjector.createFromDefinition(
+              objectMapper.readTree(
+                  """
+                            { "_id" : 1,
+                              "$similarity": 1
+                            }
+                            """));
+      FindOperation operation =
+          FindOperation.vsearch(
+              VECTOR_COMMAND_CONTEXT,
+              List.of(),
+              projection,
+              null,
+              2,
+              2,
+              ReadType.DOCUMENT,
+              objectMapper,
+              new float[] {0.25f, 0.25f, 0.25f, 0.25f});
+
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
+
+      // assert query execution
+      candidatesAssert.assertExecuteCount().isOne();
+      // then result
+      CommandResult result = execute.get();
+      assertThat(result.data().getResponseDocuments()).hasSize(2);
+      assertThat(result.data().getResponseDocuments().get(0).get("$similarity").floatValue())
+          .isCloseTo(0.75f, Offset.offset(0.001f));
+      assertThat(result.data().getResponseDocuments().get(1).get("$similarity").floatValue())
+          .isCloseTo(0.5f, Offset.offset(0.001f));
+      assertThat(result.status()).isNullOrEmpty();
+      assertThat(result.errors()).isNullOrEmpty();
+    }
+
+    @Test
+    public void vectorSearchWithSimilarityProjectionDotProduct() throws Exception {
+      String collectionReadCql =
+          "SELECT key, tx_id, doc_json, SIMILARITY_DOT_PRODUCT(query_vector_value, ?) FROM \"%s\".\"%s\" ORDER BY query_vector_value ANN OF ? LIMIT 2"
+              .formatted(KEYSPACE_NAME, COLLECTION_NAME);
+      String doc1 =
+          """
+        {
+          "_id": "doc1",
+          "username": "user1",
+          "$vector": [0.25, 0.25, 0.25, 0.25]
+        }
+        """;
+      String doc2 =
+          """
+        {
+          "_id": "doc2",
+          "username": "user1",
+          "$vector": [0.35, 0.35, 0.35, 0.35]
+        }
+        """;
+      String doc1Projection =
+          """
+        {
+          "_id": "doc1",
+          "$similarity": 0.75
+        }
+        """;
+      String doc2Projection =
+          """
+        {
+          "_id": "doc2",
+          "$similarity": 0.5
+        }
+        """;
+      ValidatingStargateBridge.QueryAssert candidatesAssert =
+          withQuery(
+                  collectionReadCql,
+                  CustomValueSerializers.getVectorValue(new float[] {0.25f, 0.25f, 0.25f, 0.25f}),
+                  CustomValueSerializers.getVectorValue(new float[] {0.25f, 0.25f, 0.25f, 0.25f}))
+              .withPageSize(2)
+              .withColumnSpec(
+                  List.of(
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("key")
+                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("tx_id")
+                          .setType(TypeSpecs.UUID)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("doc_json")
+                          .setType(TypeSpecs.VARCHAR)
+                          .build(),
+                      QueryOuterClass.ColumnSpec.newBuilder()
+                          .setName("SIMILARITY_DOT_PRODUCT(query_vector_value)")
+                          .setType(TypeSpecs.FLOAT)
+                          .build()))
+              .returning(
+                  List.of(
+                      List.of(
+                          Values.of(
+                              CustomValueSerializers.getDocumentIdValue(
+                                  DocumentId.fromString("doc1"))),
+                          Values.of(UUID.randomUUID()),
+                          Values.of(doc1),
+                          Values.of(0.75f)),
+                      List.of(
+                          Values.of(
+                              CustomValueSerializers.getDocumentIdValue(
+                                  DocumentId.fromString("doc2"))),
+                          Values.of(UUID.randomUUID()),
+                          Values.of(doc2),
+                          Values.of(0.50f))));
+
+      DocumentProjector projection =
+          DocumentProjector.createFromDefinition(
+              objectMapper.readTree(
+                  """
+                { "_id" : 1,
+                  "$similarity": 1
+                }
+                """));
+      FindOperation operation =
+          FindOperation.vsearch(
+              VECTOR_DOT_PRODUCT_COMMAND_CONTEXT,
+              List.of(),
+              projection,
+              null,
+              2,
+              2,
+              ReadType.DOCUMENT,
+              objectMapper,
+              new float[] {0.25f, 0.25f, 0.25f, 0.25f});
+
+      Supplier<CommandResult> execute =
+          operation
+              .execute(queryExecutor)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .awaitItem()
+              .getItem();
+
+      // assert query execution
+      candidatesAssert.assertExecuteCount().isOne();
+      // then result
+      CommandResult result = execute.get();
+      assertThat(result.data().getResponseDocuments()).hasSize(2);
+      assertThat(result.data().getResponseDocuments().get(0).get("$similarity").floatValue())
+          .isCloseTo(0.75f, Offset.offset(0.001f));
+      assertThat(result.data().getResponseDocuments().get(1).get("$similarity").floatValue())
+          .isCloseTo(0.5f, Offset.offset(0.001f));
       assertThat(result.status()).isNullOrEmpty();
       assertThat(result.errors()).isNullOrEmpty();
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -14,6 +14,7 @@ import io.stargate.sgv2.common.bridge.ValidatingStargateBridge;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.service.bridge.executor.NamespaceCache;
 import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadOperation;
@@ -41,7 +42,11 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
       new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);
 
   private static final CommandContext VECTOR_COMMAND_CONTEXT =
-      new CommandContext(KEYSPACE_NAME, COLLECTION_NAME, true);
+      new CommandContext(
+          KEYSPACE_NAME,
+          COLLECTION_NAME,
+          true,
+          NamespaceCache.CollectionProperty.SimilarityFunction.COSINE);
 
   @Inject QueryExecutor queryExecutor;
   @Inject ObjectMapper objectMapper;

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
@@ -20,6 +20,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import io.stargate.sgv2.jsonapi.service.bridge.executor.NamespaceCache;
 import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.bridge.serializer.CustomValueSerializers;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
@@ -41,7 +42,11 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
       new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);
 
   private static final CommandContext COMMAND_CONTEXT_VECTOR =
-      new CommandContext(KEYSPACE_NAME, COLLECTION_NAME, true);
+      new CommandContext(
+          KEYSPACE_NAME,
+          COLLECTION_NAME,
+          true,
+          NamespaceCache.CollectionProperty.SimilarityFunction.COSINE);
 
   @Inject Shredder shredder;
   @Inject ObjectMapper objectMapper;

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
@@ -333,6 +333,44 @@ public class DocumentProjectorTest {
     }
 
     @Test
+    public void testOptionWithSimilarityZero() throws Exception {
+      final JsonNode doc =
+          objectMapper.readTree(
+              """
+                    { "_id" : 1,
+                       "value1" : true,
+                       "value2" : false,
+                       "nested" : {
+                          "x": 3,
+                          "y": 4,
+                          "z": -1
+                       },
+                       "nested2" : {
+                          "z": 5
+                       },
+                       "$vector" : [0.11, 0.22, 0.33, 0.44]
+                    }
+                    """);
+      Throwable t =
+          catchThrowable(
+              () ->
+                  DocumentProjector.createFromDefinition(
+                      objectMapper.readTree(
+                          """
+                    { "value2" : 1,
+                      "$vector": 1,
+                      "$similarity": 0
+                    }
+                    """),
+                      true));
+      assertThat(t)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_PROJECTION_PARAM)
+          .hasMessageStartingWith(
+              "Unsupported projection parameter: Cannot exclude $similarity when `includeSimilarity` option is set `true`");
+    }
+
+    @Test
     public void testSimpleIncludeWithoutId() throws Exception {
       final JsonNode doc =
           objectMapper.readTree(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
@@ -298,6 +298,41 @@ public class DocumentProjectorTest {
     }
 
     @Test
+    public void testSimpleIncludeWithSimilarity() throws Exception {
+      final JsonNode doc =
+          objectMapper.readTree(
+              """
+            { "_id" : 1,
+               "value1" : true,
+               "value2" : false,
+               "nested" : {
+                  "x": 3,
+                  "y": 4,
+                  "z": -1
+               },
+               "nested2" : {
+                  "z": 5
+               },
+               "$vector" : [0.11, 0.22, 0.33, 0.44]
+            }
+            """);
+      DocumentProjector projection =
+          DocumentProjector.createFromDefinition(
+              objectMapper.readTree(
+                  """
+                { "value2" : 1,
+                  "$vector": 1,
+                  "$similarity": 1
+                }
+                """));
+      assertThat(projection.isInclusion()).isTrue();
+      projection.applyProjection(doc, 0.25f);
+      assertThat(doc.get("value2")).isNotNull();
+      assertThat(doc.get("$vector")).isNotNull();
+      assertThat(doc.get("$similarity").floatValue()).isEqualTo(0.25f);
+    }
+
+    @Test
     public void testSimpleIncludeWithoutId() throws Exception {
       final JsonNode doc =
           objectMapper.readTree(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
@@ -401,6 +401,42 @@ public class FindCommandResolverTest {
     }
 
     @Test
+    public void vectorSearchWithOptionSimilarity() throws Exception {
+      String json =
+          """
+                      {
+                        "find": {
+                          "sort" : {"$vector" : [0.11, 0.22, 0.33, 0.44]},
+                          "options": {"includeSimilarity": true}
+                        }
+                      }
+                      """;
+      final DocumentProjector projector = DocumentProjector.createFromDefinition(null, true);
+
+      FindCommand findOneCommand = objectMapper.readValue(json, FindCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, findOneCommand);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              FindOperation.class,
+              find -> {
+                float[] vector = new float[] {0.11f, 0.22f, 0.33f, 0.44f};
+                assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                assertThat(find.commandContext()).isEqualTo(commandContext);
+                assertThat(find.projection()).isEqualTo(projector);
+                assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
+                assertThat(find.limit()).isEqualTo(operationsConfig.maxVectorSearchLimit());
+                assertThat(find.pagingState()).isNull();
+                assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
+                assertThat(find.skip()).isZero();
+                assertThat(find.maxSortReadLimit()).isZero();
+                assertThat(find.singleResponse()).isFalse();
+                assertThat(find.vector()).containsExactly(vector);
+                assertThat(find.filters()).isEmpty();
+              });
+    }
+
+    @Test
     public void vectorSearchWithFilter() throws Exception {
       String json =
           """

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
@@ -364,6 +364,43 @@ public class FindCommandResolverTest {
     }
 
     @Test
+    public void vectorSearchWithSimilarityProjection() throws Exception {
+      String json =
+          """
+              {
+                "find": {
+                  "sort" : {"$vector" : [0.11, 0.22, 0.33, 0.44]},
+                  "projection": {"$similarity": 1}
+                }
+              }
+              """;
+      JsonNode projection = objectMapper.readTree("{ \"$similarity\" : 1 }");
+      final DocumentProjector projector = DocumentProjector.createFromDefinition(projection);
+
+      FindCommand findOneCommand = objectMapper.readValue(json, FindCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, findOneCommand);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              FindOperation.class,
+              find -> {
+                float[] vector = new float[] {0.11f, 0.22f, 0.33f, 0.44f};
+                assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                assertThat(find.commandContext()).isEqualTo(commandContext);
+                assertThat(find.projection()).isEqualTo(projector);
+                assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
+                assertThat(find.limit()).isEqualTo(operationsConfig.maxVectorSearchLimit());
+                assertThat(find.pagingState()).isNull();
+                assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
+                assertThat(find.skip()).isZero();
+                assertThat(find.maxSortReadLimit()).isZero();
+                assertThat(find.singleResponse()).isFalse();
+                assertThat(find.vector()).containsExactly(vector);
+                assertThat(find.filters()).isEmpty();
+              });
+    }
+
+    @Test
     public void vectorSearchWithFilter() throws Exception {
       String json =
           """

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolverTest.java
@@ -1,8 +1,10 @@
 package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.quarkus.test.Mock;
@@ -12,11 +14,14 @@ import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndReplaceCommand;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.ReadAndUpdateOperation;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import io.stargate.sgv2.jsonapi.service.updater.DocumentUpdater;
@@ -554,6 +559,30 @@ public class FindOneAndReplaceCommandResolverTest {
                           assertThat(find.singleResponse()).isTrue();
                         });
               });
+    }
+
+    @Test
+    public void idFilterWithProjectionSimilarity() throws Exception {
+      String json =
+          """
+              {
+                "findOneAndReplace": {
+                  "filter" : {"_id" : "id"},
+                  "projection" : { "$similarity" : 1 },
+                  "replacement" : {"col1" : "val1", "col2" : "val2"}
+                }
+              }
+              """;
+      FindOneAndReplaceCommand command =
+          objectMapper.readValue(json, FindOneAndReplaceCommand.class);
+      JsonNode projection = objectMapper.readTree("{ \"$similarity\" : 1 }");
+      final DocumentProjector projector = DocumentProjector.createFromDefinition(projection);
+      assertThat(projector.doIncludeSimilarityScore()).isTrue();
+      Throwable failure = catchThrowable(() -> resolver.resolveCommand(commandContext, command));
+      assertThat(failure)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue(
+              "errorCode", ErrorCode.VECTOR_SEARCH_SIMILARITY_PROJECTION_NOT_SUPPORTED);
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolverTest.java
@@ -1,7 +1,9 @@
 package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.Mock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -12,11 +14,14 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateOperator;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.FindOneAndUpdateCommand;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.ReadAndUpdateOperation;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import io.stargate.sgv2.jsonapi.service.testutil.DocumentUpdaterUtils;
@@ -404,6 +409,29 @@ public class FindOneAndUpdateCommandResolverTest {
                           assertThat(find.singleResponse()).isTrue();
                         });
               });
+    }
+
+    @Test
+    public void idFilterWithProjectionSimilarity() throws Exception {
+      String json =
+          """
+                  {
+                    "findOneAndUpdate": {
+                      "filter" : {"_id" : "id"},
+                      "update" : {"$set" : {"location" : "New York"}},
+                      "projection" : { "$similarity" : 1 }
+                    }
+                  }
+                  """;
+      FindOneAndUpdateCommand command = objectMapper.readValue(json, FindOneAndUpdateCommand.class);
+      JsonNode projection = objectMapper.readTree("{ \"$similarity\" : 1 }");
+      final DocumentProjector projector = DocumentProjector.createFromDefinition(projection);
+      assertThat(projector.doIncludeSimilarityScore()).isTrue();
+      Throwable failure = catchThrowable(() -> resolver.resolveCommand(commandContext, command));
+      assertThat(failure)
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue(
+              "errorCode", ErrorCode.VECTOR_SEARCH_SIMILARITY_PROJECTION_NOT_SUPPORTED);
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneCommandResolverTest.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.Mock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -132,6 +133,49 @@ public class FindOneCommandResolverTest {
                 assertThat(find.objectMapper()).isEqualTo(objectMapper);
                 assertThat(find.commandContext()).isEqualTo(commandContext);
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
+                assertThat(find.pageSize()).isEqualTo(1);
+                assertThat(find.limit()).isEqualTo(1);
+                assertThat(find.pagingState()).isNull();
+                assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
+                assertThat(find.skip()).isZero();
+                assertThat(find.maxSortReadLimit()).isZero();
+                assertThat(find.singleResponse()).isTrue();
+                assertThat(find.vector()).containsExactly(vector);
+                assertThat(find.filters()).containsOnly(filter);
+              });
+    }
+
+    @Test
+    public void filterConditionAndVectorSearchSimilarity() throws Exception {
+      String json =
+          """
+              {
+                "findOne": {
+                  "sort" : {"$vector" : [0.11, 0.22, 0.33, 0.44]},
+                  "filter" : {"status" : "active"},
+                  "projection" : {"$similarity" : 1}
+                }
+              }
+              """;
+
+      JsonNode projection = objectMapper.readTree("{ \"$similarity\" : 1 }");
+      final DocumentProjector projector = DocumentProjector.createFromDefinition(projection);
+
+      FindOneCommand command = objectMapper.readValue(json, FindOneCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, command);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              FindOperation.class,
+              find -> {
+                DBFilterBase.TextFilter filter =
+                    new DBFilterBase.TextFilter(
+                        "status", DBFilterBase.MapFilterBase.Operator.EQ, "active");
+
+                float[] vector = new float[] {0.11f, 0.22f, 0.33f, 0.44f};
+                assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                assertThat(find.commandContext()).isEqualTo(commandContext);
+                assertThat(find.projection()).isEqualTo(projector);
                 assertThat(find.pageSize()).isEqualTo(1);
                 assertThat(find.limit()).isEqualTo(1);
                 assertThat(find.pagingState()).isNull();


### PR DESCRIPTION
**What this PR does**:
Change to support $similarity for find and findOne.
$similarity will return the similarity score for every document returned with respect to vector search.

**Which issue(s) this PR fixes**:
Fixes #463 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
