### PR TITLE
Fix native-cql branch: $in with multiple same values

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ExpressionBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ExpressionBuilder.java
@@ -138,7 +138,7 @@ public class ExpressionBuilder {
 
   public static List<Object> getExpressionValuesInOrder(Expression<BuiltCondition> expression) {
     List<Object> values = new ArrayList<>();
-    if(expression!=null) {
+    if (expression != null) {
       populateValuesRecursive(values, expression);
     }
     return values;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ExpressionBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ExpressionBuilder.java
@@ -118,4 +118,31 @@ public class ExpressionBuilder {
     return ExpressionUtils.buildExpression(
         conditionExpressions, logicalExpression.getLogicalRelation().getOperator());
   }
+
+  public static List<Object> getExpressionValuesInOrder(Expression<BuiltCondition> expression) {
+    List<Object> values = new ArrayList<>();
+    if(expression!=null) {
+      populateValuesRecursive(values, expression);
+    }
+    return values;
+  }
+
+  private static void populateValuesRecursive(
+      List<Object> values, Expression<BuiltCondition> outerExpression) {
+    if (outerExpression.getExprType().equals("variable")) {
+      Variable<BuiltCondition> var = (Variable<BuiltCondition>) outerExpression;
+      JsonTerm term = ((JsonTerm) var.getValue().value());
+      if (term.getKey() != null) {
+        values.add(term.getKey());
+      }
+      values.add(term.getValue());
+      return;
+    }
+    if (outerExpression.getExprType().equals("and") || outerExpression.getExprType().equals("or")) {
+      List<Expression<BuiltCondition>> innerExpressions = outerExpression.getChildren();
+      for (Expression<BuiltCondition> innerExpression : innerExpressions) {
+        populateValuesRecursive(values, innerExpression);
+      }
+    }
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ExpressionBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ExpressionBuilder.java
@@ -136,6 +136,10 @@ public class ExpressionBuilder {
         conditionExpressions, logicalExpression.getLogicalRelation().getOperator());
   }
 
+  /**
+   * Get all positional cql values from express recursively
+   * result order is in consistent of the expression structure
+   */
   public static List<Object> getExpressionValuesInOrder(Expression<BuiltCondition> expression) {
     List<Object> values = new ArrayList<>();
     if (expression != null) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ExpressionBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ExpressionBuilder.java
@@ -137,8 +137,8 @@ public class ExpressionBuilder {
   }
 
   /**
-   * Get all positional cql values from express recursively
-   * result order is in consistent of the expression structure
+   * Get all positional cql values from express recursively. Result order is in consistent of the
+   * expression structure
    */
   public static List<Object> getExpressionValuesInOrder(Expression<BuiltCondition> expression) {
     List<Object> values = new ArrayList<>();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperation.java
@@ -402,19 +402,7 @@ public record FindOperation(
     List<SimpleStatement> queries = new ArrayList<>(expressions.size());
     expressions.forEach(
         expression -> {
-          Set<BuiltCondition> conditions = new LinkedHashSet<>();
-          if (expression != null) expression.collectK(conditions, Integer.MAX_VALUE);
-          List<Object> collect =
-              conditions.stream()
-                  .flatMap(
-                      builtCondition -> {
-                        JsonTerm term = ((JsonTerm) builtCondition.value());
-                        List<Object> values = new ArrayList<>();
-                        if (term.getKey() != null) values.add(term.getKey());
-                        values.add(term.getValue());
-                        return values.stream();
-                      })
-                  .collect(Collectors.toList());
+          List<Object> collect = ExpressionBuilder.getExpressionValuesInOrder(expression);
           if (vector() == null) {
             final QueryOuterClass.Query query =
                 new QueryBuilder()
@@ -533,17 +521,7 @@ public record FindOperation(
         expression -> {
           Set<BuiltCondition> conditions = new LinkedHashSet<>();
           if (expression != null) expression.collectK(conditions, Integer.MAX_VALUE);
-          final List<Object> collect =
-              conditions.stream()
-                  .flatMap(
-                      builtCondition -> {
-                        JsonTerm term = ((JsonTerm) builtCondition.value());
-                        List<Object> values = new ArrayList<>();
-                        if (term.getKey() != null) values.add(term.getKey());
-                        values.add(term.getValue());
-                        return values.stream();
-                      })
-                  .collect(Collectors.toList());
+          List<Object> collect = ExpressionBuilder.getExpressionValuesInOrder(expression);
           final QueryOuterClass.Query query =
               new QueryBuilder()
                   .select()

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -663,6 +663,35 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
     }
 
     @Test
+    public void inConditionWithDuplicateValues() {
+      String json =
+          """
+                            {
+                              "find": {
+                                  "filter" : {
+                                       "username" : {"$in" : ["user1", "user1"]},
+                                       "_id" : {"$in" : ["doc1", "???"]}
+                                  }
+                                }
+                            }
+                          """;
+      String expected1 =
+          "{\"_id\":\"doc1\", \"username\":\"user1\", \"active_user\":true, \"date\" : {\"$date\": 1672531200000}}";
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.documents", hasSize(1))
+          .body("status", is(nullValue()))
+          .body("errors", is(nullValue()))
+          .body("data.documents[0]", jsonEquals(expected1));
+    }
+
+    @Test
     public void byIdWithProjection() {
       String json =
           """


### PR DESCRIPTION
Bug in native-cql branch : if have multiple same values in the $in value array, json api will error out.
This pr is for the fix.
**Which issue(s) this PR fixes**:
Fixes https://github.com/stargate/jsonapi/issues/623

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
