### PR TITLE
Convert "CountOperationTest" unit test to use native CQL driver

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
@@ -67,7 +67,7 @@ public class CountOperationTest extends AbstractValidatingStargateBridgeTest {
       SimpleStatement stmt = SimpleStatement.newInstance(collectionReadCql);
       QueryExecutor queryExecutorMock = mock(QueryExecutor.class);
       ColumnDefinitions columnDefs =
-          buildColumnDefs(Arrays.asList("count"), Arrays.asList(ProtocolConstants.DataType.INT));
+          buildColumnDefs(Arrays.asList("count"), Arrays.asList(ProtocolConstants.DataType.BIGINT));
       List<Row> rows = Arrays.asList(new MockRow(columnDefs, 0));
       AsyncResultSet mockResults = new MockAsyncResultSet(columnDefs, rows, null);
       when(queryExecutorMock.executeRead(eq(stmt), any(), anyInt()))
@@ -104,7 +104,7 @@ public class CountOperationTest extends AbstractValidatingStargateBridgeTest {
           .satisfies(
               commandResult -> {
                 assertThat(result.status().get(CommandStatus.COUNTED_DOCUMENT)).isNotNull();
-                assertThat(result.status().get(CommandStatus.COUNTED_DOCUMENT)).isEqualTo(5);
+                assertThat(result.status().get(CommandStatus.COUNTED_DOCUMENT)).isEqualTo(5L);
               });
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
@@ -8,16 +8,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
-import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
-import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
-import com.datastax.oss.driver.internal.core.cql.DefaultColumnDefinition;
-import com.datastax.oss.driver.internal.core.cql.DefaultColumnDefinitions;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
-import com.datastax.oss.protocol.internal.response.result.ColumnSpec;
-import com.datastax.oss.protocol.internal.response.result.RawType;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.smallrye.mutiny.Uni;
@@ -25,10 +19,8 @@ import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.bridge.grpc.TypeSpecs;
 import io.stargate.bridge.grpc.Values;
 import io.stargate.bridge.proto.QueryOuterClass;
-import io.stargate.sgv2.common.bridge.AbstractValidatingStargateBridgeTest;
 import io.stargate.sgv2.common.bridge.ValidatingStargateBridge;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
-import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandStatus;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.filter.ComparisonExpression;
@@ -39,21 +31,17 @@ import io.stargate.sgv2.jsonapi.service.shredding.model.DocValueHasher;
 import io.stargate.sgv2.jsonapi.service.testutil.MockAsyncResultSet;
 import io.stargate.sgv2.jsonapi.service.testutil.MockRow;
 import jakarta.inject.Inject;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 @TestProfile(NoGlobalResourcesTestProfile.Impl.class)
-public class CountOperationTest extends AbstractValidatingStargateBridgeTest {
-  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
-  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
-  private static final CommandContext CONTEXT = new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);
+public class CountOperationTest extends OperationTestBase {
 
   @Inject QueryExecutor queryExecutor;
 
@@ -68,25 +56,17 @@ public class CountOperationTest extends AbstractValidatingStargateBridgeTest {
       QueryExecutor queryExecutorMock = mock(QueryExecutor.class);
       ColumnDefinitions columnDefs =
           buildColumnDefs(Arrays.asList("count"), Arrays.asList(ProtocolConstants.DataType.BIGINT));
-      List<Row> rows = Arrays.asList(new MockRow(columnDefs, 0));
+      List<Row> rows = Arrays.asList(new MockRow(columnDefs, 0, Arrays.asList(byteBufferFrom(5L))));
       AsyncResultSet mockResults = new MockAsyncResultSet(columnDefs, rows, null);
+      final AtomicInteger callCount = new AtomicInteger();
       when(queryExecutorMock.executeRead(eq(stmt), any(), anyInt()))
-          .thenReturn(Uni.createFrom().item(mockResults));
-      /*
-      ValidatingStargateBridge.QueryAssert candidatesAssert =
-          withQuery(collectionReadCql)
-              .withPageSize(1)
-              .withColumnSpec(
-                  List.of(
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("count")
-                          .setType(TypeSpecs.INT)
-                          .build()))
-              .returning(List.of(List.of(Values.of(5))));
-       */
+          .then(
+              invocation -> {
+                callCount.incrementAndGet();
+                return Uni.createFrom().item(mockResults);
+              });
 
-      LogicalExpression implicitAnd = LogicalExpression.and();
-      CountOperation countOperation = new CountOperation(CONTEXT, implicitAnd);
+      CountOperation countOperation = new CountOperation(CONTEXT, LogicalExpression.and());
       Supplier<CommandResult> execute =
           countOperation
               .execute(queryExecutorMock)
@@ -96,7 +76,7 @@ public class CountOperationTest extends AbstractValidatingStargateBridgeTest {
               .getItem();
 
       // assert query execution
-      //      candidatesAssert.assertExecuteCount().isOne();
+      assertThat(callCount.get()).isEqualTo(1);
 
       // then result
       CommandResult result = execute.get();
@@ -106,27 +86,6 @@ public class CountOperationTest extends AbstractValidatingStargateBridgeTest {
                 assertThat(result.status().get(CommandStatus.COUNTED_DOCUMENT)).isNotNull();
                 assertThat(result.status().get(CommandStatus.COUNTED_DOCUMENT)).isEqualTo(5L);
               });
-    }
-
-    ColumnDefinitions buildColumnDefs(List<String> columnNames, List<Integer> typeCodes) {
-      return buildColumnDefs(KEYSPACE_NAME, COLLECTION_NAME, columnNames, typeCodes);
-    }
-
-    ColumnDefinitions buildColumnDefs(
-        String ks, String tableName, List<String> columnNames, List<Integer> typeCodes) {
-      List<ColumnDefinition> columnDefs = new ArrayList<>();
-      for (int ix = 0, end = columnNames.size(); ix < end; ++ix) {
-        columnDefs.add(
-            new DefaultColumnDefinition(
-                new ColumnSpec(
-                    ks,
-                    tableName,
-                    columnNames.get(ix),
-                    ix,
-                    RawType.PRIMITIVES.get(typeCodes.get(ix))),
-                AttachmentPoint.NONE));
-      }
-      return DefaultColumnDefinitions.valueOf(columnDefs);
     }
 
     @Disabled

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
@@ -39,7 +39,7 @@ public class CountOperationTest extends OperationTestBase {
   @Nested
   class Execute {
     private final ColumnDefinitions COUNT_RESULT_COLUMNS =
-        buildColumnDefs(Arrays.asList("count"), Arrays.asList(ProtocolConstants.DataType.BIGINT));
+        buildColumnDefs(Arrays.asList(TestColumn.of("count", ProtocolConstants.DataType.BIGINT)));
 
     @Test
     public void countWithNoFilter() {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
@@ -20,22 +20,22 @@ public class OperationTestBase {
   protected final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
   protected final CommandContext CONTEXT = new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);
 
-  protected ColumnDefinitions buildColumnDefs(List<String> columnNames, List<Integer> typeCodes) {
-    return buildColumnDefs(KEYSPACE_NAME, COLLECTION_NAME, columnNames, typeCodes);
+  protected ColumnDefinitions buildColumnDefs(List<TestColumn> columns) {
+    return buildColumnDefs(KEYSPACE_NAME, COLLECTION_NAME, columns);
   }
 
   protected ColumnDefinitions buildColumnDefs(
-      String ks, String tableName, List<String> columnNames, List<Integer> typeCodes) {
+      String ks, String tableName, List<TestColumn> columns) {
     List<ColumnDefinition> columnDefs = new ArrayList<>();
-    for (int ix = 0, end = columnNames.size(); ix < end; ++ix) {
+    for (int ix = 0, end = columns.size(); ix < end; ++ix) {
       columnDefs.add(
           new DefaultColumnDefinition(
               new ColumnSpec(
                   ks,
                   tableName,
-                  columnNames.get(ix),
+                  columns.get(ix).name(),
                   ix,
-                  RawType.PRIMITIVES.get(typeCodes.get(ix))),
+                  RawType.PRIMITIVES.get(columns.get(ix).type())),
               AttachmentPoint.NONE));
     }
     return DefaultColumnDefinitions.valueOf(columnDefs);
@@ -43,5 +43,11 @@ public class OperationTestBase {
 
   protected ByteBuffer byteBufferFrom(long value) {
     return TypeCodecs.BIGINT.encode(value, ProtocolVersion.DEFAULT);
+  }
+
+  protected static record TestColumn(String name, int type) {
+    static TestColumn of(String name, int type) {
+      return new TestColumn(name, type);
+    }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
@@ -43,6 +43,6 @@ public class OperationTestBase extends AbstractValidatingStargateBridgeTest {
   }
 
   protected ByteBuffer byteBufferFrom(long value) {
-    return TypeCodecs.BIGINT.encode(5L, ProtocolVersion.DEFAULT);
+    return TypeCodecs.BIGINT.encode(value, ProtocolVersion.DEFAULT);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
@@ -9,14 +9,13 @@ import com.datastax.oss.driver.internal.core.cql.DefaultColumnDefinition;
 import com.datastax.oss.driver.internal.core.cql.DefaultColumnDefinitions;
 import com.datastax.oss.protocol.internal.response.result.ColumnSpec;
 import com.datastax.oss.protocol.internal.response.result.RawType;
-import io.stargate.sgv2.common.bridge.AbstractValidatingStargateBridgeTest;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 
-public class OperationTestBase extends AbstractValidatingStargateBridgeTest {
+public class OperationTestBase {
   protected final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
   protected final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
   protected final CommandContext CONTEXT = new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
@@ -45,7 +45,7 @@ public class OperationTestBase {
     return TypeCodecs.BIGINT.encode(value, ProtocolVersion.DEFAULT);
   }
 
-  protected static record TestColumn(String name, int type) {
+  protected record TestColumn(String name, int type) {
     static TestColumn of(String name, int type) {
       return new TestColumn(name, type);
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
@@ -1,0 +1,48 @@
+package io.stargate.sgv2.jsonapi.service.operation.model.impl;
+
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.datastax.oss.driver.internal.core.cql.DefaultColumnDefinition;
+import com.datastax.oss.driver.internal.core.cql.DefaultColumnDefinitions;
+import com.datastax.oss.protocol.internal.response.result.ColumnSpec;
+import com.datastax.oss.protocol.internal.response.result.RawType;
+import io.stargate.sgv2.common.bridge.AbstractValidatingStargateBridgeTest;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class OperationTestBase extends AbstractValidatingStargateBridgeTest {
+  protected final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+  protected final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+  protected final CommandContext CONTEXT = new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);
+
+  protected ColumnDefinitions buildColumnDefs(List<String> columnNames, List<Integer> typeCodes) {
+    return buildColumnDefs(KEYSPACE_NAME, COLLECTION_NAME, columnNames, typeCodes);
+  }
+
+  protected ColumnDefinitions buildColumnDefs(
+      String ks, String tableName, List<String> columnNames, List<Integer> typeCodes) {
+    List<ColumnDefinition> columnDefs = new ArrayList<>();
+    for (int ix = 0, end = columnNames.size(); ix < end; ++ix) {
+      columnDefs.add(
+          new DefaultColumnDefinition(
+              new ColumnSpec(
+                  ks,
+                  tableName,
+                  columnNames.get(ix),
+                  ix,
+                  RawType.PRIMITIVES.get(typeCodes.get(ix))),
+              AttachmentPoint.NONE));
+    }
+    return DefaultColumnDefinitions.valueOf(columnDefs);
+  }
+
+  protected ByteBuffer byteBufferFrom(long value) {
+    return TypeCodecs.BIGINT.encode(5L, ProtocolVersion.DEFAULT);
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockAsyncResultSet.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockAsyncResultSet.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.jsonapi.service.testutil;
+
+import static org.mockito.Mockito.mock;
+
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.api.core.cql.Row;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.assertj.core.util.Lists;
+
+public class MockAsyncResultSet implements AsyncResultSet {
+
+  private final List<Row> rows;
+  private final Iterator<Row> iterator;
+  private final CompletionStage<AsyncResultSet> nextPage;
+  private final ExecutionInfo executionInfo = mock(ExecutionInfo.class);
+  private final ColumnDefinitions columnDefinitions = mock(ColumnDefinitions.class);
+  private int remaining;
+
+  public MockAsyncResultSet(int size, CompletionStage<AsyncResultSet> nextPage) {
+    this(IntStream.range(0, size).boxed().map(MockRow::new).collect(Collectors.toList()), nextPage);
+  }
+
+  public MockAsyncResultSet(List<Row> rows, CompletionStage<AsyncResultSet> nextPage) {
+    this.rows = rows;
+    iterator = rows.iterator();
+    remaining = rows.size();
+    this.nextPage = nextPage;
+  }
+
+  @Override
+  public Row one() {
+    Row next = iterator.next();
+    remaining--;
+    return next;
+  }
+
+  @Override
+  public int remaining() {
+    return remaining;
+  }
+
+  @NonNull
+  @Override
+  public List<Row> currentPage() {
+    return Lists.newArrayList(rows);
+  }
+
+  @Override
+  public boolean hasMorePages() {
+    return nextPage != null;
+  }
+
+  @NonNull
+  @Override
+  public CompletionStage<AsyncResultSet> fetchNextPage() throws IllegalStateException {
+    return nextPage;
+  }
+
+  @NonNull
+  @Override
+  public ColumnDefinitions getColumnDefinitions() {
+    return columnDefinitions;
+  }
+
+  @NonNull
+  @Override
+  public ExecutionInfo getExecutionInfo() {
+    return executionInfo;
+  }
+
+  @Override
+  public boolean wasApplied() {
+    return true;
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockAsyncResultSet.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockAsyncResultSet.java
@@ -23,13 +23,12 @@ import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.Row;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.assertj.core.util.Lists;
 
 public class MockAsyncResultSet implements AsyncResultSet {
 
@@ -63,10 +62,9 @@ public class MockAsyncResultSet implements AsyncResultSet {
     return remaining;
   }
 
-  @NonNull
   @Override
   public List<Row> currentPage() {
-    return Lists.newArrayList(rows);
+    return new ArrayList<>(rows);
   }
 
   @Override
@@ -74,19 +72,16 @@ public class MockAsyncResultSet implements AsyncResultSet {
     return nextPage != null;
   }
 
-  @NonNull
   @Override
   public CompletionStage<AsyncResultSet> fetchNextPage() throws IllegalStateException {
     return nextPage;
   }
 
-  @NonNull
   @Override
   public ColumnDefinitions getColumnDefinitions() {
     return columnDefinitions;
   }
 
-  @NonNull
   @Override
   public ExecutionInfo getExecutionInfo() {
     return executionInfo;

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockAsyncResultSet.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockAsyncResultSet.java
@@ -27,8 +27,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class MockAsyncResultSet implements AsyncResultSet {
 
@@ -38,17 +36,6 @@ public class MockAsyncResultSet implements AsyncResultSet {
   private final ExecutionInfo executionInfo = mock(ExecutionInfo.class);
   private final ColumnDefinitions columnDefs;
   private int remaining;
-
-  public MockAsyncResultSet(
-      ColumnDefinitions columnDefs, int size, CompletionStage<AsyncResultSet> nextPage) {
-    this(
-        columnDefs,
-        IntStream.range(0, size)
-            .boxed()
-            .map(id -> new MockRow(columnDefs, id))
-            .collect(Collectors.toList()),
-        nextPage);
-  }
 
   public MockAsyncResultSet(
       ColumnDefinitions columnDefs, List<Row> rows, CompletionStage<AsyncResultSet> nextPage) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockAsyncResultSet.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockAsyncResultSet.java
@@ -36,14 +36,23 @@ public class MockAsyncResultSet implements AsyncResultSet {
   private final Iterator<Row> iterator;
   private final CompletionStage<AsyncResultSet> nextPage;
   private final ExecutionInfo executionInfo = mock(ExecutionInfo.class);
-  private final ColumnDefinitions columnDefinitions = mock(ColumnDefinitions.class);
+  private final ColumnDefinitions columnDefs;
   private int remaining;
 
-  public MockAsyncResultSet(int size, CompletionStage<AsyncResultSet> nextPage) {
-    this(IntStream.range(0, size).boxed().map(MockRow::new).collect(Collectors.toList()), nextPage);
+  public MockAsyncResultSet(
+      ColumnDefinitions columnDefs, int size, CompletionStage<AsyncResultSet> nextPage) {
+    this(
+        columnDefs,
+        IntStream.range(0, size)
+            .boxed()
+            .map(id -> new MockRow(columnDefs, id))
+            .collect(Collectors.toList()),
+        nextPage);
   }
 
-  public MockAsyncResultSet(List<Row> rows, CompletionStage<AsyncResultSet> nextPage) {
+  public MockAsyncResultSet(
+      ColumnDefinitions columnDefs, List<Row> rows, CompletionStage<AsyncResultSet> nextPage) {
+    this.columnDefs = columnDefs;
     this.rows = rows;
     iterator = rows.iterator();
     remaining = rows.size();
@@ -79,7 +88,7 @@ public class MockAsyncResultSet implements AsyncResultSet {
 
   @Override
   public ColumnDefinitions getColumnDefinitions() {
-    return columnDefinitions;
+    return columnDefs;
   }
 
   @Override

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockRow.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockRow.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.jsonapi.service.testutil;
+
+import static org.mockito.Mockito.mock;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
+import com.datastax.oss.driver.internal.core.cql.EmptyColumnDefinitions;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+
+public class MockRow implements Row {
+
+  private int index;
+
+  MockRow(int index) {
+    this.index = index;
+  }
+
+  @Override
+  public int size() {
+    return 0;
+  }
+
+  @Override
+  public CodecRegistry codecRegistry() {
+    return mock(CodecRegistry.class);
+  }
+
+  @Override
+  public ProtocolVersion protocolVersion() {
+    return DefaultProtocolVersion.V4;
+  }
+
+  @Override
+  public ColumnDefinitions getColumnDefinitions() {
+    return EmptyColumnDefinitions.INSTANCE;
+  }
+
+  @Override
+  public List<Integer> allIndicesOf(String name) {
+    return Collections.singletonList(0);
+  }
+
+  @Override
+  public int firstIndexOf(String name) {
+    return 0;
+  }
+
+  @Override
+  public List<Integer> allIndicesOf(CqlIdentifier id) {
+    return Collections.singletonList(0);
+  }
+
+  @Override
+  public int firstIndexOf(CqlIdentifier id) {
+    return 0;
+  }
+
+  @Override
+  public DataType getType(int i) {
+    return DataTypes.INT;
+  }
+
+  @Override
+  public DataType getType(String name) {
+    return DataTypes.INT;
+  }
+
+  @Override
+  public DataType getType(CqlIdentifier id) {
+    return DataTypes.INT;
+  }
+
+  @Override
+  public ByteBuffer getBytesUnsafe(int i) {
+    return null;
+  }
+
+  @Override
+  public boolean isDetached() {
+    return false;
+  }
+
+  @Override
+  public void attach(AttachmentPoint attachmentPoint) {}
+
+  // equals and hashCode required for TCK tests that check that two subscribers
+  // receive the exact same set of items.
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MockRow)) {
+      return false;
+    }
+    MockRow mockRow = (MockRow) o;
+    return index == mockRow.index;
+  }
+
+  @Override
+  public int hashCode() {
+    return index;
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockRow.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockRow.java
@@ -99,7 +99,9 @@ public class MockRow implements Row {
     if (true) {
       //      throw new IllegalStateException("No column #" + i);
     }
-    return ByteBuffer.wrap(new byte[16]);
+    byte[] b = new byte[8];
+    b[7] = 5;
+    return ByteBuffer.wrap(b);
   }
 
   @Override

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockRow.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockRow.java
@@ -33,10 +33,12 @@ public class MockRow implements Row {
   private final CodecRegistry DEFAULT_CODECS = new DefaultCodecRegistry("json-api-test");
   private final ColumnDefinitions columnDefs;
   private final int index;
+  private final List<ByteBuffer> values;
 
-  public MockRow(ColumnDefinitions columnDefs, int index) {
+  public MockRow(ColumnDefinitions columnDefs, int index, List<ByteBuffer> values) {
     this.columnDefs = columnDefs;
     this.index = index;
+    this.values = values;
   }
 
   @Override
@@ -96,17 +98,12 @@ public class MockRow implements Row {
 
   @Override
   public ByteBuffer getBytesUnsafe(int i) {
-    if (true) {
-      //      throw new IllegalStateException("No column #" + i);
-    }
-    byte[] b = new byte[8];
-    b[7] = 5;
-    return ByteBuffer.wrap(b);
+    return values.get(i);
   }
 
   @Override
   public boolean isDetached() {
-    return false;
+    return true;
   }
 
   @Override

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockRow.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockRow.java
@@ -17,8 +17,6 @@
  */
 package io.stargate.sgv2.jsonapi.service.testutil;
 
-import static org.mockito.Mockito.mock;
-
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
@@ -26,84 +24,85 @@ import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import com.datastax.oss.driver.api.core.type.DataType;
-import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
-import com.datastax.oss.driver.internal.core.cql.EmptyColumnDefinitions;
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.List;
 
 public class MockRow implements Row {
+  private final ColumnDefinitions columnDefs;
+  private final int index;
 
-  private int index;
-
-  MockRow(int index) {
+  public MockRow(ColumnDefinitions columnDefs, int index) {
+    this.columnDefs = columnDefs;
     this.index = index;
   }
 
   @Override
   public int size() {
-    return 0;
+    return columnDefs.size();
   }
 
   @Override
   public CodecRegistry codecRegistry() {
-    return mock(CodecRegistry.class);
+    return CodecRegistry.DEFAULT;
   }
 
   @Override
   public ProtocolVersion protocolVersion() {
-    return DefaultProtocolVersion.V4;
+    return DefaultProtocolVersion.V5;
   }
 
   @Override
   public ColumnDefinitions getColumnDefinitions() {
-    return EmptyColumnDefinitions.INSTANCE;
+    return columnDefs;
   }
 
   @Override
   public List<Integer> allIndicesOf(String name) {
-    return Collections.singletonList(0);
+    return columnDefs.allIndicesOf(name);
   }
 
   @Override
   public int firstIndexOf(String name) {
-    return 0;
+    return columnDefs.firstIndexOf(name);
   }
 
   @Override
   public List<Integer> allIndicesOf(CqlIdentifier id) {
-    return Collections.singletonList(0);
+    return columnDefs.allIndicesOf(id);
   }
 
   @Override
   public int firstIndexOf(CqlIdentifier id) {
-    return 0;
+    return columnDefs.firstIndexOf(id);
   }
 
   @Override
   public DataType getType(int i) {
-    return DataTypes.INT;
+    return columnDefs.get(i).getType();
   }
 
   @Override
   public DataType getType(String name) {
-    return DataTypes.INT;
+    return columnDefs.get(name).getType();
   }
 
   @Override
   public DataType getType(CqlIdentifier id) {
-    return DataTypes.INT;
+    return columnDefs.get(id).getType();
   }
 
   @Override
   public ByteBuffer getBytesUnsafe(int i) {
+    if (true) {
+      throw new IllegalStateException("No column #" + i);
+    }
     return null;
   }
 
   @Override
   public boolean isDetached() {
-    return false;
+    return true;
   }
 
   @Override

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockRow.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/testutil/MockRow.java
@@ -25,10 +25,12 @@ import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
+import com.datastax.oss.driver.internal.core.type.codec.registry.DefaultCodecRegistry;
 import java.nio.ByteBuffer;
 import java.util.List;
 
 public class MockRow implements Row {
+  private final CodecRegistry DEFAULT_CODECS = new DefaultCodecRegistry("json-api-test");
   private final ColumnDefinitions columnDefs;
   private final int index;
 
@@ -44,7 +46,7 @@ public class MockRow implements Row {
 
   @Override
   public CodecRegistry codecRegistry() {
-    return CodecRegistry.DEFAULT;
+    return DEFAULT_CODECS;
   }
 
   @Override
@@ -95,14 +97,14 @@ public class MockRow implements Row {
   @Override
   public ByteBuffer getBytesUnsafe(int i) {
     if (true) {
-      throw new IllegalStateException("No column #" + i);
+      //      throw new IllegalStateException("No column #" + i);
     }
-    return null;
+    return ByteBuffer.wrap(new byte[16]);
   }
 
   @Override
   public boolean isDetached() {
-    return true;
+    return false;
   }
 
   @Override


### PR DESCRIPTION
**What this PR does**:

Fixes one currently disabled unit test ("CountOperationTest")

**Which issue(s) this PR fixes**:
N/A (filed on wrong issue repository)

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
