### PR TITLE
Fix #639: add testing of CreateCollection with mixed-case name, fix quoting for FindCollections

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSettings.java
@@ -59,7 +59,8 @@ public record CollectionSettings(
 
   public static CollectionSettings getCollectionSettings(
       TableMetadata table, ObjectMapper objectMapper) {
-    String collectionName = table.getName().asCql(true);
+    // [jsonapi#639]: get internal name to avoid quoting of case-sensitive names
+    String collectionName = table.getName().asInternal();
     // get vector column
     final Optional<ColumnMetadata> vectorColumn =
         table.getColumn(DocumentConstants.Fields.VECTOR_SEARCH_INDEX_COLUMN_NAME);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSettings.java
@@ -85,7 +85,7 @@ public record CollectionSettings(
         if (functionName != null)
           function = CollectionSettings.SimilarityFunction.fromString(functionName);
       }
-      final String comment = (String) table.getOptions().get(CqlIdentifier.fromCql("comment"));
+      final String comment = (String) table.getOptions().get(CqlIdentifier.fromInternal("comment"));
       if (comment != null && !comment.isBlank()) {
         return createCollectionSettingsFromJson(
             collectionName, vectorEnabled, vectorSize, function, comment, objectMapper);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/QueryExecutor.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/QueryExecutor.java
@@ -110,7 +110,7 @@ public class QueryExecutor {
               .getSession()
               .getMetadata()
               .getKeyspaces()
-              .get(CqlIdentifier.fromCql("\"" + namespace + "\""));
+              .get(CqlIdentifier.fromInternal(namespace));
     } catch (Exception e) {
       return Uni.createFrom().failure(e);
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -71,7 +71,7 @@ public record CreateCollectionOperation(
             .getSession()
             .getMetadata()
             .getKeyspaces()
-            .get(CqlIdentifier.fromCql("\"" + commandContext.namespace() + "\""));
+            .get(CqlIdentifier.fromInternal(commandContext.namespace()));
     if (keyspaceMetadata == null) {
       return Uni.createFrom()
           .failure(
@@ -182,7 +182,7 @@ public record CreateCollectionOperation(
    */
   TableMetadata findTableAndValidateLimits(List<TableMetadata> tables, String name) {
     for (TableMetadata table : tables) {
-      if (table.getName().equals(CqlIdentifier.fromCql("\"" + name + "\""))) {
+      if (table.getName().equals(CqlIdentifier.fromInternal(name))) {
         return table;
       }
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindCollectionsOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindCollectionsOperation.java
@@ -56,7 +56,7 @@ public record FindCollectionsOperation(
             .getSession()
             .getMetadata()
             .getKeyspaces()
-            .get(CqlIdentifier.fromCql("\"" + commandContext.namespace() + "\""));
+            .get(CqlIdentifier.fromInternal(commandContext.namespace()));
     if (keyspaceMetadata == null) {
       return Uni.createFrom()
           .failure(

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractCollectionIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractCollectionIntegrationTestBase.java
@@ -26,21 +26,23 @@ public abstract class AbstractCollectionIntegrationTestBase
 
   @BeforeAll
   public final void createCollection() {
-    String json =
-        """
-        {
-          "createCollection": {
-            "name": "%s"
-          }
-        }
-        """
-            .formatted(collectionName);
+    createCollection(this.collectionName);
+  }
 
+  protected void createCollection(String collectionToCreate) {
     given()
         .port(getTestPort())
         .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
         .contentType(ContentType.JSON)
-        .body(json)
+        .body(
+            """
+              {
+                "createCollection": {
+                  "name": "%s"
+                }
+              }
+              """
+                .formatted(collectionToCreate))
         .when()
         .post(NamespaceResource.BASE_PATH, namespaceName)
         .then()

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionsIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindCollectionsIntegrationTest.java
@@ -37,20 +37,18 @@ class FindCollectionsIntegrationTest extends AbstractNamespaceIntegrationTestBas
     @Order(1)
     public void happyPath() {
       // create first
-      String json =
-          """
-          {
-            "createCollection": {
-              "name": "%s"
-            }
-          }
-          """
-              .formatted("collection1");
-
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
-          .body(json)
+          .body(
+              """
+                {
+                  "createCollection": {
+                    "name": "%s"
+                  }
+                }
+                """
+                  .formatted("collection1"))
           .when()
           .post(NamespaceResource.BASE_PATH, namespaceName)
           .then()
@@ -58,18 +56,15 @@ class FindCollectionsIntegrationTest extends AbstractNamespaceIntegrationTestBas
           .body("status.ok", is(1));
 
       // then find
-      json =
-          """
-          {
-            "findCollections": {
-            }
-          }
-          """;
-
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
-          .body(json)
+          .body(
+              """
+                  {
+                    "findCollections": { }
+                  }
+                  """)
           .when()
           .post(NamespaceResource.BASE_PATH, namespaceName)
           .then()
@@ -79,7 +74,7 @@ class FindCollectionsIntegrationTest extends AbstractNamespaceIntegrationTestBas
     }
 
     @Test
-    @Order(1)
+    @Order(2)
     public void happyPathWithExplain() {
       String json =
           """
@@ -155,6 +150,44 @@ class FindCollectionsIntegrationTest extends AbstractNamespaceIntegrationTestBas
 
     @Test
     @Order(3)
+    public void happyPathWithMixedCase() {
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                                {
+                                  "createCollection": {
+                                    "name": "TableName"
+                                  }
+                                }
+                                """)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+
+      // then find
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                                {
+                                  "findCollections": { }
+                                }
+                                """)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.collections", hasSize(greaterThanOrEqualTo(1)))
+          .body("status.collections", hasItem("TableName"));
+    }
+
+    @Test
+    @Order(4)
     public void emptyNamespace() {
       // create namespace first
       String namespace = "nam" + RandomStringUtils.randomNumeric(16);
@@ -220,7 +253,7 @@ class FindCollectionsIntegrationTest extends AbstractNamespaceIntegrationTestBas
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     /**
      * The keyspace that exists when database is created, and check if there is no collection in
      * this default keyspace.
@@ -247,7 +280,7 @@ class FindCollectionsIntegrationTest extends AbstractNamespaceIntegrationTestBas
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     public void notExistingNamespace() {
       // then find
       String json =

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -827,6 +827,66 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
 
   @Nested
   @Order(3)
+  class InsertInMixedCaseCollection {
+    private static final String COLLECTION_MIXED = "MyCollection";
+
+    // Both mixed-case Collection name and a field with mixed-case name
+    @Test
+    public void insertOneWithMixedCaseField() {
+      createCollection(COLLECTION_MIXED);
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                      {
+                        "insertOne": {
+                          "document": {
+                            "_id": "mixed1",
+                            "userName": "userA"
+                          }
+                        }
+                      }
+                      """)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, COLLECTION_MIXED)
+          .then()
+          .statusCode(200)
+          .body("status.insertedIds[0]", is("mixed1"))
+          .body("data", is(nullValue()))
+          .body("errors", is(nullValue()));
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                              {
+                                "find": {
+                                  "filter" : {"userName" : "userA"}
+                                }
+                              }
+                              """)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, COLLECTION_MIXED)
+          .then()
+          .statusCode(200)
+          .body("data.documents", hasSize(1))
+          .body(
+              "data.documents[0]",
+              jsonEquals(
+                  """
+                                      {
+                                        "_id": "mixed1",
+                                        "userName": "userA"
+                                      }
+                                      """))
+          .body("errors", is(nullValue()));
+    }
+  }
+
+  @Nested
+  @Order(4)
   class InsertMany {
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Adds tests for #639 to check that mixed-case Collection names are supported, and also fix one issue found: that of unwanted quoting of Collection name in mixed-case case.

**Which issue(s) this PR fixes**:
Fixes #639

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
