### PR TITLE
fix collection not exist

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -9,7 +9,7 @@ public enum ErrorCode {
   COMMAND_ACCEPTS_NO_OPTIONS("Command accepts no options"),
 
   CONCURRENCY_FAILURE("Unable to complete transaction due to concurrent transactions"),
-
+  COLLECTION_NOT_EXIST("Collection does not exist, collection name: "),
   DATASET_TOO_BIG("Response data set too big to be sorted, add more filters"),
 
   DOCUMENT_ALREADY_EXISTS("Document already exists with the given _id"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/NamespaceCache.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/NamespaceCache.java
@@ -6,6 +6,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import io.grpc.StatusRuntimeException;
 import io.smallrye.mutiny.Uni;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import java.time.Duration;
 
 /** Caches the vector enabled status for the namespace */
@@ -41,14 +42,24 @@ public class NamespaceCache {
           .transformToUni(
               (result, error) -> {
                 if (null != error) {
+                  // collection does not exist
+                  if (error instanceof RuntimeException rte
+                      && rte.getMessage()
+                          .startsWith(ErrorCode.INVALID_COLLECTION_NAME.getMessage())) {
+                    return Uni.createFrom()
+                        .failure(
+                            new JsonApiException(
+                                ErrorCode.COLLECTION_NOT_EXIST,
+                                ErrorCode.COLLECTION_NOT_EXIST
+                                    .getMessage()
+                                    .concat(collectionName)));
+                  }
+
                   // ignoring the error and return false. This will be handled while trying to
                   //  execute the query
                   if ((error instanceof StatusRuntimeException sre
-                          && (sre.getStatus().getCode() == io.grpc.Status.Code.NOT_FOUND
-                              || sre.getStatus().getCode() == io.grpc.Status.Code.INVALID_ARGUMENT))
-                      || (error instanceof RuntimeException rte
-                          && rte.getMessage()
-                              .startsWith(ErrorCode.INVALID_COLLECTION_NAME.getMessage()))) {
+                      && (sre.getStatus().getCode() == io.grpc.Status.Code.NOT_FOUND
+                          || sre.getStatus().getCode() == io.grpc.Status.Code.INVALID_ARGUMENT))) {
                     return Uni.createFrom()
                         .item(new CollectionSettings(collectionName, false, 0, null, null, null));
                   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HttpStatusCodeIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/HttpStatusCodeIntegrationTest.java
@@ -89,7 +89,9 @@ public class HttpStatusCodeIntegrationTest extends AbstractCollectionIntegration
               endsWith(
                   "INVALID_ARGUMENT: table %s.%s does not exist"
                       .formatted(namespaceName, "badCollection")),
-              endsWith("INVALID_ARGUMENT: table %s does not exist".formatted("badCollection")));
+              endsWith("INVALID_ARGUMENT: table %s does not exist".formatted("badCollection")),
+              endsWith(
+                  "Collection does not exist, collection name: %s".formatted("badCollection")));
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
@@ -101,7 +103,7 @@ public class HttpStatusCodeIntegrationTest extends AbstractCollectionIntegration
           .body("errors", is(notNullValue()))
           .body("errors[0].message", is(not(blankString())))
           .body("errors[0].message", anyOf)
-          .body("errors[0].exceptionClass", is("StatusRuntimeException"));
+          .body("errors[0].exceptionClass", is("JsonApiException"));
     }
 
     @Test


### PR DESCRIPTION
when collection does not exist, operation involves vsearch will not error out as "collection not exist", but "vector search not enabled on this collection" which is misleading.

**Which issue(s) this PR fixes**:
Fixes https://github.com/stargate/jsonapi/issues/609

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
