### PR TITLE
Merge array_equals and sub_doc_equals field into query_text_value

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -55,9 +55,7 @@ public record CreateCollectionOperation(
               + "    tx_id               timeuuid, "
               + "    doc_json            text,"
               + "    exist_keys          set<text>,"
-              + "    sub_doc_equals      map<text, text>,"
               + "    array_size          map<text, int>,"
-              + "    array_equals        map<text, text>,"
               + "    array_contains      set<text>,"
               + "    query_bool_values   map<text, tinyint>,"
               + "    query_dbl_values    map<text, decimal>,"
@@ -78,9 +76,7 @@ public record CreateCollectionOperation(
               + "    tx_id               timeuuid, "
               + "    doc_json            text,"
               + "    exist_keys          set<text>,"
-              + "    sub_doc_equals      map<text, text>,"
               + "    array_size          map<text, int>,"
-              + "    array_equals        map<text, text>,"
               + "    array_contains      set<text>,"
               + "    query_bool_values   map<text, tinyint>,"
               + "    query_dbl_values    map<text, decimal>,"
@@ -105,25 +101,11 @@ public record CreateCollectionOperation(
             .setCql(String.format(existKeys, table, keyspace, table))
             .build());
 
-    String subDocEquals =
-        "CREATE CUSTOM INDEX IF NOT EXISTS %s_sub_doc_equals ON \"%s\".\"%s\" (entries(sub_doc_equals)) USING 'StorageAttachedIndex'";
-    statements.add(
-        QueryOuterClass.Query.newBuilder()
-            .setCql(String.format(subDocEquals, table, keyspace, table))
-            .build());
-
     String arraySize =
         "CREATE CUSTOM INDEX IF NOT EXISTS %s_array_size ON \"%s\".\"%s\" (entries(array_size)) USING 'StorageAttachedIndex'";
     statements.add(
         QueryOuterClass.Query.newBuilder()
             .setCql(String.format(arraySize, table, keyspace, table))
-            .build());
-
-    String arrayEquals =
-        "CREATE CUSTOM INDEX IF NOT EXISTS %s_array_equals ON \"%s\".\"%s\" (entries(array_equals)) USING 'StorageAttachedIndex'";
-    statements.add(
-        QueryOuterClass.Query.newBuilder()
-            .setCql(String.format(arrayEquals, table, keyspace, table))
             .build());
 
     String arrayContains =

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DBFilterBase.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DBFilterBase.java
@@ -421,7 +421,7 @@ public abstract class DBFilterBase implements Supplier<BuiltCondition> {
     private final List<Object> arrayValue;
 
     public ArrayEqualsFilter(DocValueHasher hasher, String path, List<Object> arrayData) {
-      super("array_equals", path, Operator.MAP_EQUALS, getHash(hasher, arrayData));
+      super("query_text_values", path, Operator.MAP_EQUALS, getHash(hasher, arrayData));
       this.arrayValue = arrayData;
     }
 
@@ -444,7 +444,7 @@ public abstract class DBFilterBase implements Supplier<BuiltCondition> {
     private final Map<String, Object> subDocValue;
 
     public SubDocEqualsFilter(DocValueHasher hasher, String path, Map<String, Object> subDocData) {
-      super("sub_doc_equals", path, Operator.MAP_EQUALS, getHash(hasher, subDocData));
+      super("query_text_values", path, Operator.MAP_EQUALS, getHash(hasher, subDocData));
       this.subDocValue = subDocData;
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
@@ -154,9 +154,9 @@ public record InsertOperation(
     if (vectorEnabled) {
       String insertWithVector =
           "INSERT INTO \"%s\".\"%s\""
-              + " (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values, query_timestamp_values, query_vector_value)"
+              + " (key, tx_id, doc_json, exist_keys, array_size, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values, query_timestamp_values, query_vector_value)"
               + " VALUES"
-              + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
+              + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
       return QueryOuterClass.Query.newBuilder()
           .setCql(
               String.format(
@@ -165,9 +165,9 @@ public record InsertOperation(
     } else {
       String insert =
           "INSERT INTO \"%s\".\"%s\""
-              + " (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values, query_timestamp_values)"
+              + " (key, tx_id, doc_json, exist_keys, array_size, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values, query_timestamp_values)"
               + " VALUES"
-              + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
+              + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
       return QueryOuterClass.Query.newBuilder()
           .setCql(String.format(insert, commandContext.namespace(), commandContext.collection()))
           .build();
@@ -183,9 +183,7 @@ public record InsertOperation(
             .addValues(Values.of(CustomValueSerializers.getDocumentIdValue(doc.id())))
             .addValues(Values.of(doc.docJson()))
             .addValues(Values.of(CustomValueSerializers.getSetValue(doc.existKeys())))
-            .addValues(Values.of(CustomValueSerializers.getStringMapValues(doc.subDocEquals())))
             .addValues(Values.of(CustomValueSerializers.getIntegerMapValues(doc.arraySize())))
-            .addValues(Values.of(CustomValueSerializers.getStringMapValues(doc.arrayEquals())))
             .addValues(Values.of(CustomValueSerializers.getStringSetValue(doc.arrayContains())))
             .addValues(Values.of(CustomValueSerializers.getBooleanMapValues(doc.queryBoolValues())))
             .addValues(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
@@ -230,9 +230,7 @@ public record ReadAndUpdateOperation(
             + "        SET"
             + "            tx_id = now(),"
             + "            exist_keys = ?,"
-            + "            sub_doc_equals = ?,"
             + "            array_size = ?,"
-            + "            array_equals = ?,"
             + "            array_contains = ?,"
             + "            query_bool_values = ?,"
             + "            query_dbl_values = ?,"
@@ -255,9 +253,7 @@ public record ReadAndUpdateOperation(
     QueryOuterClass.Values.Builder values =
         QueryOuterClass.Values.newBuilder()
             .addValues(Values.of(CustomValueSerializers.getSetValue(doc.existKeys())))
-            .addValues(Values.of(CustomValueSerializers.getStringMapValues(doc.subDocEquals())))
             .addValues(Values.of(CustomValueSerializers.getIntegerMapValues(doc.arraySize())))
-            .addValues(Values.of(CustomValueSerializers.getStringMapValues(doc.arrayEquals())))
             .addValues(Values.of(CustomValueSerializers.getStringSetValue(doc.arrayContains())))
             .addValues(Values.of(CustomValueSerializers.getBooleanMapValues(doc.queryBoolValues())))
             .addValues(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/model/JsonapiTableMatcher.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/model/JsonapiTableMatcher.java
@@ -13,21 +13,34 @@ public class JsonapiTableMatcher implements Predicate<Schema.CqlTable> {
 
   private final Predicate<QueryOuterClass.ColumnSpec> columnsPredicate;
 
+  private final Predicate<QueryOuterClass.ColumnSpec> columnsPredicateVector;
+
   public JsonapiTableMatcher() {
     primaryKeyPredicate = new CqlColumnMatcher.Tuple("key", Basic.TINYINT, Basic.VARCHAR);
     columnsPredicate =
         new CqlColumnMatcher.BasicType("tx_id", Basic.TIMEUUID)
             .or(new CqlColumnMatcher.BasicType("doc_json", Basic.VARCHAR))
             .or(new CqlColumnMatcher.Set("exist_keys", Basic.VARCHAR))
-            .or(new CqlColumnMatcher.Map("sub_doc_equals", Basic.VARCHAR, Basic.VARCHAR))
             .or(new CqlColumnMatcher.Map("array_size", Basic.VARCHAR, Basic.INT))
-            .or(new CqlColumnMatcher.Map("array_equals", Basic.VARCHAR, Basic.VARCHAR))
             .or(new CqlColumnMatcher.Set("array_contains", Basic.VARCHAR))
             .or(new CqlColumnMatcher.Map("query_bool_values", Basic.VARCHAR, Basic.TINYINT))
             .or(new CqlColumnMatcher.Map("query_dbl_values", Basic.VARCHAR, Basic.DECIMAL))
             .or(new CqlColumnMatcher.Map("query_text_values", Basic.VARCHAR, Basic.VARCHAR))
             .or(new CqlColumnMatcher.Map("query_timestamp_values", Basic.VARCHAR, Basic.TIMESTAMP))
             .or(new CqlColumnMatcher.Set("query_null_values", Basic.VARCHAR));
+
+    columnsPredicateVector =
+        new CqlColumnMatcher.BasicType("tx_id", Basic.TIMEUUID)
+            .or(new CqlColumnMatcher.BasicType("doc_json", Basic.VARCHAR))
+            .or(new CqlColumnMatcher.Set("exist_keys", Basic.VARCHAR))
+            .or(new CqlColumnMatcher.Map("array_size", Basic.VARCHAR, Basic.INT))
+            .or(new CqlColumnMatcher.Set("array_contains", Basic.VARCHAR))
+            .or(new CqlColumnMatcher.Map("query_bool_values", Basic.VARCHAR, Basic.TINYINT))
+            .or(new CqlColumnMatcher.Map("query_dbl_values", Basic.VARCHAR, Basic.DECIMAL))
+            .or(new CqlColumnMatcher.Map("query_text_values", Basic.VARCHAR, Basic.VARCHAR))
+            .or(new CqlColumnMatcher.Map("query_timestamp_values", Basic.VARCHAR, Basic.TIMESTAMP))
+            .or(new CqlColumnMatcher.Set("query_null_values", Basic.VARCHAR))
+            .or(new CqlColumnMatcher.BasicType("query_vector_value", Basic.CUSTOM));
   }
 
   /**
@@ -57,7 +70,8 @@ public class JsonapiTableMatcher implements Predicate<Schema.CqlTable> {
     }
 
     List<QueryOuterClass.ColumnSpec> columns = cqlTable.getColumnsList();
-    if (columns.size() != 12 || !columns.stream().allMatch(columnsPredicate)) {
+    if (!(columns.stream().allMatch(columnsPredicate)
+        || columns.stream().allMatch(columnsPredicateVector))) {
       return false;
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
@@ -122,9 +122,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
             + "    tx_id               timeuuid, "
             + "    doc_json            text,"
             + "    exist_keys          set<text>,"
-            + "    sub_doc_equals      map<text, text>,"
             + "    array_size          map<text, int>,"
-            + "    array_equals        map<text, text>,"
             + "    array_contains      set<text>,"
             + "    query_bool_values   map<text, tinyint>,"
             + "    query_dbl_values    map<text, decimal>,"
@@ -139,9 +137,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
             + "    tx_id               timeuuid, "
             + "    doc_json            text,"
             + "    exist_keys          set<text>,"
-            + "    sub_doc_equals      map<text, text>,"
             + "    array_size          map<text, int>,"
-            + "    array_equals        map<text, text>,"
             + "    array_contains      set<text>,"
             + "    query_bool_values   map<text, tinyint>,"
             + "    query_dbl_values    map<text, decimal>,"
@@ -161,13 +157,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
         "CREATE CUSTOM INDEX IF NOT EXISTS %s_exists_keys ON \"%s\".\"%s\" (exist_keys) USING 'StorageAttachedIndex'"
             .formatted(collection, namespace, collection));
     queries.add(
-        "CREATE CUSTOM INDEX IF NOT EXISTS %s_sub_doc_equals ON \"%s\".\"%s\" (entries(sub_doc_equals)) USING 'StorageAttachedIndex'"
-            .formatted(collection, namespace, collection));
-    queries.add(
         "CREATE CUSTOM INDEX IF NOT EXISTS %s_array_size ON \"%s\".\"%s\" (entries(array_size)) USING 'StorageAttachedIndex'"
-            .formatted(collection, namespace, collection));
-    queries.add(
-        "CREATE CUSTOM INDEX IF NOT EXISTS %s_array_equals ON \"%s\".\"%s\" (entries(array_equals)) USING 'StorageAttachedIndex'"
             .formatted(collection, namespace, collection));
     queries.add(
         "CREATE CUSTOM INDEX IF NOT EXISTS %s_array_contains ON \"%s\".\"%s\" (array_contains) USING 'StorageAttachedIndex'"

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -1085,7 +1085,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
     @Test
     public void findWithArrayEqualFilter() throws Exception {
       String collectionReadCql =
-          "SELECT key, tx_id, doc_json FROM \"%s\".\"%s\" WHERE array_equals[?] = ? LIMIT 1"
+          "SELECT key, tx_id, doc_json FROM \"%s\".\"%s\" WHERE query_text_values[?] = ? LIMIT 1"
               .formatted(KEYSPACE_NAME, COLLECTION_NAME);
 
       String doc1 =
@@ -1157,7 +1157,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
     @Test
     public void findWithSubDocEqualFilter() throws Exception {
       String collectionReadCql =
-          "SELECT key, tx_id, doc_json FROM \"%s\".\"%s\" WHERE sub_doc_equals[?] = ? LIMIT 1"
+          "SELECT key, tx_id, doc_json FROM \"%s\".\"%s\" WHERE query_text_values[?] = ? LIMIT 1"
               .formatted(KEYSPACE_NAME, COLLECTION_NAME);
 
       String doc1 =

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
@@ -58,15 +58,15 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
 
     static final String INSERT_CQL =
         "INSERT INTO \"%s\".\"%s\""
-            + " (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values, query_timestamp_values)"
+            + " (key, tx_id, doc_json, exist_keys, array_size, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values, query_timestamp_values)"
             + " VALUES"
-            + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
+            + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
 
     static final String INSERT_VECTOR_CQL =
         "INSERT INTO \"%s\".\"%s\""
-            + " (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values, query_timestamp_values, query_vector_value)"
+            + " (key, tx_id, doc_json, exist_keys, array_size, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values, query_timestamp_values, query_vector_value)"
             + " VALUES"
-            + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
+            + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
 
     @Test
     public void insertOne() throws Exception {
@@ -94,10 +94,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument.id())),
                   Values.of(shredDocument.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -164,10 +161,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument.id())),
                   Values.of(shredDocument.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -257,11 +251,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument1.id())),
                   Values.of(shredDocument1.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument1.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument1.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument1.arraySize())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument1.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument1.arrayContains())),
                   Values.of(
@@ -289,11 +279,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument2.id())),
                   Values.of(shredDocument2.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument2.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument2.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument2.arraySize())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument2.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument2.arrayContains())),
                   Values.of(
@@ -380,11 +366,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument1.id())),
                   Values.of(shredDocument1.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument1.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument1.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument1.arraySize())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument1.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument1.arrayContains())),
                   Values.of(
@@ -412,11 +394,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument2.id())),
                   Values.of(shredDocument2.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument2.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument2.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument2.arraySize())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument2.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument2.arrayContains())),
                   Values.of(
@@ -506,11 +484,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument1.id())),
                   Values.of(shredDocument1.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument1.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument1.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument1.arraySize())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument1.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument1.arrayContains())),
                   Values.of(
@@ -601,11 +575,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument1.id())),
                   Values.of(shredDocument1.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument1.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument1.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument1.arraySize())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument1.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument1.arrayContains())),
                   Values.of(
@@ -633,11 +603,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument2.id())),
                   Values.of(shredDocument2.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument2.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument2.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument2.arraySize())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument2.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument2.arrayContains())),
                   Values.of(
@@ -732,11 +698,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument1.id())),
                   Values.of(shredDocument1.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument1.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument1.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument1.arraySize())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument1.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument1.arrayContains())),
                   Values.of(
@@ -764,11 +726,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument2.id())),
                   Values.of(shredDocument2.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument2.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument2.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument2.arraySize())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument2.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument2.arrayContains())),
                   Values.of(
@@ -862,11 +820,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument1.id())),
                   Values.of(shredDocument1.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument1.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument1.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument1.arraySize())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument1.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument1.arrayContains())),
                   Values.of(
@@ -894,11 +848,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument2.id())),
                   Values.of(shredDocument2.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument2.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument2.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument2.arraySize())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument2.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument2.arrayContains())),
                   Values.of(
@@ -974,10 +924,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument.id())),
                   Values.of(shredDocument.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -1046,10 +993,7 @@ public class InsertOperationTest extends AbstractValidatingStargateBridgeTest {
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument.id())),
                   Values.of(shredDocument.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
@@ -56,9 +56,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
           + "        SET"
           + "            tx_id = now(),"
           + "            exist_keys = ?,"
-          + "            sub_doc_equals = ?,"
           + "            array_size = ?,"
-          + "            array_equals = ?,"
           + "            array_contains = ?,"
           + "            query_bool_values = ?,"
           + "            query_dbl_values = ?,"
@@ -164,9 +162,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
@@ -195,9 +191,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
@@ -364,9 +358,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
@@ -395,9 +387,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
@@ -572,9 +562,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
@@ -603,9 +591,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
@@ -807,9 +793,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
@@ -838,9 +822,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
@@ -872,9 +854,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
@@ -1111,9 +1091,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
@@ -1142,9 +1120,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
@@ -1176,9 +1152,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),
@@ -1206,9 +1180,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
         withQuery(
                 collectionUpdateCql,
                 Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                 Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                 Values.of(CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                 Values.of(
                     CustomValueSerializers.getBooleanMapValues(shredDocument.queryBoolValues())),

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -56,9 +56,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           + "        SET"
           + "            tx_id = now(),"
           + "            exist_keys = ?,"
-          + "            sub_doc_equals = ?,"
           + "            array_size = ?,"
-          + "            array_equals = ?,"
           + "            array_contains = ?,"
           + "            query_bool_values = ?,"
           + "            query_dbl_values = ?,"
@@ -134,10 +132,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           withQuery(
                   collectionUpdateCql,
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -418,10 +413,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           withQuery(
                   collectionUpdateCql,
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -564,10 +556,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           withQuery(
                   collectionUpdateCql,
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -688,10 +677,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           withQuery(
                   collectionUpdateCql,
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -879,10 +865,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           withQuery(
                   collectionUpdateCql,
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -1063,10 +1046,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           withQuery(
                   collectionUpdateCql,
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -1186,10 +1166,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           withQuery(
                   collectionUpdateCql,
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -1429,10 +1406,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           withQuery(
                   collectionUpdateCql,
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -1464,10 +1438,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           withQuery(
                   collectionUpdateCql,
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -1587,10 +1558,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
           withQuery(
                   collectionUpdateCql,
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
@@ -138,9 +138,9 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
   class Insert {
     static final String INSERT_CQL =
         "INSERT INTO \"%s\".\"%s\""
-            + " (key, tx_id, doc_json, exist_keys, sub_doc_equals, array_size, array_equals, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values, query_timestamp_values)"
+            + " (key, tx_id, doc_json, exist_keys, array_size, array_contains, query_bool_values, query_dbl_values , query_text_values, query_null_values, query_timestamp_values)"
             + " VALUES"
-            + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
+            + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
 
     @Test
     public void insert() throws Exception {
@@ -167,10 +167,7 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
                   Values.of(CustomValueSerializers.getDocumentIdValue(shredDocument.id())),
                   Values.of(shredDocument.docJson()),
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(
@@ -273,9 +270,7 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
               + "        SET"
               + "            tx_id = now(),"
               + "            exist_keys = ?,"
-              + "            sub_doc_equals = ?,"
               + "            array_size = ?,"
-              + "            array_equals = ?,"
               + "            array_contains = ?,"
               + "            query_bool_values = ?,"
               + "            query_dbl_values = ?,"
@@ -295,10 +290,7 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
           withQuery(
                   collectionUpdateCql,
                   Values.of(CustomValueSerializers.getSetValue(shredDocument.existKeys())),
-                  Values.of(
-                      CustomValueSerializers.getStringMapValues(shredDocument.subDocEquals())),
                   Values.of(CustomValueSerializers.getIntegerMapValues(shredDocument.arraySize())),
-                  Values.of(CustomValueSerializers.getStringMapValues(shredDocument.arrayEquals())),
                   Values.of(
                       CustomValueSerializers.getStringSetValue(shredDocument.arrayContains())),
                   Values.of(


### PR DESCRIPTION
Merge array_equals and sub_doc_equals field into query_text_value field.
**Which issue(s) this PR fixes**:
Fixes #505 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
