### PR TITLE
Fix #596: renaming "pagingState"/"nextPagingState" as "pageState"/"nextPageState"

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -115,7 +115,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                              "filter": {"location": "London", "race.competitors" : {"$eq" : 100}},
                              "projection": {"tags":0},
                              "sort" : {"location" : 1},
-                             "options": {"limit" : 1000, "pagingState" : "Next paging state got from previous page call"}
+                             "options": {"limit" : 1000, "pageState" : "Next paging state got from previous page call"}
                         }
                       }
                       """),

--- a/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/StargateJsonApi.java
@@ -115,7 +115,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
                              "filter": {"location": "London", "race.competitors" : {"$eq" : 100}},
                              "projection": {"tags":0},
                              "sort" : {"location" : 1},
-                             "options": {"limit" : 1000, "pageState" : "Next paging state got from previous page call"}
+                             "options": {"limit" : 1000, "pageState" : "Next page state got from previous page call"}
                         }
                       }
                       """),

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandResult.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandResult.java
@@ -124,7 +124,7 @@ public record CommandResult(
    * responses.
    *
    * @param documents Documents.
-   * @param nextPageState Optional next paging state.
+   * @param nextPageState Optional next page state.
    */
   @Schema(description = "Response data for multiple documents commands.")
   public record MultiResponseData(
@@ -140,7 +140,7 @@ public record CommandResult(
       implements ResponseData {
 
     /**
-     * Constructor that sets documents without next paging state.
+     * Constructor that sets documents without next page state.
      *
      * @param documents Documents, must not be <code>null</code>.
      */

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
@@ -52,8 +52,8 @@ public record FindCommand(
               description = "Next page state for pagination.",
               type = SchemaType.STRING,
               implementation = String.class)
-      @JsonProperty("pageState")
-      @JsonAlias("pageState")
+          @JsonProperty("pageState")
+          @JsonAlias("pageState")
           String pageState,
 
       // include similarity function score

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
@@ -53,7 +53,7 @@ public record FindCommand(
               type = SchemaType.STRING,
               implementation = String.class)
           @JsonProperty("pageState")
-          @JsonAlias("pageState")
+          @JsonAlias("pagingState") // old name, 1.0.0-BETA-3 and prior
           String pageState,
 
       // include similarity function score

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
@@ -34,7 +34,7 @@ public record FindCommand(
       @Positive(message = "limit should be greater than `0`")
           @Schema(
               description =
-                  "Maximum number of document that can be fetched for the command. If value is higher than the default page size, amount of returned documents will be limited to the default page size and paging state will be returned in the response, so a caller can to continue paging through documents.",
+                  "Maximum number of document that can be fetched for the command. If value is higher than the default page size, amount of returned documents will be limited to the default page size and page state will be returned in the response, so a caller can to continue paging through documents.",
               type = SchemaType.INTEGER,
               implementation = Integer.class)
           Integer limit,
@@ -47,7 +47,7 @@ public record FindCommand(
               implementation = Integer.class)
           Integer skip,
 
-      // paging state for pagination
+      // page state for pagination
       @Schema(
               description = "Next page state for pagination.",
               type = SchemaType.STRING,

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommand.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.api.model.command.impl;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -51,7 +52,9 @@ public record FindCommand(
               description = "Next page state for pagination.",
               type = SchemaType.STRING,
               implementation = String.class)
-          String pagingState,
+      @JsonProperty("pageState")
+      @JsonAlias("pageState")
+          String pageState,
 
       // include similarity function score
       @Schema(

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/validation/FindOptionsValidation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/validation/FindOptionsValidation.java
@@ -56,10 +56,10 @@ public class FindOptionsValidation implements ConstraintValidator<CheckFindOptio
       return false;
     }
 
-    if (options.pagingState() != null && value.sortClause() != null) {
+    if (options.pageState() != null && value.sortClause() != null) {
       context
-          .buildConstraintViolationWithTemplate("pagingState is not supported with sort clause")
-          .addPropertyNode("options.pagingState")
+          .buildConstraintViolationWithTemplate("pageState is not supported with sort clause")
+          .addPropertyNode("options.pageState")
           .addConstraintViolation();
       return false;
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/QueryExecutor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/QueryExecutor.java
@@ -36,7 +36,7 @@ public class QueryExecutor {
    * Runs the provided read document query, Updates the query with parameters
    *
    * @param query read query to be executed
-   * @param pageState read paging state provided for subsequent pages
+   * @param pageState read page state provided for subsequent pages
    * @param pageSize request page size
    * @return proto result set
    */

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/QueryExecutor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/executor/QueryExecutor.java
@@ -36,19 +36,19 @@ public class QueryExecutor {
    * Runs the provided read document query, Updates the query with parameters
    *
    * @param query read query to be executed
-   * @param pagingState read paging state provided for subsequent pages
+   * @param pageState read paging state provided for subsequent pages
    * @param pageSize request page size
    * @return proto result set
    */
   public Uni<QueryOuterClass.ResultSet> executeRead(
-      QueryOuterClass.Query query, Optional<String> pagingState, int pageSize) {
+      QueryOuterClass.Query query, Optional<String> pageState, int pageSize) {
     QueryOuterClass.Consistency consistency = queriesConfig.consistency().reads();
     QueryOuterClass.ConsistencyValue.Builder consistencyValue =
         QueryOuterClass.ConsistencyValue.newBuilder().setValue(consistency);
     QueryOuterClass.QueryParameters.Builder params =
         QueryOuterClass.QueryParameters.newBuilder().setConsistency(consistencyValue);
-    if (pagingState.isPresent()) {
-      params.setPagingState(BytesValue.of(ByteString.copyFrom(decodeBase64(pagingState.get()))));
+    if (pageState.isPresent()) {
+      params.setPagingState(BytesValue.of(ByteString.copyFrom(decodeBase64(pageState.get()))));
     }
 
     params.setPageSize(Int32Value.of(pageSize));

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
@@ -124,10 +124,10 @@ public interface ReadOperation extends Operation {
                 }
               } else {
                 // pagination is handled only when single query is run(non `in` filter), so here
-                // paging state of the last query is returned
+                // page state of the last query is returned
                 for (FindResponse response : list) {
                   documents.addAll(response.docs());
-                  // picking the last paging state
+                  // picking the last page state
                   tempPageState = response.pageState();
                 }
               }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperation.java
@@ -69,11 +69,11 @@ public record DeleteOperation(
                   findOperation().getDocuments(queryExecutor, stateRef.get(), null);
               return docsToDelete
                   .onItem()
-                  .invoke(findResponse -> stateRef.set(findResponse.pagingState()));
+                  .invoke(findResponse -> stateRef.set(findResponse.pageState()));
             })
 
-        // Documents read until pagingState available, max records read is deleteLimit + 1
-        .whilst(findResponse -> findResponse.pagingState() != null)
+        // Documents read until pageState available, max records read is deleteLimit + 1
+        .whilst(findResponse -> findResponse.pageState() != null)
 
         // Get the deleteLimit # of documents to be delete and set moreData flag true if extra
         // document is read.

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
@@ -38,7 +38,7 @@ public record FindOperation(
      * to avoid projection from getting applied before updates.
      */
     DocumentProjector projection,
-    String pagingState,
+    String pageState,
     int limit,
     int pageSize,
     ReadType readType,
@@ -89,7 +89,7 @@ public record FindOperation(
    * @param commandContext command context
    * @param logicalExpression expression contains filters and their logical relation
    * @param projection projections, see FindOperation#projection
-   * @param pagingState paging state to use
+   * @param pageState paging state to use
    * @param limit limit of rows to fetch
    * @param pageSize page size
    * @param readType type of the read
@@ -100,7 +100,7 @@ public record FindOperation(
       CommandContext commandContext,
       LogicalExpression logicalExpression,
       DocumentProjector projection,
-      String pagingState,
+      String pageState,
       int limit,
       int pageSize,
       ReadType readType,
@@ -109,7 +109,7 @@ public record FindOperation(
         commandContext,
         logicalExpression,
         projection,
-        pagingState,
+        pageState,
         limit,
         pageSize,
         readType,
@@ -160,7 +160,7 @@ public record FindOperation(
    * @param commandContext command context
    * @param logicalExpression expression contains filters and their logical relation
    * @param projection projections, see FindOperation#projection
-   * @param pagingState paging state to use
+   * @param pageState paging state to use
    * @param limit limit of rows to fetch
    * @param pageSize page size
    * @param readType type of the read
@@ -171,7 +171,7 @@ public record FindOperation(
       CommandContext commandContext,
       LogicalExpression logicalExpression,
       DocumentProjector projection,
-      String pagingState,
+      String pageState,
       int limit,
       int pageSize,
       ReadType readType,
@@ -181,7 +181,7 @@ public record FindOperation(
         commandContext,
         logicalExpression,
         projection,
-        pagingState,
+        pageState,
         limit,
         pageSize,
         readType,
@@ -239,7 +239,7 @@ public record FindOperation(
    * @param commandContext command context
    * @param logicalExpression expression contains filters and their logical relation
    * @param projection projections, see FindOperation#projection
-   * @param pagingState paging state to use
+   * @param pageState paging state to use
    * @param limit limit of rows to fetch
    * @param pageSize page size for in memory sorting
    * @param readType type of the read
@@ -253,7 +253,7 @@ public record FindOperation(
       CommandContext commandContext,
       LogicalExpression logicalExpression,
       DocumentProjector projection,
-      String pagingState,
+      String pageState,
       int limit,
       int pageSize,
       ReadType readType,
@@ -265,7 +265,7 @@ public record FindOperation(
         commandContext,
         logicalExpression,
         projection,
-        pagingState,
+        pageState,
         limit,
         pageSize,
         readType,
@@ -289,10 +289,10 @@ public record FindOperation(
                       + commandContext().collection()));
     }
     // get FindResponse
-    return getDocuments(queryExecutor, pagingState(), null)
+    return getDocuments(queryExecutor, pageState(), null)
 
         // map the response to result
-        .map(docs -> new ReadOperationPage(docs.docs(), docs.pagingState(), singleResponse));
+        .map(docs -> new ReadOperationPage(docs.docs(), docs.pageState(), singleResponse));
   }
 
   /**
@@ -300,13 +300,13 @@ public record FindOperation(
    * used by other commands which needs a document to be read.
    *
    * @param queryExecutor
-   * @param pagingState
+   * @param pageState
    * @param additionalIdFilter Used if a additional id filter need to be added to already available
    *     filters
    * @return
    */
   public Uni<FindResponse> getDocuments(
-      QueryExecutor queryExecutor, String pagingState, DBFilterBase.IDFilter additionalIdFilter) {
+      QueryExecutor queryExecutor, String pageState, DBFilterBase.IDFilter additionalIdFilter) {
 
     // ensure we pass failure down if read type is not DOCUMENT or KEY
     // COUNT is not supported
@@ -330,7 +330,7 @@ public record FindOperation(
         return findDocument(
             queryExecutor,
             queries,
-            pagingState,
+            pageState,
             pageSize,
             ReadType.DOCUMENT == readType,
             objectMapper,

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
@@ -89,7 +89,7 @@ public record FindOperation(
    * @param commandContext command context
    * @param logicalExpression expression contains filters and their logical relation
    * @param projection projections, see FindOperation#projection
-   * @param pageState paging state to use
+   * @param pageState page state to use
    * @param limit limit of rows to fetch
    * @param pageSize page size
    * @param readType type of the read
@@ -160,7 +160,7 @@ public record FindOperation(
    * @param commandContext command context
    * @param logicalExpression expression contains filters and their logical relation
    * @param projection projections, see FindOperation#projection
-   * @param pageState paging state to use
+   * @param pageState page state to use
    * @param limit limit of rows to fetch
    * @param pageSize page size
    * @param readType type of the read
@@ -239,7 +239,7 @@ public record FindOperation(
    * @param commandContext command context
    * @param logicalExpression expression contains filters and their logical relation
    * @param projection projections, see FindOperation#projection
-   * @param pageState paging state to use
+   * @param pageState page state to use
    * @param limit limit of rows to fetch
    * @param pageSize page size for in memory sorting
    * @param readType type of the read

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
@@ -68,10 +68,10 @@ public record ReadAndUpdateOperation(
                   findOperation().getDocuments(queryExecutor, stateRef.get(), null);
               return docsToUpdate
                   .onItem()
-                  .invoke(findResponse -> stateRef.set(findResponse.pagingState()));
+                  .invoke(findResponse -> stateRef.set(findResponse.pageState()));
             })
-        // Read document while pagingState exists, limit for read is set at updateLimit +1
-        .whilst(findResponse -> findResponse.pagingState() != null)
+        // Read document while pageState exists, limit for read is set at updateLimit +1
+        .whilst(findResponse -> findResponse.pageState() != null)
         // Transform to get only the updateLimit records, if more set `moreData` to true
         .onItem()
         .transformToMulti(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadOperationPage.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadOperationPage.java
@@ -10,7 +10,7 @@ import java.util.function.Supplier;
  * FindOperation response implementing the {@link CommandResult}.
  *
  * @param docs list of documents
- * @param pageState paging state
+ * @param pageState page state
  * @param singleResponse if the response data should be a single document response
  */
 public record ReadOperationPage(List<ReadDocument> docs, String pageState, boolean singleResponse)

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadOperationPage.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadOperationPage.java
@@ -10,10 +10,10 @@ import java.util.function.Supplier;
  * FindOperation response implementing the {@link CommandResult}.
  *
  * @param docs list of documents
- * @param pagingState paging state
+ * @param pageState paging state
  * @param singleResponse if the response data should be a single document response
  */
-public record ReadOperationPage(List<ReadDocument> docs, String pagingState, boolean singleResponse)
+public record ReadOperationPage(List<ReadDocument> docs, String pageState, boolean singleResponse)
     implements Supplier<CommandResult> {
   @Override
   public CommandResult get() {
@@ -28,7 +28,7 @@ public record ReadOperationPage(List<ReadDocument> docs, String pagingState, boo
       for (ReadDocument doc : docs) {
         jsonNodes.add(doc.document());
       }
-      return new CommandResult(new CommandResult.MultiResponseData(jsonNodes, pagingState));
+      return new CommandResult(new CommandResult.MultiResponseData(jsonNodes, pageState));
     }
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolver.java
@@ -40,7 +40,7 @@ public class FindCommandResolver extends FilterableResolver<FindCommand>
   @Override
   public Operation resolveCommand(CommandContext commandContext, FindCommand command) {
     final LogicalExpression resolvedLogicalExpression = resolve(commandContext, command);
-    // limit and paging state defaults
+    // limit and page state defaults
     int limit = Integer.MAX_VALUE;
     int skip = 0;
     String pageState = null;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolver.java
@@ -43,7 +43,7 @@ public class FindCommandResolver extends FilterableResolver<FindCommand>
     // limit and paging state defaults
     int limit = Integer.MAX_VALUE;
     int skip = 0;
-    String pagingState = null;
+    String pageState = null;
     boolean includeSimilarity = false;
 
     // update if options provided
@@ -55,7 +55,7 @@ public class FindCommandResolver extends FilterableResolver<FindCommand>
       if (null != options.skip()) {
         skip = options.skip();
       }
-      pagingState = options.pagingState();
+      pageState = options.pageState();
       includeSimilarity = options.includeSimilarity();
     }
 
@@ -76,7 +76,7 @@ public class FindCommandResolver extends FilterableResolver<FindCommand>
           commandContext,
           resolvedLogicalExpression,
           command.buildProjector(includeSimilarity),
-          pagingState,
+          pageState,
           limit,
           operationsConfig.defaultPageSize(),
           ReadType.DOCUMENT,
@@ -91,7 +91,7 @@ public class FindCommandResolver extends FilterableResolver<FindCommand>
           commandContext,
           resolvedLogicalExpression,
           command.buildProjector(),
-          pagingState,
+          pageState,
           // For in memory sorting if no limit provided in the request will use
           // documentConfig.defaultPageSize() as limit
           Math.min(limit, operationsConfig.defaultPageSize()),
@@ -107,7 +107,7 @@ public class FindCommandResolver extends FilterableResolver<FindCommand>
           commandContext,
           resolvedLogicalExpression,
           command.buildProjector(),
-          pagingState,
+          pageState,
           limit,
           operationsConfig.defaultPageSize(),
           ReadType.DOCUMENT,

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommandTest.java
@@ -163,7 +163,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void invalidOptionsPagingStateWithSort() throws Exception {
+    public void invalidOptionsPageStateWithSort() throws Exception {
       String json =
           """
           {
@@ -171,7 +171,7 @@ public class FindCommandTest {
               "filter" : {"username" : "user1"},
               "sort" : {"username" : 1},
               "options" : {
-                "pagingState" : "someState"
+                "pageState" : "someState"
               }
             }
           }
@@ -183,7 +183,7 @@ public class FindCommandTest {
       assertThat(result)
           .isNotEmpty()
           .extracting(ConstraintViolation::getMessage)
-          .contains("pagingState is not supported with sort clause");
+          .contains("pageState is not supported with sort clause");
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteManyCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteManyCommandResolverTest.java
@@ -66,7 +66,7 @@ public class DeleteManyCommandResolverTest {
                           assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                           assertThat(find.limit())
                               .isEqualTo(operationsConfig.maxDocumentDeleteCount() + 1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.KEY);
                           assertThat(
                                   find.logicalExpression()
@@ -108,7 +108,7 @@ public class DeleteManyCommandResolverTest {
                           assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                           assertThat(find.limit())
                               .isEqualTo(operationsConfig.maxDocumentDeleteCount() + 1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.KEY);
                           assertThat(find.logicalExpression().comparisonExpressions).isEmpty();
                         });
@@ -149,7 +149,7 @@ public class DeleteManyCommandResolverTest {
                           assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                           assertThat(find.limit())
                               .isEqualTo(operationsConfig.maxDocumentDeleteCount() + 1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.KEY);
                           assertThat(
                                   find.logicalExpression()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolverTest.java
@@ -65,7 +65,7 @@
 //                          assertThat(find.commandContext()).isEqualTo(commandContext);
 //                          assertThat(find.pageSize()).isEqualTo(1);
 //                          assertThat(find.limit()).isEqualTo(1);
-//                          assertThat(find.pagingState()).isNull();
+//                          assertThat(find.pageState()).isNull();
 //                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
 //                          assertThat(
 //                                  find.logicalExpression()
@@ -107,7 +107,7 @@
 //                          assertThat(find.commandContext()).isEqualTo(commandContext);
 //                          assertThat(find.pageSize()).isEqualTo(1);
 //                          assertThat(find.limit()).isEqualTo(1);
-//                          assertThat(find.pagingState()).isNull();
+//                          assertThat(find.pageState()).isNull();
 //                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
 //                          assertThat(find.logicalExpression().comparisonExpressions).isEmpty();
 //                          assertThat(find.singleResponse()).isTrue();
@@ -148,7 +148,7 @@
 //                          assertThat(find.commandContext()).isEqualTo(commandContext);
 //                          assertThat(find.pageSize()).isEqualTo(1);
 //                          assertThat(find.limit()).isEqualTo(1);
-//                          assertThat(find.pagingState()).isNull();
+//                          assertThat(find.pageState()).isNull();
 //                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
 //                          assertThat(
 //                                  find.logicalExpression()
@@ -196,7 +196,7 @@
 //                          assertThat(find.commandContext()).isEqualTo(commandContext);
 //                          assertThat(find.pageSize()).isEqualTo(100);
 //                          assertThat(find.limit()).isEqualTo(1);
-//                          assertThat(find.pagingState()).isNull();
+//                          assertThat(find.pageState()).isNull();
 //                          assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
 //                          assertThat(
 //                                  find.logicalExpression()
@@ -249,7 +249,7 @@
 //                          assertThat(find.commandContext()).isEqualTo(commandContext);
 //                          assertThat(find.pageSize()).isEqualTo(1);
 //                          assertThat(find.limit()).isEqualTo(1);
-//                          assertThat(find.pagingState()).isNull();
+//                          assertThat(find.pageState()).isNull();
 //                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
 //                          assertThat(
 //                                  find.logicalExpression()
@@ -304,7 +304,7 @@
 //                              .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
 //                          assertThat(find.pageSize()).isEqualTo(1);
 //                          assertThat(find.limit()).isEqualTo(1);
-//                          assertThat(find.pagingState()).isNull();
+//                          assertThat(find.pageState()).isNull();
 //                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
 //                          assertThat(
 //                                  find.logicalExpression()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolverTest.java
@@ -1,324 +1,324 @@
-// package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
-//
-// import static org.assertj.core.api.Assertions.assertThat;
-//
-// import com.fasterxml.jackson.databind.ObjectMapper;
-// import io.quarkus.test.junit.QuarkusTest;
-// import io.quarkus.test.junit.TestProfile;
-// import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
-// import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
-// import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteOneCommand;
-// import io.stargate.sgv2.jsonapi.config.OperationsConfig;
-// import io.stargate.sgv2.jsonapi.service.embedding.operation.TestEmbeddingService;
-// import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
-// import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
-// import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
-// import io.stargate.sgv2.jsonapi.service.operation.model.impl.DeleteOperation;
-// import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
-// import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
-// import jakarta.inject.Inject;
-// import org.junit.jupiter.api.Nested;
-// import org.junit.jupiter.api.Test;
-//
-// @QuarkusTest
-// @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
-// public class DeleteOneCommandResolverTest {
-//  @Inject ObjectMapper objectMapper;
-//  @Inject OperationsConfig operationsConfig;
-//  @Inject DeleteOneCommandResolver resolver;
-//
-//  @Nested
-//  class DeleteOneCommandResolveCommand {
-//
-//    CommandContext commandContext = CommandContext.empty();
-//
-//    @Test
-//    public void idFilterCondition() throws Exception {
-//      String json =
-//          """
-//          {
-//            "deleteOne": {
-//              "filter" : {"_id" : "id"}
-//            }
-//          }
-//          """;
-//
-//      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
-//      Operation operation = resolver.resolveCommand(commandContext, deleteOneCommand);
-//
-//      assertThat(operation)
-//          .isInstanceOfSatisfying(
-//              DeleteOperation.class,
-//              op -> {
-//                assertThat(op.commandContext()).isEqualTo(commandContext);
-//                assertThat(op.deleteLimit()).isEqualTo(1);
-//                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
-//                assertThat(op.findOperation())
-//                    .isInstanceOfSatisfying(
-//                        FindOperation.class,
-//                        find -> {
-//                          DBFilterBase.IDFilter filter =
-//                              new DBFilterBase.IDFilter(
-//                                  DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("id"));
-//
-//                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
-//                          assertThat(find.commandContext()).isEqualTo(commandContext);
-//                          assertThat(find.pageSize()).isEqualTo(1);
-//                          assertThat(find.limit()).isEqualTo(1);
-//                          assertThat(find.pageState()).isNull();
-//                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
-//                          assertThat(
-//                                  find.logicalExpression()
-//                                      .comparisonExpressions
-//                                      .get(0)
-//                                      .getDbFilters()
-//                                      .get(0))
-//                              .isEqualTo(filter);
-//                          assertThat(find.singleResponse()).isTrue();
-//                        });
-//              });
-//    }
-//
-//    @Test
-//    public void noFilterCondition() throws Exception {
-//      String json =
-//          """
-//          {
-//            "deleteOne": {
-//            }
-//          }
-//          """;
-//
-//      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
-//      Operation operation = resolver.resolveCommand(commandContext, deleteOneCommand);
-//
-//      assertThat(operation)
-//          .isInstanceOfSatisfying(
-//              DeleteOperation.class,
-//              op -> {
-//                assertThat(op.commandContext()).isEqualTo(commandContext);
-//                assertThat(op.deleteLimit()).isEqualTo(1);
-//                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
-//                assertThat(op.findOperation())
-//                    .isInstanceOfSatisfying(
-//                        FindOperation.class,
-//                        find -> {
-//                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
-//                          assertThat(find.commandContext()).isEqualTo(commandContext);
-//                          assertThat(find.pageSize()).isEqualTo(1);
-//                          assertThat(find.limit()).isEqualTo(1);
-//                          assertThat(find.pageState()).isNull();
-//                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
-//                          assertThat(find.logicalExpression().comparisonExpressions).isEmpty();
-//                          assertThat(find.singleResponse()).isTrue();
-//                        });
-//              });
-//    }
-//
-//    @Test
-//    public void dynamicFilterCondition() throws Exception {
-//      String json =
-//          """
-//          {
-//            "deleteOne": {
-//              "filter" : {"col" : "val"}
-//            }
-//          }
-//          """;
-//
-//      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
-//      Operation operation = resolver.resolveCommand(commandContext, deleteOneCommand);
-//
-//      assertThat(operation)
-//          .isInstanceOfSatisfying(
-//              DeleteOperation.class,
-//              op -> {
-//                assertThat(op.commandContext()).isEqualTo(commandContext);
-//                assertThat(op.deleteLimit()).isEqualTo(1);
-//                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
-//                assertThat(op.findOperation())
-//                    .isInstanceOfSatisfying(
-//                        FindOperation.class,
-//                        find -> {
-//                          DBFilterBase.TextFilter filter =
-//                              new DBFilterBase.TextFilter(
-//                                  "col", DBFilterBase.MapFilterBase.Operator.EQ, "val");
-//
-//                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
-//                          assertThat(find.commandContext()).isEqualTo(commandContext);
-//                          assertThat(find.pageSize()).isEqualTo(1);
-//                          assertThat(find.limit()).isEqualTo(1);
-//                          assertThat(find.pageState()).isNull();
-//                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
-//                          assertThat(
-//                                  find.logicalExpression()
-//                                      .comparisonExpressions
-//                                      .get(0)
-//                                      .getDbFilters()
-//                                      .get(0))
-//                              .isEqualTo(filter);
-//                          assertThat(find.singleResponse()).isTrue();
-//                        });
-//              });
-//    }
-//
-//    @Test
-//    public void dynamicFilterConditionWithSort() throws Exception {
-//      String json =
-//          """
-//                  {
-//                    "deleteOne": {
-//                      "filter" : {"col" : "val"},
-//                      "sort" : {"sort_col" : 1}
-//                    }
-//                  }
-//                  """;
-//
-//      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
-//      Operation operation = resolver.resolveCommand(commandContext, deleteOneCommand);
-//
-//      assertThat(operation)
-//          .isInstanceOfSatisfying(
-//              DeleteOperation.class,
-//              op -> {
-//                assertThat(op.commandContext()).isEqualTo(commandContext);
-//                assertThat(op.deleteLimit()).isEqualTo(1);
-//                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
-//                assertThat(op.findOperation())
-//                    .isInstanceOfSatisfying(
-//                        FindOperation.class,
-//                        find -> {
-//                          DBFilterBase.TextFilter filter =
-//                              new DBFilterBase.TextFilter(
-//                                  "col", DBFilterBase.MapFilterBase.Operator.EQ, "val");
-//
-//                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
-//                          assertThat(find.commandContext()).isEqualTo(commandContext);
-//                          assertThat(find.pageSize()).isEqualTo(100);
-//                          assertThat(find.limit()).isEqualTo(1);
-//                          assertThat(find.pageState()).isNull();
-//                          assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
-//                          assertThat(
-//                                  find.logicalExpression()
-//                                      .comparisonExpressions
-//                                      .get(0)
-//                                      .getDbFilters()
-//                                      .get(0))
-//                              .isEqualTo(filter);
-//                          assertThat(find.orderBy()).hasSize(1);
-//                          assertThat(find.orderBy().get(0))
-//                              .isEqualTo(new FindOperation.OrderBy("sort_col", true));
-//                          assertThat(find.maxSortReadLimit())
-//                              .isEqualTo(operationsConfig.maxDocumentSortCount());
-//                          assertThat(find.singleResponse()).isTrue();
-//                        });
-//              });
-//    }
-//
-//    @Test
-//    public void dynamicFilterConditionWithVectorSearch() throws Exception {
-//      String json =
-//          """
-//              {
-//                "deleteOne": {
-//                  "filter" : {"col" : "val"},
-//                  "sort" : {"$vector" : [0.11, 0.22, 0.33, 0.44]}
-//                }
-//              }
-//              """;
-//
-//      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
-//      Operation operation = resolver.resolveCommand(commandContext, deleteOneCommand);
-//
-//      assertThat(operation)
-//          .isInstanceOfSatisfying(
-//              DeleteOperation.class,
-//              op -> {
-//                assertThat(op.commandContext()).isEqualTo(commandContext);
-//                assertThat(op.deleteLimit()).isEqualTo(1);
-//                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
-//                assertThat(op.findOperation())
-//                    .isInstanceOfSatisfying(
-//                        FindOperation.class,
-//                        find -> {
-//                          DBFilterBase.TextFilter filter =
-//                              new DBFilterBase.TextFilter(
-//                                  "col", DBFilterBase.MapFilterBase.Operator.EQ, "val");
-//
-//                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
-//                          assertThat(find.commandContext()).isEqualTo(commandContext);
-//                          assertThat(find.pageSize()).isEqualTo(1);
-//                          assertThat(find.limit()).isEqualTo(1);
-//                          assertThat(find.pageState()).isNull();
-//                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
-//                          assertThat(
-//                                  find.logicalExpression()
-//                                      .comparisonExpressions
-//                                      .get(0)
-//                                      .getDbFilters()
-//                                      .get(0))
-//                              .isEqualTo(filter);
-//                          assertThat(find.orderBy()).isNull();
-//                          assertThat(find.vector()).isNotNull();
-//                          assertThat(find.vector()).containsExactly(0.11f, 0.22f, 0.33f, 0.44f);
-//                          assertThat(find.singleResponse()).isTrue();
-//                        });
-//              });
-//    }
-//
-//    @Test
-//    public void dynamicFilterConditionWithVectorizeSearch() throws Exception {
-//      String json =
-//          """
-//              {
-//                "deleteOne": {
-//                  "filter" : {"col" : "val"},
-//                  "sort" : {"$vectorize" : "test data"}
-//                }
-//              }
-//              """;
-//
-//      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
-//      Operation operation =
-//          resolver.resolveCommand(
-//              TestEmbeddingService.commandContextWithVectorize, deleteOneCommand);
-//
-//      assertThat(operation)
-//          .isInstanceOfSatisfying(
-//              DeleteOperation.class,
-//              op -> {
-//                assertThat(op.commandContext())
-//                    .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
-//                assertThat(op.deleteLimit()).isEqualTo(1);
-//                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
-//                assertThat(op.findOperation())
-//                    .isInstanceOfSatisfying(
-//                        FindOperation.class,
-//                        find -> {
-//                          DBFilterBase.TextFilter filter =
-//                              new DBFilterBase.TextFilter(
-//                                  "col", DBFilterBase.MapFilterBase.Operator.EQ, "val");
-//
-//                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
-//                          assertThat(find.commandContext())
-//                              .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
-//                          assertThat(find.pageSize()).isEqualTo(1);
-//                          assertThat(find.limit()).isEqualTo(1);
-//                          assertThat(find.pageState()).isNull();
-//                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
-//                          assertThat(
-//                                  find.logicalExpression()
-//                                      .comparisonExpressions
-//                                      .get(0)
-//                                      .getDbFilters()
-//                                      .get(0))
-//                              .isEqualTo(filter);
-//                          assertThat(find.orderBy()).isNull();
-//                          assertThat(find.vector()).isNotNull();
-//                          assertThat(find.vector()).containsExactly(0.25f, 0.25f, 0.25f);
-//                          assertThat(find.singleResponse()).isTrue();
-//                        });
-//              });
-//    }
-//  }
-// }
+ package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
+
+ import static org.assertj.core.api.Assertions.assertThat;
+
+ import com.fasterxml.jackson.databind.ObjectMapper;
+ import io.quarkus.test.junit.QuarkusTest;
+ import io.quarkus.test.junit.TestProfile;
+ import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+ import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
+ import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteOneCommand;
+ import io.stargate.sgv2.jsonapi.config.OperationsConfig;
+ import io.stargate.sgv2.jsonapi.service.embedding.operation.TestEmbeddingService;
+ import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
+ import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
+ import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
+ import io.stargate.sgv2.jsonapi.service.operation.model.impl.DeleteOperation;
+ import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
+ import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
+ import jakarta.inject.Inject;
+ import org.junit.jupiter.api.Nested;
+ import org.junit.jupiter.api.Test;
+
+ @QuarkusTest
+ @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+ public class DeleteOneCommandResolverTest {
+  @Inject ObjectMapper objectMapper;
+  @Inject OperationsConfig operationsConfig;
+  @Inject DeleteOneCommandResolver resolver;
+
+  @Nested
+  class DeleteOneCommandResolveCommand {
+
+    CommandContext commandContext = CommandContext.empty();
+
+    @Test
+    public void idFilterCondition() throws Exception {
+      String json =
+          """
+          {
+            "deleteOne": {
+              "filter" : {"_id" : "id"}
+            }
+          }
+          """;
+
+      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, deleteOneCommand);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              DeleteOperation.class,
+              op -> {
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.deleteLimit()).isEqualTo(1);
+                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
+                assertThat(op.findOperation())
+                    .isInstanceOfSatisfying(
+                        FindOperation.class,
+                        find -> {
+                          DBFilterBase.IDFilter filter =
+                              new DBFilterBase.IDFilter(
+                                  DBFilterBase.IDFilter.Operator.EQ, DocumentId.fromString("id"));
+
+                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                          assertThat(find.commandContext()).isEqualTo(commandContext);
+                          assertThat(find.pageSize()).isEqualTo(1);
+                          assertThat(find.limit()).isEqualTo(1);
+                          assertThat(find.pageState()).isNull();
+                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
+                          assertThat(
+                                  find.logicalExpression()
+                                      .comparisonExpressions
+                                      .get(0)
+                                      .getDbFilters()
+                                      .get(0))
+                              .isEqualTo(filter);
+                          assertThat(find.singleResponse()).isTrue();
+                        });
+              });
+    }
+
+    @Test
+    public void noFilterCondition() throws Exception {
+      String json =
+          """
+          {
+            "deleteOne": {
+            }
+          }
+          """;
+
+      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, deleteOneCommand);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              DeleteOperation.class,
+              op -> {
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.deleteLimit()).isEqualTo(1);
+                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
+                assertThat(op.findOperation())
+                    .isInstanceOfSatisfying(
+                        FindOperation.class,
+                        find -> {
+                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                          assertThat(find.commandContext()).isEqualTo(commandContext);
+                          assertThat(find.pageSize()).isEqualTo(1);
+                          assertThat(find.limit()).isEqualTo(1);
+                          assertThat(find.pageState()).isNull();
+                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
+                          assertThat(find.logicalExpression().comparisonExpressions).isEmpty();
+                          assertThat(find.singleResponse()).isTrue();
+                        });
+              });
+    }
+
+    @Test
+    public void dynamicFilterCondition() throws Exception {
+      String json =
+          """
+          {
+            "deleteOne": {
+              "filter" : {"col" : "val"}
+            }
+          }
+          """;
+
+      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, deleteOneCommand);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              DeleteOperation.class,
+              op -> {
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.deleteLimit()).isEqualTo(1);
+                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
+                assertThat(op.findOperation())
+                    .isInstanceOfSatisfying(
+                        FindOperation.class,
+                        find -> {
+                          DBFilterBase.TextFilter filter =
+                              new DBFilterBase.TextFilter(
+                                  "col", DBFilterBase.MapFilterBase.Operator.EQ, "val");
+
+                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                          assertThat(find.commandContext()).isEqualTo(commandContext);
+                          assertThat(find.pageSize()).isEqualTo(1);
+                          assertThat(find.limit()).isEqualTo(1);
+                          assertThat(find.pageState()).isNull();
+                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
+                          assertThat(
+                                  find.logicalExpression()
+                                      .comparisonExpressions
+                                      .get(0)
+                                      .getDbFilters()
+                                      .get(0))
+                              .isEqualTo(filter);
+                          assertThat(find.singleResponse()).isTrue();
+                        });
+              });
+    }
+
+    @Test
+    public void dynamicFilterConditionWithSort() throws Exception {
+      String json =
+          """
+                  {
+                    "deleteOne": {
+                      "filter" : {"col" : "val"},
+                      "sort" : {"sort_col" : 1}
+                    }
+                  }
+                  """;
+
+      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, deleteOneCommand);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              DeleteOperation.class,
+              op -> {
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.deleteLimit()).isEqualTo(1);
+                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
+                assertThat(op.findOperation())
+                    .isInstanceOfSatisfying(
+                        FindOperation.class,
+                        find -> {
+                          DBFilterBase.TextFilter filter =
+                              new DBFilterBase.TextFilter(
+                                  "col", DBFilterBase.MapFilterBase.Operator.EQ, "val");
+
+                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                          assertThat(find.commandContext()).isEqualTo(commandContext);
+                          assertThat(find.pageSize()).isEqualTo(100);
+                          assertThat(find.limit()).isEqualTo(1);
+                          assertThat(find.pageState()).isNull();
+                          assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
+                          assertThat(
+                                  find.logicalExpression()
+                                      .comparisonExpressions
+                                      .get(0)
+                                      .getDbFilters()
+                                      .get(0))
+                              .isEqualTo(filter);
+                          assertThat(find.orderBy()).hasSize(1);
+                          assertThat(find.orderBy().get(0))
+                              .isEqualTo(new FindOperation.OrderBy("sort_col", true));
+                          assertThat(find.maxSortReadLimit())
+                              .isEqualTo(operationsConfig.maxDocumentSortCount());
+                          assertThat(find.singleResponse()).isTrue();
+                        });
+              });
+    }
+
+    @Test
+    public void dynamicFilterConditionWithVectorSearch() throws Exception {
+      String json =
+          """
+              {
+                "deleteOne": {
+                  "filter" : {"col" : "val"},
+                  "sort" : {"$vector" : [0.11, 0.22, 0.33, 0.44]}
+                }
+              }
+              """;
+
+      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, deleteOneCommand);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              DeleteOperation.class,
+              op -> {
+                assertThat(op.commandContext()).isEqualTo(commandContext);
+                assertThat(op.deleteLimit()).isEqualTo(1);
+                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
+                assertThat(op.findOperation())
+                    .isInstanceOfSatisfying(
+                        FindOperation.class,
+                        find -> {
+                          DBFilterBase.TextFilter filter =
+                              new DBFilterBase.TextFilter(
+                                  "col", DBFilterBase.MapFilterBase.Operator.EQ, "val");
+
+                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                          assertThat(find.commandContext()).isEqualTo(commandContext);
+                          assertThat(find.pageSize()).isEqualTo(1);
+                          assertThat(find.limit()).isEqualTo(1);
+                          assertThat(find.pageState()).isNull();
+                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
+                          assertThat(
+                                  find.logicalExpression()
+                                      .comparisonExpressions
+                                      .get(0)
+                                      .getDbFilters()
+                                      .get(0))
+                              .isEqualTo(filter);
+                          assertThat(find.orderBy()).isNull();
+                          assertThat(find.vector()).isNotNull();
+                          assertThat(find.vector()).containsExactly(0.11f, 0.22f, 0.33f, 0.44f);
+                          assertThat(find.singleResponse()).isTrue();
+                        });
+              });
+    }
+
+    @Test
+    public void dynamicFilterConditionWithVectorizeSearch() throws Exception {
+      String json =
+          """
+              {
+                "deleteOne": {
+                  "filter" : {"col" : "val"},
+                  "sort" : {"$vectorize" : "test data"}
+                }
+              }
+              """;
+
+      DeleteOneCommand deleteOneCommand = objectMapper.readValue(json, DeleteOneCommand.class);
+      Operation operation =
+          resolver.resolveCommand(
+              TestEmbeddingService.commandContextWithVectorize, deleteOneCommand);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              DeleteOperation.class,
+              op -> {
+                assertThat(op.commandContext())
+                    .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
+                assertThat(op.deleteLimit()).isEqualTo(1);
+                assertThat(op.retryLimit()).isEqualTo(operationsConfig.lwt().retries());
+                assertThat(op.findOperation())
+                    .isInstanceOfSatisfying(
+                        FindOperation.class,
+                        find -> {
+                          DBFilterBase.TextFilter filter =
+                              new DBFilterBase.TextFilter(
+                                  "col", DBFilterBase.MapFilterBase.Operator.EQ, "val");
+
+                          assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                          assertThat(find.commandContext())
+                              .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
+                          assertThat(find.pageSize()).isEqualTo(1);
+                          assertThat(find.limit()).isEqualTo(1);
+                          assertThat(find.pageState()).isNull();
+                          assertThat(find.readType()).isEqualTo(ReadType.KEY);
+                          assertThat(
+                                  find.logicalExpression()
+                                      .comparisonExpressions
+                                      .get(0)
+                                      .getDbFilters()
+                                      .get(0))
+                              .isEqualTo(filter);
+                          assertThat(find.orderBy()).isNull();
+                          assertThat(find.vector()).isNotNull();
+                          assertThat(find.vector()).containsExactly(0.25f, 0.25f, 0.25f);
+                          assertThat(find.singleResponse()).isTrue();
+                        });
+              });
+    }
+  }
+ }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/DeleteOneCommandResolverTest.java
@@ -1,28 +1,28 @@
- package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
+package io.stargate.sgv2.jsonapi.service.resolver.model.impl;
 
- import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
- import com.fasterxml.jackson.databind.ObjectMapper;
- import io.quarkus.test.junit.QuarkusTest;
- import io.quarkus.test.junit.TestProfile;
- import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
- import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
- import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteOneCommand;
- import io.stargate.sgv2.jsonapi.config.OperationsConfig;
- import io.stargate.sgv2.jsonapi.service.embedding.operation.TestEmbeddingService;
- import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
- import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
- import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
- import io.stargate.sgv2.jsonapi.service.operation.model.impl.DeleteOperation;
- import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
- import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
- import jakarta.inject.Inject;
- import org.junit.jupiter.api.Nested;
- import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
+import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteOneCommand;
+import io.stargate.sgv2.jsonapi.config.OperationsConfig;
+import io.stargate.sgv2.jsonapi.service.embedding.operation.TestEmbeddingService;
+import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
+import io.stargate.sgv2.jsonapi.service.operation.model.ReadType;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.DBFilterBase;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.DeleteOperation;
+import io.stargate.sgv2.jsonapi.service.operation.model.impl.FindOperation;
+import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
- @QuarkusTest
- @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
- public class DeleteOneCommandResolverTest {
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class DeleteOneCommandResolverTest {
   @Inject ObjectMapper objectMapper;
   @Inject OperationsConfig operationsConfig;
   @Inject DeleteOneCommandResolver resolver;
@@ -321,4 +321,4 @@
               });
     }
   }
- }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
@@ -63,7 +63,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -104,7 +104,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -144,7 +144,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -182,7 +182,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -225,7 +225,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -261,7 +261,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -296,7 +296,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultSortPageSize());
                 assertThat(find.limit()).isEqualTo(operationsConfig.defaultPageSize());
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit())
@@ -332,7 +332,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultSortPageSize());
                 assertThat(find.limit()).isEqualTo(operationsConfig.defaultPageSize());
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit())
@@ -367,7 +367,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(operationsConfig.maxVectorSearchLimit());
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -403,7 +403,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(operationsConfig.maxVectorSearchLimit());
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -440,7 +440,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(projector);
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(operationsConfig.maxVectorSearchLimit());
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -476,7 +476,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(projector);
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(operationsConfig.maxVectorSearchLimit());
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -514,7 +514,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(operationsConfig.maxVectorSearchLimit());
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -552,7 +552,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultSortPageSize());
                 assertThat(find.limit()).isEqualTo(10);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
                 assertThat(find.skip()).isEqualTo(5);
                 assertThat(find.maxSortReadLimit())
@@ -571,7 +571,7 @@ public class FindCommandResolverTest {
                 "find": {
                   "options" : {
                     "limit" : 7,
-                    "pagingState" : "dlavjhvbavkjbna"
+                    "pageState" : "dlavjhvbavkjbna"
                   }
                 }
               }
@@ -589,7 +589,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(7);
-                assertThat(find.pagingState()).isEqualTo("dlavjhvbavkjbna");
+                assertThat(find.pageState()).isEqualTo("dlavjhvbavkjbna");
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -626,7 +626,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -671,7 +671,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -735,7 +735,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -791,7 +791,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -855,7 +855,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -942,7 +942,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -999,7 +999,7 @@ public class FindCommandResolverTest {
                     .isEqualTo(DocumentProjector.createFromDefinition(projectionDef));
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -1046,7 +1046,7 @@ public class FindCommandResolverTest {
                     .isEqualTo(DocumentProjector.createFromDefinition(projectionDef));
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -1087,7 +1087,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -1131,7 +1131,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -1177,7 +1177,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -1222,7 +1222,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(operationsConfig.maxVectorSearchLimit());
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -1269,7 +1269,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                 assertThat(find.limit()).isEqualTo(operationsConfig.maxVectorSearchLimit());
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -1316,7 +1316,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultSortPageSize());
                 assertThat(find.limit()).isEqualTo(operationsConfig.defaultPageSize());
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit())
@@ -1366,7 +1366,7 @@ public class FindCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultSortPageSize());
                 assertThat(find.limit()).isEqualTo(operationsConfig.defaultPageSize());
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit())

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndDeleteCommandResolverTest.java
@@ -70,7 +70,7 @@ public class FindOneAndDeleteCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -117,7 +117,7 @@ public class FindOneAndDeleteCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(100);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -170,7 +170,7 @@ public class FindOneAndDeleteCommandResolverTest {
                               .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -219,7 +219,7 @@ public class FindOneAndDeleteCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -271,7 +271,7 @@ public class FindOneAndDeleteCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndReplaceCommandResolverTest.java
@@ -98,7 +98,7 @@ public class FindOneAndReplaceCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -166,7 +166,7 @@ public class FindOneAndReplaceCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -235,7 +235,7 @@ public class FindOneAndReplaceCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(100);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -307,7 +307,7 @@ public class FindOneAndReplaceCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -382,7 +382,7 @@ public class FindOneAndReplaceCommandResolverTest {
                               .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -453,7 +453,7 @@ public class FindOneAndReplaceCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -523,7 +523,7 @@ public class FindOneAndReplaceCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -595,7 +595,7 @@ public class FindOneAndReplaceCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.limit()).isEqualTo(1);
                           assertThat(find.pageSize()).isEqualTo(100);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -670,7 +670,7 @@ public class FindOneAndReplaceCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneAndUpdateCommandResolverTest.java
@@ -96,7 +96,7 @@ public class FindOneAndUpdateCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -161,7 +161,7 @@ public class FindOneAndUpdateCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(100);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -229,7 +229,7 @@ public class FindOneAndUpdateCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -301,7 +301,7 @@ public class FindOneAndUpdateCommandResolverTest {
                               .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -371,7 +371,7 @@ public class FindOneAndUpdateCommandResolverTest {
                               .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -438,7 +438,7 @@ public class FindOneAndUpdateCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -506,7 +506,7 @@ public class FindOneAndUpdateCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.limit()).isEqualTo(1);
                           assertThat(find.pageSize()).isEqualTo(100);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -576,7 +576,7 @@ public class FindOneAndUpdateCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindOneCommandResolverTest.java
@@ -58,7 +58,7 @@ public class FindOneCommandResolverTest {
                 assertThat(op.commandContext()).isEqualTo(commandContext);
                 assertThat(op.limit()).isEqualTo(1);
                 assertThat(op.pageSize()).isEqualTo(1);
-                assertThat(op.pagingState()).isNull();
+                assertThat(op.pageState()).isNull();
                 assertThat(op.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(
                         op.logicalExpression().comparisonExpressions.get(0).getDbFilters().get(0))
@@ -95,7 +95,7 @@ public class FindOneCommandResolverTest {
                 assertThat(op.commandContext()).isEqualTo(commandContext);
                 assertThat(op.limit()).isEqualTo(1);
                 assertThat(op.pageSize()).isEqualTo(100);
-                assertThat(op.pagingState()).isNull();
+                assertThat(op.pageState()).isNull();
                 assertThat(op.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
                 assertThat(
                         op.logicalExpression().comparisonExpressions.get(0).getDbFilters().get(0))
@@ -139,7 +139,7 @@ public class FindOneCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(1);
                 assertThat(find.limit()).isEqualTo(1);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -182,7 +182,7 @@ public class FindOneCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
                 assertThat(find.pageSize()).isEqualTo(1);
                 assertThat(find.limit()).isEqualTo(1);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -227,7 +227,7 @@ public class FindOneCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(projector);
                 assertThat(find.pageSize()).isEqualTo(1);
                 assertThat(find.limit()).isEqualTo(1);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -271,7 +271,7 @@ public class FindOneCommandResolverTest {
                 assertThat(find.projection()).isEqualTo(projector);
                 assertThat(find.pageSize()).isEqualTo(1);
                 assertThat(find.limit()).isEqualTo(1);
-                assertThat(find.pagingState()).isNull();
+                assertThat(find.pageState()).isNull();
                 assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(find.skip()).isZero();
                 assertThat(find.maxSortReadLimit()).isZero();
@@ -305,7 +305,7 @@ public class FindOneCommandResolverTest {
                 assertThat(op.commandContext()).isEqualTo(commandContext);
                 assertThat(op.limit()).isEqualTo(1);
                 assertThat(op.pageSize()).isEqualTo(1);
-                assertThat(op.pagingState()).isNull();
+                assertThat(op.pageState()).isNull();
                 assertThat(op.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(op.logicalExpression().comparisonExpressions).isEmpty();
                 assertThat(op.singleResponse()).isTrue();
@@ -334,7 +334,7 @@ public class FindOneCommandResolverTest {
                 assertThat(op.commandContext()).isEqualTo(commandContext);
                 assertThat(op.limit()).isEqualTo(1);
                 assertThat(op.pageSize()).isEqualTo(1);
-                assertThat(op.pagingState()).isNull();
+                assertThat(op.pageState()).isNull();
                 assertThat(op.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(op.logicalExpression().comparisonExpressions).isEmpty();
                 assertThat(op.singleResponse()).isTrue();
@@ -367,7 +367,7 @@ public class FindOneCommandResolverTest {
                 assertThat(op.commandContext()).isEqualTo(commandContext);
                 assertThat(op.limit()).isEqualTo(1);
                 assertThat(op.pageSize()).isEqualTo(1);
-                assertThat(op.pagingState()).isNull();
+                assertThat(op.pageState()).isNull();
                 assertThat(op.readType()).isEqualTo(ReadType.DOCUMENT);
                 assertThat(
                         op.logicalExpression().comparisonExpressions.get(0).getDbFilters().get(0))

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateManyCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateManyCommandResolverTest.java
@@ -91,7 +91,7 @@ public class UpdateManyCommandResolverTest {
                           assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                           assertThat(find.limit())
                               .isEqualTo(operationsConfig.maxDocumentUpdateCount() + 1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -150,7 +150,7 @@ public class UpdateManyCommandResolverTest {
                           assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                           assertThat(find.limit())
                               .isEqualTo(operationsConfig.maxDocumentUpdateCount() + 1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(find.logicalExpression().comparisonExpressions).isEmpty();
                         });
@@ -208,7 +208,7 @@ public class UpdateManyCommandResolverTest {
                           assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                           assertThat(find.limit())
                               .isEqualTo(operationsConfig.maxDocumentUpdateCount() + 1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -276,7 +276,7 @@ public class UpdateManyCommandResolverTest {
                               .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
                           assertThat(find.pageSize()).isEqualTo(20);
                           assertThat(find.limit()).isEqualTo(21);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -337,7 +337,7 @@ public class UpdateManyCommandResolverTest {
                           assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
                           assertThat(find.limit())
                               .isEqualTo(operationsConfig.maxDocumentUpdateCount() + 1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(find.logicalExpression().comparisonExpressions).isEmpty();
                         });

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateOneCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/UpdateOneCommandResolverTest.java
@@ -90,7 +90,7 @@ public class UpdateOneCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -149,7 +149,7 @@ public class UpdateOneCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(find.logicalExpression().comparisonExpressions).isEmpty();
                           assertThat(find.singleResponse()).isTrue();
@@ -207,7 +207,7 @@ public class UpdateOneCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -272,7 +272,7 @@ public class UpdateOneCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(100);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.SORTED_DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -342,7 +342,7 @@ public class UpdateOneCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -412,7 +412,7 @@ public class UpdateOneCommandResolverTest {
                               .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -483,7 +483,7 @@ public class UpdateOneCommandResolverTest {
                               .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(
                                   find.logicalExpression()
@@ -543,7 +543,7 @@ public class UpdateOneCommandResolverTest {
                           assertThat(find.commandContext()).isEqualTo(commandContext);
                           assertThat(find.pageSize()).isEqualTo(1);
                           assertThat(find.limit()).isEqualTo(1);
-                          assertThat(find.pagingState()).isNull();
+                          assertThat(find.pageState()).isNull();
                           assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
                           assertThat(find.logicalExpression().comparisonExpressions).isEmpty();
                           assertThat(find.singleResponse()).isTrue();


### PR DESCRIPTION
**What this PR does**:

Renames "pagingState" (and derived) as "pageState"

**Which issue(s) this PR fixes**:
Fixes #596

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
