### PR TITLE
Fix #622: add Integration tests verifying both biggest allowed, and bigger-than-allowed JSON docs, values

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -13,15 +13,26 @@ import jakarta.validation.constraints.Positive;
 @ConfigMapping(prefix = "stargate.jsonapi.document.limits")
 public interface DocumentLimitsConfig {
 
-  /** Defines the max size of filter fields, default is 64 fields. */
+  /** Defines the default max size of filter fields. */
   int DEFAULT_MAX_FILTER_SIZE = 64;
 
+  /** Defines the default maximum document size. */
+  int DEFAULT_MAX_DOCUMENT_SIZE = 1_000_000;
+
+  /** Defines the default maximum length (in elements) of a single Array value */
+  int DEFAULT_MAX_ARRAY_LENGTH = 100;
+
+  /** Defines the maximum length of property names in JSON documents */
+  int DEFAULT_MAX_PROPERTY_NAME_LENGTH = 48;
+
+  /** Defines the default maximum length of a single String value */
+  int DEFAULT_MAX_STRING_LENGTH = 16_000;
+
   /**
-   * @return Defines the maximum document page size, defaults to {@code 1 meg} (1 million
-   *     characters).
+   * @return Defines the maximum document size, defaults to {@code 1 meg} (1 million characters).
    */
   @Positive
-  @WithDefault("1000000")
+  @WithDefault("" + DEFAULT_MAX_DOCUMENT_SIZE)
   int maxSize();
 
   /** @return Defines the maximum document depth (nesting), defaults to {@code 8 levels} */
@@ -34,7 +45,7 @@ public interface DocumentLimitsConfig {
    *     characters} (note: length is for individual name segments; full dotted names can be longer)
    */
   @Positive
-  @WithDefault("48")
+  @WithDefault("" + DEFAULT_MAX_PROPERTY_NAME_LENGTH)
   int maxPropertyNameLength();
 
   /**
@@ -62,12 +73,12 @@ public interface DocumentLimitsConfig {
 
   /** @return Defines the maximum length of a single String value. */
   @Positive
-  @WithDefault("16000")
+  @WithDefault("" + DEFAULT_MAX_STRING_LENGTH)
   int maxStringLength();
 
   /** @return Maximum length of an array. */
   @Positive
-  @WithDefault("100")
+  @WithDefault("" + DEFAULT_MAX_ARRAY_LENGTH)
   int maxArrayLength();
 
   /**

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -22,6 +22,11 @@ public interface DocumentLimitsConfig {
   /** Defines the default maximum length (in elements) of a single Array value */
   int DEFAULT_MAX_ARRAY_LENGTH = 100;
 
+  /**
+   * Defines the default maximum number of properties any single Object in JSON document can contain
+   */
+  int DEFAULT_MAX_OBJECT_PROPERTIES = 64;
+
   /** Defines the default maximum length of a single Number value (in characters) */
   int DEFAULT_MAX_NUMBER_LENGTH = 50;
 
@@ -57,7 +62,7 @@ public interface DocumentLimitsConfig {
    *     whole document, only on individual main or sub-document)
    */
   @Positive
-  @WithDefault("64")
+  @WithDefault("" + DEFAULT_MAX_OBJECT_PROPERTIES)
   int maxObjectProperties();
 
   /**

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -22,6 +22,9 @@ public interface DocumentLimitsConfig {
   /** Defines the default maximum length (in elements) of a single Array value */
   int DEFAULT_MAX_ARRAY_LENGTH = 100;
 
+  /** Defines the default maximum length of a single Number value (in characters) */
+  int DEFAULT_MAX_NUMBER_LENGTH = 50;
+
   /** Defines the maximum length of property names in JSON documents */
   int DEFAULT_MAX_PROPERTY_NAME_LENGTH = 48;
 
@@ -68,7 +71,7 @@ public interface DocumentLimitsConfig {
 
   /** @return Defines the maximum length of a single Number value (in characters). */
   @Positive
-  @WithDefault("50")
+  @WithDefault("" + DEFAULT_MAX_NUMBER_LENGTH)
   int maxNumberLength();
 
   /** @return Defines the maximum length of a single String value. */

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -24,6 +24,7 @@ import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.config.constants.HttpConstants;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import java.math.BigInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Nested;
@@ -606,6 +607,15 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
               "errors[0].message",
               is(
                   "Document size limitation violated: Property name length (50) exceeds maximum allowed (48)"));
+    }
+
+    @Test
+    public void insertLongestValidNumber() {
+      final String LONGEST_NUM = "9".repeat(DocumentLimitsConfig.DEFAULT_MAX_NUMBER_LENGTH);
+      ObjectNode doc = MAPPER.createObjectNode();
+      doc.put(DocumentConstants.Fields.DOC_ID, "docWithLongNumber");
+      doc.put("num", new BigInteger(LONGEST_NUM));
+      _verifyInsert("docWithLongNumber", doc);
     }
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Adds Integration tests to verify allowed maximum docs wrt max doc size, max string value length etc.

**Which issue(s) this PR fixes**:
Fixes #622

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
