### PR TITLE
Fix #634: add tests to verify that empty JSON Object as projection includes whole doc

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorTest.java
@@ -266,6 +266,25 @@ public class DocumentProjectorTest {
 
   @Nested
   class ProjectorApplyInclusions {
+    // [json-api#634]: empty Object same as "include all"
+    @Test
+    public void testIncludeWithEmptyProject() throws Exception {
+      final JsonNode doc =
+          objectMapper.readTree(
+              """
+                              {
+                                 "_id" : 1,
+                                 "value1": 42
+                              }
+                              """);
+      DocumentProjector projection =
+          DocumentProjector.createFromDefinition(objectMapper.readTree("{ }"));
+      // Technically considered "Exclusion" but one that excludes nothing
+      assertThat(projection.isInclusion()).isFalse();
+      projection.applyProjection(doc);
+      assertThat(doc).isEqualTo(doc);
+    }
+
     @Test
     public void testSimpleIncludeWithId() throws Exception {
       final JsonNode doc =


### PR DESCRIPTION
**What this PR does**:

Adds tests to verify behavior of `{ }` as `"projection"`: it should include the whole document (as opposed to including nothing).

**Which issue(s) this PR fixes**:
Fixes #634

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
