### PR TITLE
provide additional detail on swagger docs for insertMany

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
@@ -36,7 +36,7 @@ public record InsertManyCommand(
   public record Options(
       @Schema(
               description =
-                  "When `true` the server will insert the documents in sequential order, otherwise when `false` the server is free to re-order the inserts and parallelize them for performance. See specifications for more info on failure modes.",
+                  "When `true` the server will insert the documents in sequential order, ensuring each document is successfully inserted before starting the next. Additionally the command will \"fail fast\", failing the first document that fails to insert. When `false` the server is free to re-order the inserts and parallelize them for performance. In this mode more than one document may fail to be inserted (aka \"fail silently\" mode).",
               defaultValue = "true")
           Boolean ordered) {}
 }


### PR DESCRIPTION
During testing some users have become confused by the behavior of the `insertMany` command with respect to how partial failure is handled. Users don't realize that setting the `ordered` option to false will allow them to bypass the default fail fast behavior, which returns on the first insert failure, even a failure as simple as inserting a duplicate `_id`. 

Instead of referencing "specifications" that most users will not know how to find, this PR updates the swagger docs to pull in the detail from the spec. 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
