### PR TITLE
Fix #521: allow hyphen in names, prevent empty String

### DIFF
--- a/docs/jsonapi-spec.md
+++ b/docs/jsonapi-spec.md
@@ -256,7 +256,7 @@ the rules for user defined field names.
                 <user-field-name> 
 
 <id-field-name> = _id
-<user-field-name> ::= ["a-zA-Z0-9_"]+
+<user-field-name> ::= ["a-zA-Z0-9_-"]+
 ```
 
 The `_id` field is a "reserved name" and is always interpreted as the

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/constants/DocumentConstants.java
@@ -24,7 +24,7 @@ public interface DocumentConstants {
     // Current definition of valid JSON API names: note that this only validates
     // characters, not length limits (nor empty nor "too long" allowed but validated
     // separately)
-    Pattern VALID_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_]*");
+    Pattern VALID_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_\\-]*");
   }
 
   interface KeyTypeId {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -294,6 +294,13 @@ public class Shredder {
               key.length(),
               limits.maxPropertyNameLength()));
     }
+    if (key.length() == 0) {
+      // NOTE: validity failure, not size limit
+      throw new JsonApiException(
+          ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION,
+          String.format(
+              "%s: empty names not allowed", ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION.getMessage()));
+    }
     if (!DocumentConstants.Fields.VALID_NAME_PATTERN.matcher(key).matches()) {
       // Special names are accepted in some cases: for now only one such case for
       // Date values -- if more needed, will refactor. But for now inline:

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -112,7 +112,7 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
               "insertOne": {
                 "document": {
                   "_id": {"$date": 6},
-                  "username": "user6"
+                  "user-name": "user6"
                 }
               }
             }
@@ -227,7 +227,7 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           """
           {
             "_id": {"$date": 6},
-            "username": "user6"
+            "user-name": "user6"
           }
           """;
       given()
@@ -464,6 +464,38 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .body("errors", is(nullValue()))
           .body("data.documents[0]", jsonEquals(expected))
           .body("data.documents", hasSize(1));
+    }
+
+    // [https://github.com/stargate/jsonapi/issues/521]: allow hyphens in property names
+    @Test
+    public void byColumnWithHyphen() {
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                  {
+                    "find": {
+                      "filter" : {"user-name" : "user6"}
+                    }
+                  }
+              """)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("status", is(nullValue()))
+          .body("errors", is(nullValue()))
+          .body("data.documents", hasSize(1))
+          .body(
+              "data.documents[0]",
+              jsonEquals(
+                  """
+                  {
+                    "_id": {"$date": 6},
+                    "user-name": "user6"
+                  }
+                """));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -96,7 +96,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
 
     // [https://github.com/stargate/jsonapi/issues/521]: allow hyphens in property names
     @Test
-    public void insertDocumentWithHyphen() {
+    public void insertDocumentWithHyphenatedColumn() {
       String json =
           """
               {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -67,22 +67,47 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body("status.insertedIds[0]", is("doc3"))
           .body("data", is(nullValue()))
           .body("errors", is(nullValue()));
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+              {
+                "find": {
+                  "filter" : {"_id" : "doc3"}
+                }
+              }
+              """)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body(
+              "data.documents[0]",
+              jsonEquals(
+                  """
+              {
+                "_id":"doc3",
+                "username":"user3"
+              }
+              """))
+          .body("errors", is(nullValue()));
+    }
 
-      json =
+    // [https://github.com/stargate/jsonapi/issues/521]: allow hyphens in property names
+    @Test
+    public void insertDocumentWithHyphen() {
+      String json =
           """
-          {
-            "find": {
-              "filter" : {"_id" : "doc3"}
-            }
-          }
-          """;
-      String expected =
-          """
-          {
-            "_id":"doc3",
-            "username":"user3"
-          }
-          """;
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": "doc-hyphen",
+                    "user-name": "user #1"
+                  }
+                }
+              }
+              """;
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -92,7 +117,33 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("data.documents[0]", jsonEquals(expected))
+          .body("status.insertedIds[0]", is("doc-hyphen"))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+              {
+                "find": {
+                  "filter" : {"_id" : "doc-hyphen"}
+                }
+              }
+              """)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body(
+              "data.documents[0]",
+              jsonEquals(
+                  """
+              {
+                "_id": "doc-hyphen",
+                "user-name": "user #1"
+              }
+              """))
           .body("errors", is(nullValue()));
     }
 


### PR DESCRIPTION
**What this PR does**:

Improves property name validation wrt #521 so that:

- Allow hyphen (`-`) in names and name segments
- Empty names no longer allowed (shouldn't have been, oversight)

**Which issue(s) this PR fixes**:
Fixes #521

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
