### PR TITLE
Moved JAVA_OPTS_APPEND out of Dockerfile

### DIFF
--- a/docker-compose/docker-compose-dev-mode.yml
+++ b/docker-compose/docker-compose-dev-mode.yml
@@ -40,6 +40,7 @@ services:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_PORT=8091
       - QUARKUS_HTTP_ACCESS_LOG_ENABLED=${REQUESTLOG}
       - QUARKUS_LOG_LEVEL=${LOGLEVEL}
+      - JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
     healthcheck:
       test: curl -f http://localhost:8181/stargate/health || exit 1
       interval: 5s

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       - QUARKUS_GRPC_CLIENTS_BRIDGE_PORT=8091
       - QUARKUS_HTTP_ACCESS_LOG_ENABLED=${REQUESTLOG}
       - QUARKUS_LOG_LEVEL=${LOGLEVEL}
+      - JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
     healthcheck:
       test: curl -f http://localhost:8181/stargate/health || exit 1
       interval: 5s

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -90,6 +90,5 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8181
 USER 185
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 


### PR DESCRIPTION
**What this PR does**:
Moved JAVA_OPTS_APPEND out of Dockerfile so we can pass jvm args as required from docker compose file, k8s yaml, etc.

**Which issue(s) this PR fixes**:
Related to #662 

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
