### PR TITLE
Verify max 5 collections creation (per namespace)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -11,6 +11,12 @@ Here are some Stargate-relevant property groups that are necessary for correct s
 * `quarkus.grpc.clients.bridge` - property group for defining the Bridge gRPC client (see [gRPC Client configuration](https://quarkus.io/guides/grpc-service-consumption#client-configuration) for all options)
 * `quarkus.cache.caffeine.keyspace-cache` - property group  for defining the keyspace cache used by [SchemaManager](../sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/schema/SchemaManager.java) (see [Caffeine cache configuration](https://quarkus.io/guides/cache#caffeine-configuration-properties) for all options)
 
+## Database limits configuration
+*Configuration for document limits, defined by [DatabaseLimitsConfig.java](src/main/java/io/stargate/sgv2/jsonapi/config/DatabaseLimitsConfig.java).*
+
+| Property                                    | Type  | Default | Description                                                                          |
+|---------------------------------------------|-------|---------|--------------------------------------------------------------------------------------|
+| `stargate.database.limits.max-collections`  | `int` | `5`     | The maximum number of Collections allowed to be created per Database: defaults to 5. |
 
 ## Document limits configuration
 *Configuration for document limits, defined by [DocumentLimitsConfig.java](src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java).*

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DatabaseLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DatabaseLimitsConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The Stargate Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.stargate.sgv2.jsonapi.config;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import jakarta.validation.constraints.Positive;
+
+/** Configuration for limits that apply to Databases. */
+@ConfigMapping(prefix = "stargate.database.limits")
+public interface DatabaseLimitsConfig {
+  int DEFAULT_MAX_COLLECTIONS = 5;
+
+  /**
+   * @return Defines maximum Collections allowed to be created per Database. Defaults to <code>5
+   *     </code> due to underlying Cassandra indexing limitations.
+   */
+  @Positive
+  @WithDefault("" + DEFAULT_MAX_COLLECTIONS)
+  int maxCollections();
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DatabaseLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DatabaseLimitsConfig.java
@@ -17,11 +17,13 @@
 
 package io.stargate.sgv2.jsonapi.config;
 
+import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import jakarta.validation.constraints.Positive;
 
 /** Configuration for limits that apply to Databases. */
+@StaticInitSafe
 @ConfigMapping(prefix = "stargate.database.limits")
 public interface DatabaseLimitsConfig {
   // Constant we need to access from Integration tests

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DatabaseLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DatabaseLimitsConfig.java
@@ -24,6 +24,7 @@ import jakarta.validation.constraints.Positive;
 /** Configuration for limits that apply to Databases. */
 @ConfigMapping(prefix = "stargate.database.limits")
 public interface DatabaseLimitsConfig {
+  // Constant we need to access from Integration tests
   int DEFAULT_MAX_COLLECTIONS = 5;
 
   /**

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -59,6 +59,8 @@ public enum ErrorCode {
 
   INVALID_COLLECTION_NAME("Invalid collection name "),
 
+  TOO_MANY_COLLECTIONS("Too many collections"),
+
   UNSUPPORTED_FILTER_DATA_TYPE("Unsupported filter data type"),
 
   UNSUPPORTED_FILTER_OPERATION("Unsupported filter operator"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -7,6 +7,7 @@ import io.stargate.bridge.proto.Schema;
 import io.stargate.sgv2.api.common.schema.SchemaManager;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.config.DatabaseLimitsConfig;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.bridge.executor.CollectionSettings;
@@ -19,6 +20,7 @@ import java.util.function.Supplier;
 
 public record CreateCollectionOperation(
     CommandContext commandContext,
+    DatabaseLimitsConfig dbLimitsConfig,
     ObjectMapper objectMapper,
     SchemaManager schemaManager,
     String name,
@@ -40,6 +42,7 @@ public record CreateCollectionOperation(
 
   public static CreateCollectionOperation withVectorSearch(
       CommandContext commandContext,
+      DatabaseLimitsConfig dbLimitsConfig,
       ObjectMapper objectMapper,
       SchemaManager schemaManager,
       String name,
@@ -48,6 +51,7 @@ public record CreateCollectionOperation(
       String vectorize) {
     return new CreateCollectionOperation(
         commandContext,
+        dbLimitsConfig,
         objectMapper,
         schemaManager,
         name,
@@ -59,11 +63,12 @@ public record CreateCollectionOperation(
 
   public static CreateCollectionOperation withoutVectorSearch(
       CommandContext commandContext,
+      DatabaseLimitsConfig dbLimitsConfig,
       ObjectMapper objectMapper,
       SchemaManager schemaManager,
       String name) {
     return new CreateCollectionOperation(
-        commandContext, objectMapper, schemaManager, name, false, 0, null, null);
+        commandContext, dbLimitsConfig, objectMapper, schemaManager, name, false, 0, null, null);
   }
 
   @Override
@@ -154,7 +159,7 @@ public record CreateCollectionOperation(
   }
 
   void verifyLimits(List<Schema.CqlTable> tables) {
-    final int MAX_COLLECTIONS = 5;
+    final int MAX_COLLECTIONS = dbLimitsConfig.maxCollections();
     if (tables.size() >= MAX_COLLECTIONS) {
       throw new JsonApiException(
           ErrorCode.TOO_MANY_COLLECTIONS,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -154,7 +154,14 @@ public record CreateCollectionOperation(
   }
 
   void verifyLimits(List<Schema.CqlTable> tables) {
-    // TODO: add actual validation
+    final int MAX_COLLECTIONS = 5;
+    if (tables.size() > MAX_COLLECTIONS) {
+      throw new JsonApiException(
+          ErrorCode.TOO_MANY_COLLECTIONS,
+          String.format(
+              "%s:  number of Collections cannot exceed %d, already have %d",
+              ErrorCode.TOO_MANY_COLLECTIONS.getMessage(), MAX_COLLECTIONS, tables.size()));
+    }
   }
 
   Schema.CqlTable findTableOrNull(List<Schema.CqlTable> tables, String name) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -164,7 +164,7 @@ public record CreateCollectionOperation(
       throw new JsonApiException(
           ErrorCode.TOO_MANY_COLLECTIONS,
           String.format(
-              "%s:  number of Collections cannot exceed %d, already have %d",
+              "%s: number of collections in database cannot exceed %d, already have %d",
               ErrorCode.TOO_MANY_COLLECTIONS.getMessage(), MAX_COLLECTIONS, tables.size()));
     }
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -155,7 +155,7 @@ public record CreateCollectionOperation(
 
   void verifyLimits(List<Schema.CqlTable> tables) {
     final int MAX_COLLECTIONS = 5;
-    if (tables.size() > MAX_COLLECTIONS) {
+    if (tables.size() >= MAX_COLLECTIONS) {
       throw new JsonApiException(
           ErrorCode.TOO_MANY_COLLECTIONS,
           String.format(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
@@ -6,6 +6,7 @@ import io.stargate.sgv2.api.common.config.DataStoreConfig;
 import io.stargate.sgv2.api.common.schema.SchemaManager;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.CreateCollectionCommand;
+import io.stargate.sgv2.jsonapi.config.DatabaseLimitsConfig;
 import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
@@ -23,21 +24,24 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
   private final DataStoreConfig dataStoreConfig;
 
   private final DocumentLimitsConfig documentLimitsConfig;
+  private final DatabaseLimitsConfig dbLimitsConfig;
 
   @Inject
   public CreateCollectionCommandResolver(
       ObjectMapper objectMapper,
       SchemaManager schemaManager,
       DataStoreConfig dataStoreConfig,
-      DocumentLimitsConfig documentLimitsConfig) {
+      DocumentLimitsConfig documentLimitsConfig,
+      DatabaseLimitsConfig dbLimitsConfig) {
     this.objectMapper = objectMapper;
     this.schemaManager = schemaManager;
     this.dataStoreConfig = dataStoreConfig;
     this.documentLimitsConfig = documentLimitsConfig;
+    this.dbLimitsConfig = dbLimitsConfig;
   }
 
   public CreateCollectionCommandResolver() {
-    this(null, null, null, null);
+    this(null, null, null, null, null);
   }
 
   @Override
@@ -75,6 +79,7 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
 
       return CreateCollectionOperation.withVectorSearch(
           ctx,
+          dbLimitsConfig,
           objectMapper,
           schemaManager,
           command.name(),
@@ -83,7 +88,7 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
           vectorize);
     } else {
       return CreateCollectionOperation.withoutVectorSearch(
-          ctx, objectMapper, schemaManager, command.name());
+          ctx, dbLimitsConfig, objectMapper, schemaManager, command.name());
     }
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,9 @@
 # please keep properties in the alphabetical order
 
 stargate:
+  database:
+    limits:
+      maxCollections: 5
 
   debug:
     enabled: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,11 @@
 # please keep properties in the alphabetical order
 
 stargate:
+
+  database:
+    limits:
+      max-collections: 5
+
   debug:
     enabled: false
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,10 +2,6 @@
 # please keep properties in the alphabetical order
 
 stargate:
-  database:
-    limits:
-      maxCollections: 5
-
   debug:
     enabled: false
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractNamespaceIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractNamespaceIntegrationTestBase.java
@@ -38,6 +38,10 @@ public abstract class AbstractNamespaceIntegrationTestBase {
 
   @BeforeAll
   public void createNamespace() {
+    createNamespace(namespaceName);
+  }
+
+  protected void createNamespace(String nsToCreate) {
     String json =
         """
         {
@@ -46,7 +50,7 @@ public abstract class AbstractNamespaceIntegrationTestBase {
           }
         }
         """
-            .formatted(namespaceName);
+            .formatted(nsToCreate);
 
     given()
         .port(getTestPort())

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -314,7 +314,10 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body(
               "errors[0].message",
               is(
-                  "Too many collections:  number of Collections cannot exceed "+MAX_DBS+", already have "+MAX_DBS))
+                  "Too many collections:  number of Collections cannot exceed "
+                      + MAX_DBS
+                      + ", already have "
+                      + MAX_DBS))
           .body("errors[0].errorCode", is("TOO_MANY_COLLECTIONS"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -274,6 +274,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
   class TooManyCollections {
     @Test
     public void enforceMaxCollections() {
+      final int MAX_DBS = 5; // !!! TODO from config
       // Don't use auto-generated namespace that rest of the test uses
       final String NS = "ns_too_many_collections";
       createNamespace(NS);
@@ -286,8 +287,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
               }
               """;
 
-      int i = 1;
-      for (; i <= 5; ++i) {
+      for (int i = 1; i <= MAX_DBS; ++i) {
         String json = createTemplate.formatted(i);
         given()
             .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -300,7 +300,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
             .body("status.ok", is(1));
       }
       // And then failure
-      String json = createTemplate.formatted(i);
+      String json = createTemplate.formatted(99);
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -314,8 +314,8 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body(
               "errors[0].message",
               is(
-                  "The provided collection name 'simple_collection' already exists with a non-vector setting."))
-          .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
+                  "Too many collections:  number of Collections cannot exceed "+MAX_DBS+", already have "+MAX_DBS))
+          .body("errors[0].errorCode", is("TOO_MANY_COLLECTIONS"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -276,6 +276,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
     public void enforceMaxCollections() {
       // Don't use auto-generated namespace that rest of the test uses
       final String NS = "ns_too_many_collections";
+      createNamespace(NS);
       final String createTemplate =
           """
               {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -9,6 +9,7 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
+import io.stargate.sgv2.jsonapi.config.DatabaseLimitsConfig;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.ClassOrderer;
@@ -21,7 +22,6 @@ import org.junit.jupiter.api.TestClassOrder;
 @QuarkusTestResource(DseTestResource.class)
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBase {
-
   @Nested
   @Order(1)
   class CreateCollection {
@@ -274,7 +274,8 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
   class TooManyCollections {
     @Test
     public void enforceMaxCollections() {
-      final int MAX_DBS = 5; // !!! TODO from config
+      // Cannot @Inject configs into ITs so rely on constant for default values:
+      final int MAX_DBS = DatabaseLimitsConfig.DEFAULT_MAX_COLLECTIONS;
       // Don't use auto-generated namespace that rest of the test uses
       final String NS = "ns_too_many_collections";
       createNamespace(NS);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
@@ -13,6 +13,7 @@ import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
+import io.stargate.sgv2.jsonapi.config.DatabaseLimitsConfig;
 import io.stargate.sgv2.jsonapi.service.bridge.executor.QueryExecutor;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
   @Inject ObjectMapper objectMapper;
   @Inject SchemaManager schemaManager;
   @Inject QueryExecutor queryExecutor;
+  @Inject DatabaseLimitsConfig dbLimitsConfig;
 
   @Nested
   class CreateCollectionOperationsTest {
@@ -47,7 +49,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
 
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withoutVectorSearch(
-              commandContext, objectMapper, schemaManagerMock, COLLECTION_NAME);
+              commandContext, dbLimitsConfig, objectMapper, schemaManagerMock, COLLECTION_NAME);
 
       final Supplier<CommandResult> execute =
           createCollectionOperation.execute(queryExecutor).subscribeAsCompletionStage().get();
@@ -70,7 +72,11 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
       when(schemaManagerMock.getKeyspaces()).thenReturn(null);
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withoutVectorSearch(
-              commandContextUpper, objectMapper, schemaManagerMock, COLLECTION_NAME.toUpperCase());
+              commandContextUpper,
+              dbLimitsConfig,
+              objectMapper,
+              schemaManagerMock,
+              COLLECTION_NAME.toUpperCase());
 
       final Supplier<CommandResult> execute =
           createCollectionOperation.execute(queryExecutor).subscribeAsCompletionStage().get();
@@ -90,7 +96,14 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
       when(schemaManagerMock.getKeyspaces()).thenReturn(null);
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withVectorSearch(
-              commandContext, objectMapper, schemaManagerMock, COLLECTION_NAME, 4, "cosine", null);
+              commandContext,
+              dbLimitsConfig,
+              objectMapper,
+              schemaManagerMock,
+              COLLECTION_NAME,
+              4,
+              "cosine",
+              null);
 
       final Supplier<CommandResult> execute =
           createCollectionOperation.execute(queryExecutor).subscribeAsCompletionStage().get();
@@ -117,6 +130,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withVectorSearch(
               commandContext,
+              dbLimitsConfig,
               objectMapper,
               schemaManagerMock,
               COLLECTION_NAME,
@@ -143,6 +157,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
       CreateCollectionOperation createCollectionOperation =
           CreateCollectionOperation.withVectorSearch(
               commandContext,
+              dbLimitsConfig,
               objectMapper,
               schemaManagerMock,
               COLLECTION_NAME,


### PR DESCRIPTION

**What this PR does**:

Adds validation that no more than 5 (configurable) Collections are created per Namespace.

**Which issue(s) this PR fixes**:
Fixes #577

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
