### PR TITLE
fix error mapping 

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/exception/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/exception/ConstraintViolationExceptionMapper.java
@@ -18,6 +18,9 @@ public class ConstraintViolationExceptionMapper {
   public static final Map<String, Object> ERROR_FIELDS =
       Map.of("exceptionClass", ConstraintViolationException.class.getSimpleName());
 
+  public static final Map<String, Object> ERROR_FIELDS_METRICS_TAG =
+      Map.of("exceptionClass", ConstraintViolationException.class.getSimpleName());
+
   @ServerExceptionMapper
   public RestResponse<CommandResult> constraintViolationException(
       ConstraintViolationException exception) {
@@ -35,6 +38,6 @@ public class ConstraintViolationExceptionMapper {
     String message = violation.getMessage();
     Path propertyPath = violation.getPropertyPath();
     String msg = "Request invalid, the field %s not valid: %s.".formatted(propertyPath, message);
-    return new CommandResult.Error(msg, ERROR_FIELDS, Response.Status.OK);
+    return new CommandResult.Error(msg, ERROR_FIELDS, ERROR_FIELDS_METRICS_TAG, Response.Status.OK);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandResult.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandResult.java
@@ -173,6 +173,7 @@ public record CommandResult(
       String message,
       @JsonAnyGetter @Schema(hidden = true) Map<String, Object> fields,
       // Http status to be used in the response, defaulted to 200
+      @JsonIgnore @Schema(hidden = true) Map<String, Object> fieldsForMetricsTag,
       @JsonIgnore Response.Status status) {
 
     // this is a compact constructor for records

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandResult.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandResult.java
@@ -171,9 +171,9 @@ public record CommandResult(
       })
   public record Error(
       String message,
+      @JsonIgnore @Schema(hidden = true) Map<String, Object> fieldsForMetricsTag,
       @JsonAnyGetter @Schema(hidden = true) Map<String, Object> fields,
       // Http status to be used in the response, defaulted to 200
-      @JsonIgnore @Schema(hidden = true) Map<String, Object> fieldsForMetricsTag,
       @JsonIgnore Response.Status status) {
 
     // this is a compact constructor for records

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/security/ErrorChallengeSender.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/security/ErrorChallengeSender.java
@@ -41,7 +41,8 @@ public class ErrorChallengeSender implements ChallengeSender {
         "Role unauthorized for operation: Missing token, expecting one in the %s header."
             .formatted(headerName);
     CommandResult.Error error =
-        new CommandResult.Error(message, Collections.emptyMap(), Response.Status.UNAUTHORIZED);
+        new CommandResult.Error(
+            message, Collections.emptyMap(), Collections.emptyMap(), Response.Status.UNAUTHORIZED);
     commandResult = new CommandResult(List.of(error));
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/JsonApiException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/JsonApiException.java
@@ -74,7 +74,7 @@ public class JsonApiException extends RuntimeException implements Supplier<Comma
     } else {
       fields = Map.of("errorCode", errorCode.name());
     }
-    return new CommandResult.Error(message, fields, fieldsForMetricsTag, Response.Status.OK);
+    return new CommandResult.Error(message, fieldsForMetricsTag, fields, Response.Status.OK);
   }
 
   public ErrorCode getErrorCode() {

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/JsonApiException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/JsonApiException.java
@@ -61,6 +61,8 @@ public class JsonApiException extends RuntimeException implements Supplier<Comma
   }
 
   public CommandResult.Error getCommandResultError(String message) {
+    Map<String, Object> fieldsForMetricsTag =
+        Map.of("errorCode", errorCode.name(), "exceptionClass", this.getClass().getSimpleName());
     Map<String, Object> fields = null;
     SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
     // enable debug mode for unit tests, since it can not be injected
@@ -72,7 +74,7 @@ public class JsonApiException extends RuntimeException implements Supplier<Comma
     } else {
       fields = Map.of("errorCode", errorCode.name());
     }
-    return new CommandResult.Error(message, fields, Response.Status.OK);
+    return new CommandResult.Error(message, fields, fieldsForMetricsTag, Response.Status.OK);
   }
 
   public ErrorCode getErrorCode() {

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -31,20 +31,28 @@ public final class ThrowableToErrorMapper {
         if (throwable instanceof StatusRuntimeException sre) {
           Map<String, Object> fields =
               debugEnabled ? Map.of("exceptionClass", throwable.getClass().getSimpleName()) : null;
+          Map<String, Object> fieldsForMetricsTag =
+              Map.of("exceptionClass", throwable.getClass().getSimpleName());
           if (sre.getStatus().getCode() == Status.Code.UNAUTHENTICATED) {
-            return new CommandResult.Error(message, fields, Response.Status.UNAUTHORIZED);
+            return new CommandResult.Error(
+                message, fields, fieldsForMetricsTag, Response.Status.UNAUTHORIZED);
           } else if (sre.getStatus().getCode() == Status.Code.INTERNAL) {
-            return new CommandResult.Error(message, fields, Response.Status.INTERNAL_SERVER_ERROR);
+            return new CommandResult.Error(
+                message, fields, fieldsForMetricsTag, Response.Status.INTERNAL_SERVER_ERROR);
           } else if (sre.getStatus().getCode() == Status.Code.UNAVAILABLE) {
-            return new CommandResult.Error(message, fields, Response.Status.BAD_GATEWAY);
+            return new CommandResult.Error(
+                message, fields, fieldsForMetricsTag, Response.Status.BAD_GATEWAY);
           } else if (sre.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
-            return new CommandResult.Error(message, fields, Response.Status.GATEWAY_TIMEOUT);
+            return new CommandResult.Error(
+                message, fields, fieldsForMetricsTag, Response.Status.GATEWAY_TIMEOUT);
           }
         }
         // add error code as error field
         Map<String, Object> fields =
             debugEnabled ? Map.of("exceptionClass", throwable.getClass().getSimpleName()) : null;
-        return new CommandResult.Error(message, fields, Response.Status.OK);
+        Map<String, Object> fieldsForMetricsTag =
+            Map.of("exceptionClass", throwable.getClass().getSimpleName());
+        return new CommandResult.Error(message, fields, fieldsForMetricsTag, Response.Status.OK);
       };
 
   private static final Function<Throwable, CommandResult.Error> MAPPER =

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -35,16 +35,16 @@ public final class ThrowableToErrorMapper {
               Map.of("exceptionClass", throwable.getClass().getSimpleName());
           if (sre.getStatus().getCode() == Status.Code.UNAUTHENTICATED) {
             return new CommandResult.Error(
-                message, fields, fieldsForMetricsTag, Response.Status.UNAUTHORIZED);
+                message, fieldsForMetricsTag, fields, Response.Status.UNAUTHORIZED);
           } else if (sre.getStatus().getCode() == Status.Code.INTERNAL) {
             return new CommandResult.Error(
-                message, fields, fieldsForMetricsTag, Response.Status.INTERNAL_SERVER_ERROR);
+                message, fieldsForMetricsTag, fields, Response.Status.INTERNAL_SERVER_ERROR);
           } else if (sre.getStatus().getCode() == Status.Code.UNAVAILABLE) {
             return new CommandResult.Error(
-                message, fields, fieldsForMetricsTag, Response.Status.BAD_GATEWAY);
+                message, fieldsForMetricsTag, fields, Response.Status.BAD_GATEWAY);
           } else if (sre.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
             return new CommandResult.Error(
-                message, fields, fieldsForMetricsTag, Response.Status.GATEWAY_TIMEOUT);
+                message, fieldsForMetricsTag, fields, Response.Status.GATEWAY_TIMEOUT);
           }
         }
         // add error code as error field
