### PR TITLE
Fix #446: expose StreamConstaintsException as ApiException

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/exception/WebApplicationExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/exception/WebApplicationExceptionMapper.java
@@ -13,7 +13,12 @@ public class WebApplicationExceptionMapper {
 
   @ServerExceptionMapper
   public RestResponse<CommandResult> webApplicationExceptionMapper(WebApplicationException e) {
-    Throwable toReport = null != e.getCause() ? e.getCause() : e;
+    // 06-Nov-2023, tatu: Let's dig the innermost root cause; needed f.ex for [jsonapi#448]
+    //    to get to StreamConstraintsException
+    Throwable toReport = e;
+    while (toReport.getCause() != null) {
+      toReport = toReport.getCause();
+    }
     CommandResult commandResult = new ThrowableCommandResultSupplier(toReport).get();
     // Return 405 for method not allowed and 404 for not found
     if (e instanceof NotAllowedException) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/exception/WebApplicationExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/exception/WebApplicationExceptionMapper.java
@@ -12,7 +12,7 @@ import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 public class WebApplicationExceptionMapper {
 
   @ServerExceptionMapper
-  public RestResponse<CommandResult> genericExceptionMapper(WebApplicationException e) {
+  public RestResponse<CommandResult> webApplicationExceptionMapper(WebApplicationException e) {
     Throwable toReport = null != e.getCause() ? e.getCause() : e;
     CommandResult commandResult = new ThrowableCommandResultSupplier(toReport).get();
     // Return 405 for method not allowed and 404 for not found

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountIntegrationTest.java
@@ -2,6 +2,7 @@ package io.stargate.sgv2.jsonapi.api.v1;
 
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
@@ -336,7 +337,10 @@ public class CountIntegrationTest extends AbstractCollectionIntegrationTestBase 
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("errors[1].message", is("$exists operator supports only true"));
+          .body("errors", hasSize(1))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"))
+          .body("errors[0].message", is("$exists operator supports only true"));
     }
 
     @Test
@@ -758,7 +762,10 @@ public class CountIntegrationTest extends AbstractCollectionIntegrationTestBase 
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("errors[1].message", startsWith("Unsupported filter operator $ne"));
+          .body("errors", hasSize(1))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"))
+          .body("errors[0].message", startsWith("Unsupported filter operator $ne"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountIntegrationTest.java
@@ -764,7 +764,7 @@ public class CountIntegrationTest extends AbstractCollectionIntegrationTestBase 
           .statusCode(200)
           .body("errors", hasSize(1))
           .body("errors[0].exceptionClass", is("JsonApiException"))
-          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"))
+          .body("errors[0].errorCode", is("UNSUPPORTED_FILTER_OPERATION"))
           .body("errors[0].message", startsWith("Unsupported filter operator $ne"));
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteOneIntegrationTest.java
@@ -148,12 +148,10 @@ public class DeleteOneIntegrationTest extends AbstractCollectionIntegrationTestB
           .body("data.document", is(nullValue()))
           .body("status", is(nullValue()))
           .body("errors", is(notNullValue()))
-          .body("errors", hasSize(2))
+          .body("errors", hasSize(1))
           .body("errors[0].message", is("Command accepts no options: DeleteOneCommand"))
-          .body("errors[0].exceptionClass", is("JsonMappingException"))
-          .body("errors[1].message", is("Command accepts no options: DeleteOneCommand"))
-          .body("errors[1].errorCode", is("COMMAND_ACCEPTS_NO_OPTIONS"))
-          .body("errors[1].exceptionClass", is("JsonApiException"));
+          .body("errors[0].errorCode", is("COMMAND_ACCEPTS_NO_OPTIONS"))
+          .body("errors[0].exceptionClass", is("JsonApiException"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -1247,7 +1247,7 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .body("errors", hasSize(1))
           .body("errors[0].message", startsWith("Unsupported filter operator $ne"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
-          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors[0].errorCode", is("UNSUPPORTED_FILTER_OPERATION"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -439,9 +439,10 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
           .body("errors", is(notNullValue()))
-          .body("errors[1].message", is("$in operator must have `ARRAY`"))
-          .body("errors[1].exceptionClass", is("JsonApiException"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors", hasSize(1))
+          .body("errors[0].message", is("$in operator must have `ARRAY`"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test
@@ -802,9 +803,10 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .statusCode(200)
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
-          .body("errors[1].message", is("$exists operator supports only true"))
-          .body("errors[1].exceptionClass", is("JsonApiException"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors", hasSize(1))
+          .body("errors[0].message", is("$exists operator supports only true"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test
@@ -1242,7 +1244,10 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .statusCode(200)
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
-          .body("errors[1].message", startsWith("Unsupported filter operator $ne"));
+          .body("errors", hasSize(1))
+          .body("errors[0].message", startsWith("Unsupported filter operator $ne"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -347,9 +348,10 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
           .then()
           .statusCode(200)
           .body("errors", is(notNullValue()))
-          .body("errors[1].message", is("$in operator must have `ARRAY`"))
-          .body("errors[1].exceptionClass", is("JsonApiException"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors", hasSize(1))
+          .body("errors[0].message", is("$in operator must have `ARRAY`"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test
@@ -545,9 +547,10 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
           .statusCode(200)
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
-          .body("errors[1].message", is("$exists operator supports only true"))
-          .body("errors[1].exceptionClass", is("JsonApiException"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors", hasSize(1))
+          .body("errors[0].message", is("$exists operator supports only true"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test
@@ -643,9 +646,10 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
           .statusCode(200)
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
-          .body("errors[1].message", is("$all operator must have `ARRAY` value"))
-          .body("errors[1].exceptionClass", is("JsonApiException"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors", hasSize(1))
+          .body("errors[0].message", is("$all operator must have `ARRAY` value"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
 
     @Test
@@ -718,9 +722,10 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
           .statusCode(200)
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
-          .body("errors[1].message", is("$size operator must have integer"))
-          .body("errors[1].exceptionClass", is("JsonApiException"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"));
+          .body("errors", hasSize(1))
+          .body("errors[0].message", is("$size operator must have integer"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -367,12 +367,10 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body("data.document", is(nullValue()))
           .body("status", is(nullValue()))
           .body("errors", is(notNullValue()))
-          .body("errors", hasSize(2))
+          .body("errors", hasSize(1))
           .body("errors[0].message", startsWith("Command accepts no options: InsertOneCommand"))
-          .body("errors[0].exceptionClass", is("JsonMappingException"))
-          .body("errors[1].message", startsWith("Command accepts no options: InsertOneCommand"))
-          .body("errors[1].errorCode", is("COMMAND_ACCEPTS_NO_OPTIONS"))
-          .body("errors[1].exceptionClass", is("JsonApiException"));
+          .body("errors[0].errorCode", is("COMMAND_ACCEPTS_NO_OPTIONS"))
+          .body("errors[0].exceptionClass", is("JsonApiException"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -530,6 +530,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .then()
           .statusCode(200)
           .body("errors", hasSize(1))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
           .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
           .body(
               "errors[0].message",
@@ -563,6 +564,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .then()
           .statusCode(200)
           .body("errors", hasSize(1))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
           .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
           .body(
               "errors[0].message",
@@ -596,10 +598,12 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors", hasSize(1))
-          .body(
-              "errors[0].message", startsWith("Number length (60) exceeds the maximum length (50)"))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
           .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
-          .body("errors[0].exceptionClass", is("StreamConstraintsException"));
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "Document size limitation violated: Number length (60) exceeds the maximum length (50)"));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -531,6 +531,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("errors", hasSize(1))
           .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
           .body(
               "errors[0].message",
@@ -563,6 +564,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("errors", hasSize(1))
           .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
           .body(
               "errors[0].message",
@@ -598,6 +600,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body("errors", hasSize(1))
           .body(
               "errors[0].message", startsWith("Number length (60) exceeds the maximum length (50)"))
+          .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
           .body("errors[0].exceptionClass", is("StreamConstraintsException"));
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -595,13 +595,10 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .then()
           .statusCode(200)
           .body("errors", is(notNullValue()))
-          .body("errors", hasSize(2))
+          .body("errors", hasSize(1))
           .body(
               "errors[0].message", startsWith("Number length (60) exceeds the maximum length (50)"))
-          .body("errors[0].exceptionClass", is("JsonMappingException"))
-          .body(
-              "errors[1].message", startsWith("Number length (60) exceeds the maximum length (50)"))
-          .body("errors[1].exceptionClass", is("StreamConstraintsException"));
+          .body("errors[0].exceptionClass", is("StreamConstraintsException"));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -655,9 +655,10 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .then()
           .statusCode(200)
           .body("errors", is(notNullValue()))
-          .body("errors[1].exceptionClass", is("JsonApiException"))
-          .body("errors[1].errorCode", is("SHRED_BAD_VECTOR_SIZE"))
-          .body("errors[1].message", is(ErrorCode.SHRED_BAD_VECTOR_SIZE.getMessage()));
+          .body("errors", hasSize(1))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("SHRED_BAD_VECTOR_SIZE"))
+          .body("errors[0].message", is(ErrorCode.SHRED_BAD_VECTOR_SIZE.getMessage()));
     }
 
     @Test
@@ -684,9 +685,10 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("errors[1].exceptionClass", is("JsonApiException"))
-          .body("errors[1].errorCode", is("SHRED_BAD_VECTOR_VALUE"))
-          .body("errors[1].message", is(ErrorCode.SHRED_BAD_VECTOR_VALUE.getMessage()));
+          .body("errors", hasSize(1))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("SHRED_BAD_VECTOR_VALUE"))
+          .body("errors[0].message", is(ErrorCode.SHRED_BAD_VECTOR_VALUE.getMessage()));
     }
 
     @Test
@@ -830,9 +832,10 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .then()
           .statusCode(200)
           .body("errors", is(notNullValue()))
-          .body("errors[1].exceptionClass", is("JsonApiException"))
-          .body("errors[1].errorCode", is("SHRED_BAD_VECTOR_SIZE"))
-          .body("errors[1].message", is(ErrorCode.SHRED_BAD_VECTOR_SIZE.getMessage()));
+          .body("errors", hasSize(1))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("SHRED_BAD_VECTOR_SIZE"))
+          .body("errors[0].message", is(ErrorCode.SHRED_BAD_VECTOR_SIZE.getMessage()));
     }
 
     @Test
@@ -857,9 +860,10 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .then()
           .statusCode(200)
           .body("errors", is(notNullValue()))
-          .body("errors[1].exceptionClass", is("JsonApiException"))
-          .body("errors[1].errorCode", is("SHRED_BAD_VECTOR_VALUE"))
-          .body("errors[1].message", is(ErrorCode.SHRED_BAD_VECTOR_VALUE.getMessage()));
+          .body("errors", hasSize(1))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("SHRED_BAD_VECTOR_VALUE"))
+          .body("errors[0].message", is(ErrorCode.SHRED_BAD_VECTOR_VALUE.getMessage()));
     }
 
     // Vector columns can only use ANN, not regular filtering
@@ -884,10 +888,11 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .then()
           .statusCode(200)
           .body("errors", is(notNullValue()))
-          .body("errors[1].exceptionClass", is("JsonApiException"))
-          .body("errors[1].errorCode", is("INVALID_FILTER_EXPRESSION"))
+          .body("errors", hasSize(1))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"))
           .body(
-              "errors[1].message",
+              "errors[0].message",
               is(
                   "Cannot filter on '$vector' field using operator '$eq': only '$exists' is supported"));
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
@@ -409,9 +409,10 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("errors[1].message", startsWith("$vectorize search needs to be text value"))
-          .body("errors[1].errorCode", is("SHRED_BAD_VECTORIZE_VALUE"))
-          .body("errors[1].exceptionClass", is("JsonApiException"));
+          .body("errors", hasSize(1))
+          .body("errors[0].message", startsWith("$vectorize search needs to be text value"))
+          .body("errors[0].errorCode", is("SHRED_BAD_VECTORIZE_VALUE"))
+          .body("errors[0].exceptionClass", is("JsonApiException"));
     }
   }
 
@@ -496,9 +497,10 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
           .then()
           .statusCode(200)
           .body("errors", is(notNullValue()))
-          .body("errors[1].exceptionClass", is("JsonApiException"))
-          .body("errors[1].errorCode", is("SHRED_BAD_VECTORIZE_VALUE"))
-          .body("errors[1].message", is(ErrorCode.SHRED_BAD_VECTORIZE_VALUE.getMessage()));
+          .body("errors", hasSize(1))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("SHRED_BAD_VECTORIZE_VALUE"))
+          .body("errors[0].message", is(ErrorCode.SHRED_BAD_VECTORIZE_VALUE.getMessage()));
     }
   }
 


### PR DESCRIPTION
**What this PR does**:

Improves exception handling for specific StreamConstraintsException-caused failures, to make them appear as regular `JsonApiException`.

Also fixes a few other existing cases where we expose `JsonMappingException` instead of `JsonApiException`, to reduce exposure of irrelevant/unnecessary internal details.

**Which issue(s) this PR fixes**:
Fixes #466

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
