### PR TITLE
Fixes #516: add validation to fail on attempts to filter on $vector (except with $exists)

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
@@ -269,7 +269,7 @@ public class FilterClauseDeserializerTest {
           .satisfies(
               t -> {
                 assertThat(t.getMessage())
-                    .isEqualTo("$size operator must have interger value >= 0");
+                    .isEqualTo("$size operator must have integer value >= 0");
               });
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
@@ -268,8 +268,7 @@ public class FilterClauseDeserializerTest {
           .isInstanceOf(JsonApiException.class)
           .satisfies(
               t -> {
-                assertThat(t.getMessage())
-                    .isEqualTo("$size operator must have integer value >= 0");
+                assertThat(t.getMessage()).isEqualTo("$size operator must have integer value >= 0");
               });
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -734,7 +734,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
 
     @Test
     @Order(3)
-    public void happyPathWithFilter() {
+    public void happyPathWithIdFilter() {
       String json =
           """
                       {
@@ -759,7 +759,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
 
     @Test
     @Order(4)
-    public void happyPathWithEmptyVector() {
+    public void failWithEmptyVector() {
       String json =
           """
                       {
@@ -786,7 +786,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
 
     @Test
     @Order(5)
-    public void happyPathWithInvalidData() {
+    public void failWithInvalidVectorElements() {
       String json =
           """
                       {
@@ -809,6 +809,36 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .body("errors[1].exceptionClass", is("JsonApiException"))
           .body("errors[1].errorCode", is("SHRED_BAD_VECTOR_VALUE"))
           .body("errors[1].message", is(ErrorCode.SHRED_BAD_VECTOR_VALUE.getMessage()));
+    }
+
+    // Vector columns can only use ANN, not regular filtering
+    @Test
+    @Order(6)
+    public void failWithVectorFilter() {
+      String json =
+          """
+                          {
+                            "findOne": {
+                              "filter" : {"$vector" : [ 1, 1, 1, 1, 1 ]}
+                            }
+                          }
+                          """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("errors", is(notNullValue()))
+          .body("errors[1].exceptionClass", is("JsonApiException"))
+          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"))
+          .body(
+              "errors[1].message",
+              is(
+                  "Cannot filter on '$vector' field using operator '$eq': only '$exists' is supported"));
     }
   }
 


### PR DESCRIPTION
**What this PR does**:

Adds explicit fail on attempts to filter by $vector, except for one supported operation ($exists).

**Which issue(s) this PR fixes**:

Fixes #516

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