@@ -52,7 +52,7 @@ public final class ThrowableToErrorMapper {
             debugEnabled ? Map.of("exceptionClass", throwable.getClass().getSimpleName()) : null;
         Map<String, Object> fieldsForMetricsTag =
             Map.of("exceptionClass", throwable.getClass().getSimpleName());
-        return new CommandResult.Error(message, fields, fieldsForMetricsTag, Response.Status.OK);
+        return new CommandResult.Error(message, fieldsForMetricsTag, fields, Response.Status.OK);
       };
 
   private static final Function<Throwable, CommandResult.Error> MAPPER =

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import io.quarkus.logging.Log;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.api.common.StargateRequestInfo;
 import io.stargate.sgv2.api.common.config.MetricsConfig;
@@ -109,13 +110,18 @@ public class MeteredCommandProcessor {
     if (null != result.errors() && !result.errors().isEmpty()) {
       errorTag = errorTrue;
       String errorClass =
-          (String) result.errors().get(0).fields().getOrDefault("exceptionClass", UNKNOWN_VALUE);
+          (String)
+              result
+                  .errors()
+                  .get(0)
+                  .fieldsForMetricsTag()
+                  .getOrDefault("exceptionClass", UNKNOWN_VALUE);
       errorClassTag = Tag.of(jsonApiMetricsConfig.errorClass(), errorClass);
       String errorCode =
-          (String) result.errors().get(0).fields().getOrDefault("errorCode", UNKNOWN_VALUE);
+          (String)
+              result.errors().get(0).fieldsForMetricsTag().getOrDefault("errorCode", UNKNOWN_VALUE);
       errorCodeTag = Tag.of(jsonApiMetricsConfig.errorCode(), errorCode);
     }
-
     Tag vectorEnabled =
         commandContext.isVectorEnabled()
             ? Tag.of(jsonApiMetricsConfig.vectorEnabled(), "true")

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessor.java
@@ -4,7 +4,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
-import io.quarkus.logging.Log;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.api.common.StargateRequestInfo;
 import io.stargate.sgv2.api.common.config.MetricsConfig;

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/serializers/ErrorSerializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/serializers/ErrorSerializerTest.java
@@ -27,7 +27,11 @@ class ErrorSerializerTest {
     @Test
     public void happyPath() throws Exception {
       CommandResult.Error error =
-          new CommandResult.Error("My message.", Map.of("field", "value"), Response.Status.OK);
+          new CommandResult.Error(
+              "My message.",
+              Map.of("field", "value"),
+              Map.of("field", "value"),
+              Response.Status.OK);
 
       String result = objectMapper.writeValueAsString(error);
 
@@ -39,7 +43,8 @@ class ErrorSerializerTest {
     @Test
     public void withoutProps() throws Exception {
       CommandResult.Error error =
-          new CommandResult.Error("My message.", Collections.emptyMap(), Response.Status.OK);
+          new CommandResult.Error(
+              "My message.", Collections.emptyMap(), Collections.emptyMap(), Response.Status.OK);
 
       String result = objectMapper.writeValueAsString(error);
 
@@ -53,7 +58,10 @@ class ErrorSerializerTest {
           catchThrowable(
               () ->
                   new CommandResult.Error(
-                      "My message.", Map.of("message", "value"), Response.Status.OK));
+                      "My message.",
+                      Map.of("message", "value"),
+                      Map.of("message", "value"),
+                      Response.Status.OK));
 
       assertThat(throwable)
           .isInstanceOf(IllegalArgumentException.class)
@@ -62,7 +70,7 @@ class ErrorSerializerTest {
 
     @Test
     public void withNulls() throws Exception {
-      CommandResult.Error error = new CommandResult.Error(null, null, Response.Status.OK);
+      CommandResult.Error error = new CommandResult.Error(null, null, null, Response.Status.OK);
 
       String result = objectMapper.writeValueAsString(error);
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HttpStatusCodeIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HttpStatusCodeIntegrationTest.java
@@ -51,6 +51,28 @@ public class HttpStatusCodeIntegrationTest extends AbstractCollectionIntegration
     }
 
     @Test
+    public void unauthenticatedNamespaceResource() {
+      String json =
+          """
+                {
+                    "createNamespace": {
+                        "name": "unAuthenticated"
+                    }
+                }
+                """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, "invalid token")
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(GeneralResource.BASE_PATH)
+          .then()
+          .statusCode(401)
+          .body("errors", is(notNullValue()))
+          .body("errors[0].message", endsWith("UNAUTHENTICATED: Invalid token"));
+    }
+
+    @Test
     public void regularError() {
       String json =
           """

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/response/CommandResultToRestResponseTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/response/CommandResultToRestResponseTest.java
@@ -32,7 +32,10 @@ public class CommandResultToRestResponseTest {
           new CommandResult(
               List.of(
                   new CommandResult.Error(
-                      "My message.", Map.of("field", "value"), Response.Status.OK)));
+                      "My message.",
+                      Map.of("field", "value"),
+                      Map.of("field", "value"),
+                      Response.Status.OK)));
       final RestResponse mappedResult = result.map();
       assertThat(mappedResult.getStatus()).isEqualTo(RestResponse.Status.OK.getStatusCode());
     }
@@ -43,7 +46,10 @@ public class CommandResultToRestResponseTest {
           new CommandResult(
               List.of(
                   new CommandResult.Error(
-                      "My message.", Map.of("field", "value"), Response.Status.UNAUTHORIZED)));
+                      "My message.",
+                      Map.of("field", "value"),
+                      Map.of("field", "value"),
+                      Response.Status.UNAUTHORIZED)));
       final RestResponse mappedResult = result.map();
       assertThat(mappedResult.getStatus())
           .isEqualTo(RestResponse.Status.UNAUTHORIZED.getStatusCode());
@@ -55,7 +61,10 @@ public class CommandResultToRestResponseTest {
           new CommandResult(
               List.of(
                   new CommandResult.Error(
-                      "My message.", Map.of("field", "value"), Response.Status.BAD_GATEWAY)));
+                      "My message.",
+                      Map.of("field", "value"),
+                      Map.of("field", "value"),
+                      Response.Status.BAD_GATEWAY)));
       final RestResponse mappedResult = result.map();
       assertThat(mappedResult.getStatus())
           .isEqualTo(RestResponse.Status.BAD_GATEWAY.getStatusCode());
@@ -69,6 +78,7 @@ public class CommandResultToRestResponseTest {
                   new CommandResult.Error(
                       "My message.",
                       Map.of("field", "value"),
+                      Map.of("field", "value"),
                       Response.Status.INTERNAL_SERVER_ERROR)));
       final RestResponse mappedResult = result.map();
       assertThat(mappedResult.getStatus())
@@ -81,7 +91,10 @@ public class CommandResultToRestResponseTest {
           new CommandResult(
               List.of(
                   new CommandResult.Error(
-                      "My message.", Map.of("field", "value"), Response.Status.GATEWAY_TIMEOUT)));
+                      "My message.",
+                      Map.of("field", "value"),
+                      Map.of("field", "value"),
+                      Response.Status.GATEWAY_TIMEOUT)));
       final RestResponse mappedResult = result.map();
       assertThat(mappedResult.getStatus())
           .isEqualTo(RestResponse.Status.GATEWAY_TIMEOUT.getStatusCode());

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/processor/MeteredCommandProcessorTest.java
@@ -98,7 +98,8 @@ public class MeteredCommandProcessorTest {
       CommandContext commandContext = new CommandContext("namespace", "collection");
       Map<String, Object> fields = new HashMap<>();
       fields.put("exceptionClass", "TestExceptionClass");
-      CommandResult.Error error = new CommandResult.Error("message", fields, Response.Status.OK);
+      CommandResult.Error error =
+          new CommandResult.Error("message", fields, fields, Response.Status.OK);
       CommandResult commandResult = new CommandResult(Collections.singletonList(error));
       Mockito.when(commandProcessor.processCommand(commandContext, countCommand))
           .thenReturn(Uni.createFrom().item(commandResult));
@@ -151,7 +152,8 @@ public class MeteredCommandProcessorTest {
       Map<String, Object> fields = new HashMap<>();
       fields.put("exceptionClass", "TestExceptionClass");
       fields.put("errorCode", "TestErrorCode");
-      CommandResult.Error error = new CommandResult.Error("message", fields, Response.Status.OK);
+      CommandResult.Error error =
+          new CommandResult.Error("message", fields, fields, Response.Status.OK);
       CommandResult commandResult = new CommandResult(Collections.singletonList(error));
       Mockito.when(commandProcessor.processCommand(commandContext, countCommand))
           .thenReturn(Uni.createFrom().item(commandResult));


### PR DESCRIPTION
**What this PR does**:
fix a bug of NamespaceResource commands
error msg should map to unauthorized token, but map to another msg

**Which issue(s) this PR fixes**:
Fixes https://github.com/stargate/jsonapi/issues/603

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
