### PR TITLE
Add error message in createCollection()

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -109,7 +109,11 @@ public enum ErrorCode {
   VECTORIZE_SERVICE_TYPE_UNSUPPORTED("Vectorize service type unsupported : "),
 
   VECTORIZE_SERVICE_TYPE_UNAVAILABLE("Vectorize service unavailable : "),
-  VECTORIZE_USAGE_ERROR("Vectorize search can't be used with other sort clause");
+  VECTORIZE_USAGE_ERROR("Vectorize search can't be used with other sort clause"),
+
+  VECTORIZECONFIG_CHECK_FAIL("VectorizeConfig check null fail");
+
+
 
   private final String message;
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -111,7 +111,7 @@ public enum ErrorCode {
   VECTORIZE_SERVICE_TYPE_UNAVAILABLE("Vectorize service unavailable : "),
   VECTORIZE_USAGE_ERROR("Vectorize search can't be used with other sort clause"),
 
-  VECTORIZECONFIG_CHECK_FAIL("VectorizeConfig check null fail");
+  VECTORIZECONFIG_CHECK_FAIL("Internal server error: VectorizeConfig check fail");
 
   private final String message;
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -113,8 +113,6 @@ public enum ErrorCode {
 
   VECTORIZECONFIG_CHECK_FAIL("VectorizeConfig check null fail");
 
-
-
   private final String message;
 
   ErrorCode(String message) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
@@ -81,17 +81,8 @@ public record CollectionSettings(
       }
       final String comment = table.getOptionsOrDefault("comment", null);
       if (comment != null && !comment.isBlank()) {
-        try {
-          JsonNode vectorizeConfig = objectMapper.readTree(comment);
-          String vectorizeServiceName = vectorizeConfig.get("service").textValue();
-          final JsonNode optionsNode = vectorizeConfig.get("options");
-          String modelName = optionsNode.get("modelName").textValue();
-          return new CollectionSettings(
-              collectionName, vectorEnabled, vectorSize, function, vectorizeServiceName, modelName);
-        } catch (JsonProcessingException e) {
-          // This should never happen
-          throw new RuntimeException(e);
-        }
+        return createCollectionSettingsFromJson(
+            collectionName, vectorEnabled, vectorSize, function, comment, objectMapper);
       } else {
         return new CollectionSettings(
             collectionName, vectorEnabled, vectorSize, function, null, null);
@@ -116,25 +107,31 @@ public record CollectionSettings(
       ObjectMapper objectMapper) {
     // parse vectorize to get vectorizeServiceName and modelName
     if (vectorize != null && !vectorize.isBlank()) {
-      try {
-        JsonNode vectorizeConfig = objectMapper.readTree(vectorize);
-        String vectorizeServiceName_ = vectorizeConfig.get("service").textValue();
-        final JsonNode optionsNode = vectorizeConfig.get("options");
-        String modelName_ = optionsNode.get("modelName").textValue();
-        return new CollectionSettings(
-            collectionName,
-            vectorEnabled,
-            vectorSize,
-            similarityFunction,
-            vectorizeServiceName_,
-            modelName_);
-      } catch (JsonProcessingException e) {
-        // This should never happen
-        throw new RuntimeException(e);
-      }
+      return createCollectionSettingsFromJson(
+          collectionName, vectorEnabled, vectorSize, similarityFunction, vectorize, objectMapper);
     } else {
       return new CollectionSettings(
           collectionName, vectorEnabled, vectorSize, similarityFunction, null, null);
+    }
+  }
+
+  private static CollectionSettings createCollectionSettingsFromJson(
+      String collectionName,
+      boolean vectorEnabled,
+      int vectorSize,
+      SimilarityFunction function,
+      String vectorize,
+      ObjectMapper objectMapper) {
+    try {
+      JsonNode vectorizeConfig = objectMapper.readTree(vectorize);
+      String vectorizeServiceName = vectorizeConfig.get("service").textValue();
+      JsonNode optionsNode = vectorizeConfig.get("options");
+      String modelName = optionsNode.get("modelName").textValue();
+      return new CollectionSettings(
+          collectionName, vectorEnabled, vectorSize, function, vectorizeServiceName, modelName);
+    } catch (JsonProcessingException e) {
+      // This should never happen
+      throw new RuntimeException(e);
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
@@ -1,5 +1,7 @@
 package io.stargate.sgv2.jsonapi.service.bridge.executor;
 
+import static io.stargate.sgv2.jsonapi.exception.ErrorCode.VECTORIZECONFIG_CHECK_FAIL;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,8 +11,6 @@ import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.util.Optional;
-
-import static io.stargate.sgv2.jsonapi.exception.ErrorCode.VECTORIZECONFIG_CHECK_FAIL;
 
 /**
  * Refactored as seperate class that represent a collection property.

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
@@ -124,14 +124,21 @@ public record CollectionSettings(
       ObjectMapper objectMapper) {
     try {
       JsonNode vectorizeConfig = objectMapper.readTree(vectorize);
-      String vectorizeServiceName = vectorizeConfig.get("service").textValue();
-      JsonNode optionsNode = vectorizeConfig.get("options");
-      String modelName = optionsNode.get("modelName").textValue();
-      return new CollectionSettings(
-          collectionName, vectorEnabled, vectorSize, function, vectorizeServiceName, modelName);
+      String vectorizeServiceName = vectorizeConfig.path("service").textValue();
+      JsonNode optionsNode = vectorizeConfig.path("options");
+      String modelName = optionsNode.path("modelName").textValue();
+      if (vectorizeServiceName != null
+          && !vectorizeServiceName.isEmpty()
+          && modelName != null
+          && !modelName.isEmpty()) {
+        return new CollectionSettings(
+            collectionName, vectorEnabled, vectorSize, function, vectorizeServiceName, modelName);
+      } else {
+        throw new RuntimeException("Invalid json string");
+      }
     } catch (JsonProcessingException e) {
       // This should never happen
-      throw new RuntimeException(e);
+      throw new RuntimeException("Invalid json string");
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
@@ -115,21 +115,26 @@ public record CollectionSettings(
       String vectorize,
       ObjectMapper objectMapper) {
     // parse vectorize to get vectorizeServiceName and modelName
-    try {
-      JsonNode vectorizeConfig = objectMapper.readTree(vectorize);
-      String vectorizeServiceName_ = vectorizeConfig.get("service").textValue();
-      final JsonNode optionsNode = vectorizeConfig.get("options");
-      String modelName_ = optionsNode.get("modelName").textValue();
+    if (vectorize != null && !vectorize.isBlank()) {
+      try {
+        JsonNode vectorizeConfig = objectMapper.readTree(vectorize);
+        String vectorizeServiceName_ = vectorizeConfig.get("service").textValue();
+        final JsonNode optionsNode = vectorizeConfig.get("options");
+        String modelName_ = optionsNode.get("modelName").textValue();
+        return new CollectionSettings(
+            collectionName,
+            vectorEnabled,
+            vectorSize,
+            similarityFunction,
+            vectorizeServiceName_,
+            modelName_);
+      } catch (JsonProcessingException e) {
+        // This should never happen
+        throw new RuntimeException(e);
+      }
+    } else {
       return new CollectionSettings(
-          collectionName,
-          vectorEnabled,
-          vectorSize,
-          similarityFunction,
-          vectorizeServiceName_,
-          modelName_);
-    } catch (JsonProcessingException e) {
-      // This should never happen
-      throw new RuntimeException(e);
+          collectionName, vectorEnabled, vectorSize, similarityFunction, null, null);
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
@@ -139,7 +139,8 @@ public record CollectionSettings(
         // This should never happen, VectorizeConfig check null, unless it fails
         throw new JsonApiException(
             VECTORIZECONFIG_CHECK_FAIL,
-            "%s, please check 'vectorize' configuration.".formatted(VECTORIZECONFIG_CHECK_FAIL.getMessage()));
+            "%s, please check 'vectorize' configuration."
+                .formatted(VECTORIZECONFIG_CHECK_FAIL.getMessage()));
       }
     } catch (JsonProcessingException e) {
       // This should never happen, already check if vectorize is a valid JSON

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
@@ -10,6 +10,8 @@ import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.util.Optional;
 
+import static io.stargate.sgv2.jsonapi.exception.ErrorCode.VECTORIZECONFIG_CHECK_FAIL;
+
 /**
  * Refactored as seperate class that represent a collection property.
  *
@@ -134,11 +136,12 @@ public record CollectionSettings(
         return new CollectionSettings(
             collectionName, vectorEnabled, vectorSize, function, vectorizeServiceName, modelName);
       } else {
-        throw new RuntimeException("Invalid json string");
+        // This should never happen, VectorizeConfig check null, unless it fails
+        throw new JsonApiException(VECTORIZECONFIG_CHECK_FAIL);
       }
     } catch (JsonProcessingException e) {
-      // This should never happen
-      throw new RuntimeException("Invalid json string");
+      // This should never happen, already check if vectorize is a valid JSON
+      throw new RuntimeException("Invalid json string", e);
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
@@ -137,11 +137,13 @@ public record CollectionSettings(
             collectionName, vectorEnabled, vectorSize, function, vectorizeServiceName, modelName);
       } else {
         // This should never happen, VectorizeConfig check null, unless it fails
-        throw new JsonApiException(VECTORIZECONFIG_CHECK_FAIL);
+        throw new JsonApiException(
+            VECTORIZECONFIG_CHECK_FAIL,
+            "%s, please check 'vectorize' configuration.".formatted(VECTORIZECONFIG_CHECK_FAIL.getMessage()));
       }
     } catch (JsonProcessingException e) {
       // This should never happen, already check if vectorize is a valid JSON
-      throw new RuntimeException("Invalid json string", e);
+      throw new RuntimeException("Invalid json string, please check 'vectorize' configuration.", e);
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/CollectionSettings.java
@@ -106,4 +106,30 @@ public record CollectionSettings(
           null);
     }
   }
+
+  public static CollectionSettings getCollectionSettings(
+      String collectionName,
+      boolean vectorEnabled,
+      int vectorSize,
+      SimilarityFunction similarityFunction,
+      String vectorize,
+      ObjectMapper objectMapper) {
+    // parse vectorize to get vectorizeServiceName and modelName
+    try {
+      JsonNode vectorizeConfig = objectMapper.readTree(vectorize);
+      String vectorizeServiceName_ = vectorizeConfig.get("service").textValue();
+      final JsonNode optionsNode = vectorizeConfig.get("options");
+      String modelName_ = optionsNode.get("modelName").textValue();
+      return new CollectionSettings(
+          collectionName,
+          vectorEnabled,
+          vectorSize,
+          similarityFunction,
+          vectorizeServiceName_,
+          modelName_);
+    } catch (JsonProcessingException e) {
+      // This should never happen
+      throw new RuntimeException(e);
+    }
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -69,13 +69,9 @@ public record CreateCollectionOperation(
   public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
     return schemaManager
         .getTable(commandContext.namespace(), name, MISSING_KEYSPACE_FUNCTION)
-        .onItemOrFailure()
+        .onItem()
         .transformToUni(
-            (table, error) -> {
-              // if getTable return null, continue
-              if (error != null) {
-                return executeCollectionCreation(queryExecutor);
-              }
+            table -> {
               // table doesn't exist
               if (table == null) {
                 return executeCollectionCreation(queryExecutor);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -68,9 +68,13 @@ public record CreateCollectionOperation(
   public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
     return schemaManager
         .getTable(commandContext.namespace(), name, MISSING_KEYSPACE_FUNCTION)
-        .onItem()
+        .onItemOrFailure()
         .transformToUni(
-            table -> {
+            (table, error) -> {
+              // if getTable return null, continue
+              if (error != null) {
+                return executeQuery(queryExecutor);
+              }
               // table doesn't exist
               if (table == null) {
                 return executeQuery(queryExecutor);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -102,7 +102,8 @@ public record CreateCollectionOperation(
                         .failure(
                             new JsonApiException(
                                 ErrorCode.INVALID_COLLECTION_NAME,
-                                "The provided collection already exists with a different vector setting"));
+                                "The provided collection name '%s' already exists with a different vector setting."
+                                    .formatted(name)));
                   }
                 } else {
                   // if existing collection is a non-vector collection, error out
@@ -110,7 +111,8 @@ public record CreateCollectionOperation(
                       .failure(
                           new JsonApiException(
                               ErrorCode.INVALID_COLLECTION_NAME,
-                              "The provided collection already exists with a non-vector setting"));
+                              "The provided collection name '%s' already exists with a non-vector setting."
+                                  .formatted(name)));
                 }
               } else { // if table exists and user want to create a non-vector collection
                 // if existing table is vector enabled, error out
@@ -119,7 +121,8 @@ public record CreateCollectionOperation(
                       .failure(
                           new JsonApiException(
                               ErrorCode.INVALID_COLLECTION_NAME,
-                              "The provided collection already exists with a vector setting"));
+                              "The provided collection name '%s' already exists with a vector setting."
+                                  .formatted(name)));
                 } else {
                   // if existing table is a non-vector collection, continue
                   return executeCollectionCreation(queryExecutor);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -68,11 +68,11 @@ public record CreateCollectionOperation(
   public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
     return schemaManager
         .getTable(commandContext.namespace(), name, MISSING_KEYSPACE_FUNCTION)
-        .onItemOrFailure()
+        .onItem()
         .transformToUni(
-            (table, error) -> {
+            table -> {
               // table doesn't exist
-              if (error == null) {
+              if (table == null) {
                 return executeQuery(queryExecutor);
               }
               // if table exists and user want to create a vector collection with the same name
@@ -98,10 +98,9 @@ public record CreateCollectionOperation(
                     // if settings are not equal, error out
                     return Uni.createFrom()
                         .failure(
-                            new RuntimeException(
-                                new JsonApiException(
-                                    ErrorCode.INVALID_COLLECTION_NAME,
-                                    "The provided collection already exists with a different vector setting")));
+                            new JsonApiException(
+                                ErrorCode.INVALID_COLLECTION_NAME,
+                                "The provided collection already exists with a different vector setting"));
                   }
                 } else {
                   // if existing collection is a non-vector collection, error out

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -1,17 +1,26 @@
 package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.smallrye.mutiny.Uni;
 import io.stargate.bridge.proto.QueryOuterClass;
+import io.stargate.bridge.proto.Schema;
+import io.stargate.sgv2.api.common.schema.SchemaManager;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import io.stargate.sgv2.jsonapi.service.bridge.executor.CollectionSettings;
 import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public record CreateCollectionOperation(
     CommandContext commandContext,
+    ObjectMapper objectMapper,
+    SchemaManager schemaManager,
     String name,
     boolean vectorSearch,
     int vectorSize,
@@ -19,23 +28,96 @@ public record CreateCollectionOperation(
     String vectorize)
     implements Operation {
 
+  private static final Function<String, Uni<? extends Schema.CqlKeyspaceDescribe>>
+      MISSING_KEYSPACE_FUNCTION =
+          keyspace -> {
+            String message = "Unknown namespace %s, you must create it first.".formatted(keyspace);
+            Exception exception = new JsonApiException(ErrorCode.NAMESPACE_DOES_NOT_EXIST, message);
+            return Uni.createFrom().failure(exception);
+          };
+
   public static CreateCollectionOperation withVectorSearch(
       CommandContext commandContext,
+      ObjectMapper objectMapper,
+      SchemaManager schemaManager,
       String name,
       int vectorSize,
       String vectorFunction,
       String vectorize) {
     return new CreateCollectionOperation(
-        commandContext, name, true, vectorSize, vectorFunction, vectorize);
+        commandContext,
+        objectMapper,
+        schemaManager,
+        name,
+        true,
+        vectorSize,
+        vectorFunction,
+        vectorize);
   }
 
   public static CreateCollectionOperation withoutVectorSearch(
-      CommandContext commandContext, String name) {
-    return new CreateCollectionOperation(commandContext, name, false, 0, null, null);
+      CommandContext commandContext,
+      ObjectMapper objectMapper,
+      SchemaManager schemaManager,
+      String name) {
+    return new CreateCollectionOperation(
+        commandContext, objectMapper, schemaManager, name, false, 0, null, null);
   }
 
   @Override
   public Uni<Supplier<CommandResult>> execute(QueryExecutor queryExecutor) {
+    return schemaManager
+        .getTable(commandContext.namespace(), name, MISSING_KEYSPACE_FUNCTION)
+        .onItemOrFailure()
+        .transformToUni(
+            (table, error) -> {
+              // table doesn't exist
+              if (error == null) {
+                return executeQuery(queryExecutor);
+              }
+              // if table exists and user want to create a vector collection with the same name
+              if (vectorSearch) {
+                // get collection settings from the existing collection
+                CollectionSettings collectionSettings =
+                    CollectionSettings.getCollectionSettings(table, objectMapper);
+                // if existing collection is a vector collection
+                if (collectionSettings.vectorEnabled()) {
+                  // get collection settings from user input
+                  CollectionSettings collectionSettings_cur =
+                      CollectionSettings.getCollectionSettings(
+                          name,
+                          vectorSearch,
+                          vectorSize,
+                          CollectionSettings.SimilarityFunction.fromString(vectorFunction),
+                          vectorize,
+                          objectMapper);
+                  if (collectionSettings.equals(collectionSettings_cur)) {
+                    // if settings are equal, no error
+                    return executeQuery(queryExecutor);
+                  } else {
+                    // if settings are not equal, error out
+                    return Uni.createFrom()
+                        .failure(
+                            new RuntimeException(
+                                new JsonApiException(
+                                    ErrorCode.INVALID_COLLECTION_NAME,
+                                    "The provided collection already exists with a different vector setting")));
+                  }
+                } else {
+                  // if existing collection is a non-vector collection, error out
+                  return Uni.createFrom()
+                      .failure(
+                          new JsonApiException(
+                              ErrorCode.INVALID_COLLECTION_NAME,
+                              "The provided collection already exists with a non-vector setting"));
+                }
+              }
+              // if table exists and user want to create a non-vector collection, continue
+              return executeQuery(queryExecutor);
+            });
+  }
+
+  private Uni<Supplier<CommandResult>> executeQuery(QueryExecutor queryExecutor) {
     final Uni<QueryOuterClass.ResultSet> execute =
         queryExecutor.executeSchemaChange(getCreateTable(commandContext.namespace(), name));
     final Uni<Boolean> indexResult =

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -31,7 +31,8 @@ public record CreateCollectionOperation(
   private static final Function<String, Uni<? extends Schema.CqlKeyspaceDescribe>>
       MISSING_KEYSPACE_FUNCTION =
           keyspace -> {
-            String message = "Unknown namespace %s, you must create it first.".formatted(keyspace);
+            String message =
+                "Unknown namespace '%s', you must create it first.".formatted(keyspace);
             Exception exception = new JsonApiException(ErrorCode.NAMESPACE_DOES_NOT_EXIST, message);
             return Uni.createFrom().failure(exception);
           };
@@ -73,11 +74,11 @@ public record CreateCollectionOperation(
             (table, error) -> {
               // if getTable return null, continue
               if (error != null) {
-                return executeQuery(queryExecutor);
+                return executeCollectionCreation(queryExecutor);
               }
               // table doesn't exist
               if (table == null) {
-                return executeQuery(queryExecutor);
+                return executeCollectionCreation(queryExecutor);
               }
               // if table exists and user want to create a vector collection with the same name
               if (vectorSearch) {
@@ -97,7 +98,7 @@ public record CreateCollectionOperation(
                           objectMapper);
                   if (collectionSettings.equals(collectionSettings_cur)) {
                     // if settings are equal, no error
-                    return executeQuery(queryExecutor);
+                    return executeCollectionCreation(queryExecutor);
                   } else {
                     // if settings are not equal, error out
                     return Uni.createFrom()
@@ -116,11 +117,11 @@ public record CreateCollectionOperation(
                 }
               }
               // if table exists and user want to create a non-vector collection, continue
-              return executeQuery(queryExecutor);
+              return executeCollectionCreation(queryExecutor);
             });
   }
 
-  private Uni<Supplier<CommandResult>> executeQuery(QueryExecutor queryExecutor) {
+  private Uni<Supplier<CommandResult>> executeCollectionCreation(QueryExecutor queryExecutor) {
     final Uni<QueryOuterClass.ResultSet> execute =
         queryExecutor.executeSchemaChange(getCreateTable(commandContext.namespace(), name));
     final Uni<Boolean> indexResult =

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -32,7 +32,8 @@ public record CreateCollectionOperation(
       MISSING_KEYSPACE_FUNCTION =
           keyspace -> {
             String message =
-                "Unknown namespace '%s', you must create it first.".formatted(keyspace);
+                "INVALID_ARGUMENT: Unknown namespace '%s', you must create it first."
+                    .formatted(keyspace);
             Exception exception = new JsonApiException(ErrorCode.NAMESPACE_DOES_NOT_EXIST, message);
             return Uni.createFrom().failure(exception);
           };

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stargate.sgv2.api.common.config.DataStoreConfig;
+import io.stargate.sgv2.api.common.schema.SchemaManager;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.CreateCollectionCommand;
 import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
@@ -18,6 +19,7 @@ import jakarta.inject.Inject;
 public class CreateCollectionCommandResolver implements CommandResolver<CreateCollectionCommand> {
 
   private final ObjectMapper objectMapper;
+  private final SchemaManager schemaManager;
   private final DataStoreConfig dataStoreConfig;
 
   private final DocumentLimitsConfig documentLimitsConfig;
@@ -25,15 +27,17 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
   @Inject
   public CreateCollectionCommandResolver(
       ObjectMapper objectMapper,
+      SchemaManager schemaManager,
       DataStoreConfig dataStoreConfig,
       DocumentLimitsConfig documentLimitsConfig) {
     this.objectMapper = objectMapper;
+    this.schemaManager = schemaManager;
     this.dataStoreConfig = dataStoreConfig;
     this.documentLimitsConfig = documentLimitsConfig;
   }
 
   public CreateCollectionCommandResolver() {
-    this(null, null, null);
+    this(null, null, null, null);
   }
 
   @Override
@@ -70,9 +74,16 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
       }
 
       return CreateCollectionOperation.withVectorSearch(
-          ctx, command.name(), vectorSize, command.options().vector().function(), vectorize);
+          ctx,
+          objectMapper,
+          schemaManager,
+          command.name(),
+          vectorSize,
+          command.options().vector().function(),
+          vectorize);
     } else {
-      return CreateCollectionOperation.withoutVectorSearch(ctx, command.name());
+      return CreateCollectionOperation.withoutVectorSearch(
+          ctx, objectMapper, schemaManager, command.name());
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -143,7 +143,8 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body("data", is(nullValue()))
           .body(
               "errors[0].message",
-              is("The provided collection already exists with a non-vector setting"))
+              is(
+                  "The provided collection name 'simple_collection' already exists with a non-vector setting."))
           .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
 
@@ -193,7 +194,8 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body("data", is(nullValue()))
           .body(
               "errors[0].message",
-              is("The provided collection already exists with a vector setting"))
+              is(
+                  "The provided collection name 'simple_collection' already exists with a vector setting."))
           .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
       // delete the collection
@@ -233,7 +235,8 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body("data", is(nullValue()))
           .body(
               "errors[0].message",
-              is("The provided collection already exists with a different vector setting"))
+              is(
+                  "The provided collection name 'simple_collection' already exists with a different vector setting."))
           .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
       // create another vector collection with the same name but different function setting
@@ -249,7 +252,8 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body("data", is(nullValue()))
           .body(
               "errors[0].message",
-              is("The provided collection already exists with a different vector setting"))
+              is(
+                  "The provided collection name 'simple_collection' already exists with a different vector setting."))
           .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
       // delete the collection

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.api.v1;
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -46,6 +47,152 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .then()
           .statusCode(200)
           .body("status.ok", is(1));
+    }
+
+    @Test
+    public void duplicateCollectionName() {
+      String deleteCollectionJson =
+          """
+          {
+            "deleteCollection": {
+              "name": "simple_collection"
+            }
+          }
+          """;
+      String createNonVectorCollectionJson =
+          """
+          {
+            "createCollection": {
+              "name": "simple_collection"
+            }
+          }
+          """;
+      String createVectorCollection =
+          """
+          {
+            "createCollection": {
+              "name": "simple_collection",
+              "options" : {
+                "vector" : {
+                "size" : 5,
+                  "function" : "cosine"
+                }
+              }
+            }
+          }
+          """;
+      String createVectorCollectionWithOtherSettings =
+          """
+          {
+            "createCollection": {
+              "name": "simple_collection",
+              "options" : {
+                "vector" : {
+                "size" : 6,
+                  "function" : "cosine"
+                }
+              }
+            }
+          }
+          """;
+      // create a non vector collection
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(createNonVectorCollectionJson)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+
+      // recreate the same non vector collection
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(createNonVectorCollectionJson)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+
+      // create a vector collection with the same name
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(createVectorCollection)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .body("status", is(nullValue()))
+          .body("data", is(nullValue()))
+          .body(
+              "errors[0].message",
+              is("The provided collection already exists with a non-vector setting"))
+          .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
+          .body("errors[0].exceptionClass", is("JsonApiException"));
+
+      // delete the collection
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(deleteCollectionJson.formatted("simple_collection"))
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+
+      // create a vector collection
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(createVectorCollection)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+
+      // recreate the same vector collection
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(createVectorCollection)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+
+      // create a non vector collection with the same name
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(createNonVectorCollectionJson)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+
+      // create another vector collection with the same name but different setting
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(createVectorCollectionWithOtherSettings)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status", is(nullValue()))
+          .body("data", is(nullValue()))
+          .body(
+              "errors[0].message",
+              is("The provided collection already exists with a different vector setting"))
+          .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
+          .body("errors[0].exceptionClass", is("JsonApiException"));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HttpStatusCodeIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HttpStatusCodeIntegrationTest.java
@@ -179,7 +179,7 @@ public class HttpStatusCodeIntegrationTest extends AbstractCollectionIntegration
           .body("errors", is(notNullValue()))
           .body("errors[0].message", is(not(blankString())))
           .body("errors[0].message", anyOf)
-          .body("errors[0].exceptionClass", is("StatusRuntimeException"));
+          .body("errors[0].exceptionClass", is("JsonApiException"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HttpStatusCodeIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HttpStatusCodeIntegrationTest.java
@@ -165,7 +165,9 @@ public class HttpStatusCodeIntegrationTest extends AbstractCollectionIntegration
       AnyOf<String> anyOf =
           AnyOf.anyOf(
               endsWith("INVALID_ARGUMENT: Keyspace '%s' doesn't exist".formatted("badNamespace")),
-              endsWith("INVALID_ARGUMENT: Unknown keyspace %s".formatted("badNamespace")));
+              endsWith(
+                  "INVALID_ARGUMENT: Unknown namespace '%s', you must create it first."
+                      .formatted("badNamespace")));
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
@@ -1,6 +1,8 @@
 package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.junit.QuarkusTest;
@@ -39,9 +41,12 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
           getAllQueryString(KEYSPACE_NAME, COLLECTION_NAME, false, 0, null, null);
       queries.stream().forEach(query -> withQuery(query).returningNothing());
 
+      SchemaManager schemaManagerMock = mock(SchemaManager.class);
+      when(schemaManagerMock.getKeyspaces()).thenReturn(null);
+
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withoutVectorSearch(
-              commandContext, objectMapper, schemaManager, COLLECTION_NAME);
+              commandContext, objectMapper, schemaManagerMock, COLLECTION_NAME);
 
       final Supplier<CommandResult> execute =
           createCollectionOperation.execute(queryExecutor).subscribeAsCompletionStage().get();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
@@ -35,13 +35,14 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
   @Nested
   class CreateCollectionOperationsTest {
 
+    SchemaManager schemaManagerMock = mock(SchemaManager.class);
+
     @Test
     public void createCollection() throws Exception {
       List<String> queries =
           getAllQueryString(KEYSPACE_NAME, COLLECTION_NAME, false, 0, null, null);
       queries.stream().forEach(query -> withQuery(query).returningNothing());
 
-      SchemaManager schemaManagerMock = mock(SchemaManager.class);
       when(schemaManagerMock.getKeyspaces()).thenReturn(null);
 
       CreateCollectionOperation createCollectionOperation =
@@ -66,9 +67,10 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
       queries.stream().forEach(query -> withQuery(query).returningNothing());
       CommandContext commandContextUpper =
           new CommandContext(KEYSPACE_NAME.toUpperCase(), COLLECTION_NAME.toUpperCase());
+      when(schemaManagerMock.getKeyspaces()).thenReturn(null);
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withoutVectorSearch(
-              commandContextUpper, objectMapper, schemaManager, COLLECTION_NAME.toUpperCase());
+              commandContextUpper, objectMapper, schemaManagerMock, COLLECTION_NAME.toUpperCase());
 
       final Supplier<CommandResult> execute =
           createCollectionOperation.execute(queryExecutor).subscribeAsCompletionStage().get();
@@ -85,10 +87,10 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
       List<String> queries =
           getAllQueryString(KEYSPACE_NAME, COLLECTION_NAME, true, 4, "cosine", null);
       queries.stream().forEach(query -> withQuery(query).returningNothing());
-
+      when(schemaManagerMock.getKeyspaces()).thenReturn(null);
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withVectorSearch(
-              commandContext, objectMapper, schemaManager, COLLECTION_NAME, 4, "cosine", null);
+              commandContext, objectMapper, schemaManagerMock, COLLECTION_NAME, 4, "cosine", null);
 
       final Supplier<CommandResult> execute =
           createCollectionOperation.execute(queryExecutor).subscribeAsCompletionStage().get();
@@ -111,12 +113,12 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
               "cosine",
               "{\"service\":\"openai\",\"options\":{\"modelName\":\"text-embedding-ada-002\"}}");
       queries.stream().forEach(query -> withQuery(query).returningNothing());
-
+      when(schemaManagerMock.getKeyspaces()).thenReturn(null);
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withVectorSearch(
               commandContext,
               objectMapper,
-              schemaManager,
+              schemaManagerMock,
               COLLECTION_NAME,
               4,
               "cosine",
@@ -137,10 +139,16 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
       List<String> queries =
           getAllQueryString(KEYSPACE_NAME, COLLECTION_NAME, true, 4, "dot_product", null);
       queries.stream().forEach(query -> withQuery(query).returningNothing());
-
+      when(schemaManagerMock.getKeyspaces()).thenReturn(null);
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withVectorSearch(
-              commandContext, objectMapper, schemaManager, COLLECTION_NAME, 4, "dot_product", null);
+              commandContext,
+              objectMapper,
+              schemaManagerMock,
+              COLLECTION_NAME,
+              4,
+              "dot_product",
+              null);
 
       final Supplier<CommandResult> execute =
           createCollectionOperation.execute(queryExecutor).subscribeAsCompletionStage().get();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
@@ -2,8 +2,10 @@ package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.api.common.schema.SchemaManager;
 import io.stargate.sgv2.common.bridge.AbstractValidatingStargateBridgeTest;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
@@ -24,7 +26,8 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
   private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
   private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
   private CommandContext commandContext = new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);
-
+  @Inject ObjectMapper objectMapper;
+  @Inject SchemaManager schemaManager;
   @Inject QueryExecutor queryExecutor;
 
   @Nested
@@ -37,7 +40,8 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
       queries.stream().forEach(query -> withQuery(query).returningNothing());
 
       CreateCollectionOperation createCollectionOperation =
-          CreateCollectionOperation.withoutVectorSearch(commandContext, COLLECTION_NAME);
+          CreateCollectionOperation.withoutVectorSearch(
+              commandContext, objectMapper, schemaManager, COLLECTION_NAME);
 
       final Supplier<CommandResult> execute =
           createCollectionOperation.execute(queryExecutor).subscribeAsCompletionStage().get();
@@ -59,7 +63,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
           new CommandContext(KEYSPACE_NAME.toUpperCase(), COLLECTION_NAME.toUpperCase());
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withoutVectorSearch(
-              commandContextUpper, COLLECTION_NAME.toUpperCase());
+              commandContextUpper, objectMapper, schemaManager, COLLECTION_NAME.toUpperCase());
 
       final Supplier<CommandResult> execute =
           createCollectionOperation.execute(queryExecutor).subscribeAsCompletionStage().get();
@@ -79,7 +83,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
 
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withVectorSearch(
-              commandContext, COLLECTION_NAME, 4, "cosine", null);
+              commandContext, objectMapper, schemaManager, COLLECTION_NAME, 4, "cosine", null);
 
       final Supplier<CommandResult> execute =
           createCollectionOperation.execute(queryExecutor).subscribeAsCompletionStage().get();
@@ -106,6 +110,8 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withVectorSearch(
               commandContext,
+              objectMapper,
+              schemaManager,
               COLLECTION_NAME,
               4,
               "cosine",
@@ -129,7 +135,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
 
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withVectorSearch(
-              commandContext, COLLECTION_NAME, 4, "dot_product", null);
+              commandContext, objectMapper, schemaManager, COLLECTION_NAME, 4, "dot_product", null);
 
       final Supplier<CommandResult> execute =
           createCollectionOperation.execute(queryExecutor).subscribeAsCompletionStage().get();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Introduces error messaging for scenarios where a user attempts to create a collection with a name that already exists, but with differing settings. The error is triggered in two specific cases:
1. When an existing collection is non-vector, but the user attempts to create a vector-based collection with the same name.
2. When the existing vector collection's settings do not align with the vector options specified by the user.

**Which issue(s) this PR fixes**:
Fixes #546 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
