### PR TITLE
Convert "FindOperationTest" to not use ValidatingBridge 

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocValueHasher.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocValueHasher.java
@@ -198,6 +198,8 @@ public class DocValueHasher {
       return numberValue((BigDecimal) value).hash();
     } else if (value instanceof Boolean) {
       return booleanValue((Boolean) value).hash();
+    } else if (value instanceof Date) {
+      return timestampValue((Date) value).hash();
     } else if (value instanceof Instant) {
       return timestampValue(new Date(((Instant) value).toEpochMilli())).hash();
     } else if (value instanceof List) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocValueHasher.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/model/DocValueHasher.java
@@ -198,8 +198,6 @@ public class DocValueHasher {
       return numberValue((BigDecimal) value).hash();
     } else if (value instanceof Boolean) {
       return booleanValue((Boolean) value).hash();
-    } else if (value instanceof Date) {
-      return timestampValue((Date) value).hash();
     } else if (value instanceof Instant) {
       return timestampValue(new Date(((Instant) value).toEpochMilli())).hash();
     } else if (value instanceof List) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CountOperationTest.java
@@ -38,7 +38,7 @@ public class CountOperationTest extends OperationTestBase {
   @Nested
   class Execute {
     private final ColumnDefinitions COUNT_RESULT_COLUMNS =
-        buildColumnDefs(Arrays.asList(TestColumn.ofLong("count")));
+        buildColumnDefs(TestColumn.ofLong("count"));
 
     @Test
     public void countWithNoFilter() {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -160,9 +160,11 @@ public class FindOperationTest extends OperationTestBase {
               }
               """;
 
-      SimpleStatement stmt1 = SimpleStatement.newInstance(collectionReadCql, "doc1");
+      SimpleStatement stmt1 =
+          SimpleStatement.newInstance(collectionReadCql, boundKeyForStatement("doc1"));
       List<Row> rows1 = Arrays.asList(resultRow(0, "doc1", UUID.randomUUID(), doc1));
-      SimpleStatement stmt2 = SimpleStatement.newInstance(collectionReadCql, "doc2");
+      SimpleStatement stmt2 =
+          SimpleStatement.newInstance(collectionReadCql, boundKeyForStatement("doc2"));
       List<Row> rows2 = Arrays.asList(resultRow(0, "doc2", UUID.randomUUID(), doc2));
       AsyncResultSet results1 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows1, null);
       AsyncResultSet results2 = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows2, null);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -1722,7 +1722,6 @@ public class FindOperationTest extends OperationTestBase {
       assertThat(result.errors()).isNullOrEmpty();
     }
 
-    @Disabled
     @Test
     public void findAllSortDescending() throws Exception {
       String collectionReadCql =
@@ -1771,115 +1770,96 @@ public class FindOperationTest extends OperationTestBase {
                   "username": "user6"
                 }
                 """;
-      ValidatingStargateBridge.QueryAssert candidatesAssert =
-          withQuery(collectionReadCql)
-              .withPageSize(20)
-              .withColumnSpec(
-                  List.of(
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("tx_id")
-                          .setType(TypeSpecs.UUID)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("doc_json")
-                          .setType(TypeSpecs.VARCHAR)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("doc_json")
-                          .setType(TypeSpecs.VARCHAR)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_text_values['username']")
-                          .setType(TypeSpecs.VARCHAR)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_dbl_values['username']")
-                          .setType(TypeSpecs.DECIMAL)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_bool_values['username']")
-                          .setType(TypeSpecs.BOOLEAN)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_null_values['username']")
-                          .setType(TypeSpecs.VARCHAR)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_timestamp_values['username']")
-                          .setType(TypeSpecs.DATE)
-                          .build()))
-              .returning(
-                  List.of(
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc6"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc6),
-                          Values.of("user6"),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc4"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc4),
-                          Values.of("user4"),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc2"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc2),
-                          Values.of("user2"),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc1"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc1),
-                          Values.of("user1"),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc3"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc3),
-                          Values.of("user3"),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc5"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc5),
-                          Values.of("user5"),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL)));
+
+      SimpleStatement stmt = SimpleStatement.newInstance(collectionReadCql);
+      ColumnDefinitions columnDefs =
+          buildColumnDefs(
+              TestColumn.keyColumn(),
+              TestColumn.ofUuid("tx_id"),
+              TestColumn.ofVarchar("doc_json"),
+              TestColumn.ofVarchar("query_text_values['username']"),
+              TestColumn.ofDecimal("query_dbl_values['username']"),
+              TestColumn.ofBoolean("query_bool_values['username']"),
+              TestColumn.ofVarchar("query_null_values['username']"),
+              TestColumn.ofDate("query_timestamp_values['username']"));
+      List<Row> rows =
+          Arrays.asList(
+              resultRow(
+                  columnDefs,
+                  0,
+                  byteBufferForKey("doc6"),
+                  UUID.randomUUID(),
+                  doc6,
+                  "user6",
+                  null,
+                  null,
+                  null,
+                  null),
+              resultRow(
+                  columnDefs,
+                  1,
+                  byteBufferForKey("doc4"),
+                  UUID.randomUUID(),
+                  doc4,
+                  "user4",
+                  null,
+                  null,
+                  null,
+                  null),
+              resultRow(
+                  columnDefs,
+                  2,
+                  byteBufferForKey("doc2"),
+                  UUID.randomUUID(),
+                  doc2,
+                  "user2",
+                  null,
+                  null,
+                  null,
+                  null),
+              resultRow(
+                  columnDefs,
+                  3,
+                  byteBufferForKey("doc1"),
+                  UUID.randomUUID(),
+                  doc1,
+                  "user1",
+                  null,
+                  null,
+                  null,
+                  null),
+              resultRow(
+                  columnDefs,
+                  4,
+                  byteBufferForKey("doc3"),
+                  UUID.randomUUID(),
+                  doc3,
+                  "user3",
+                  null,
+                  null,
+                  null,
+                  null),
+              resultRow(
+                  columnDefs,
+                  5,
+                  byteBufferForKey("doc5"),
+                  UUID.randomUUID(),
+                  doc5,
+                  "user5",
+                  null,
+                  null,
+                  null,
+                  null));
+
+      AsyncResultSet results = new MockAsyncResultSet(columnDefs, rows, null);
+      final AtomicInteger callCount = new AtomicInteger();
+      QueryExecutor queryExecutor = mock(QueryExecutor.class);
+      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+          .then(
+              invocation -> {
+                callCount.incrementAndGet();
+                return Uni.createFrom().item(results);
+              });
 
       LogicalExpression implicitAnd = LogicalExpression.and();
       FindOperation operation =
@@ -1898,14 +1878,14 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor0)
+              .execute(queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
               .getItem();
 
       // assert query execution
-      candidatesAssert.assertExecuteCount().isOne();
+      assertThat(callCount.get()).isEqualTo(1);
 
       // then result
       CommandResult result = execute.get();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -57,10 +57,7 @@ public class FindOperationTest extends OperationTestBase {
 
   private final ColumnDefinitions KEY_TXID_JSON_COLUMNS =
       buildColumnDefs(
-          Arrays.asList(
-              TestColumn.keyColumn(),
-              TestColumn.ofUuid("tx_id"),
-              TestColumn.ofVarchar("doc_json")));
+          TestColumn.keyColumn(), TestColumn.ofUuid("tx_id"), TestColumn.ofVarchar("doc_json"));
 
   @Inject ObjectMapper objectMapper;
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -34,6 +34,7 @@ import io.stargate.sgv2.jsonapi.service.testutil.MockAsyncResultSet;
 import io.stargate.sgv2.jsonapi.service.testutil.MockRow;
 import jakarta.inject.Inject;
 import java.nio.ByteBuffer;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -690,7 +691,7 @@ public class FindOperationTest extends OperationTestBase {
                       }
                       """;
       final String dateFilterValue =
-          "date_field " + new DocValueHasher().getHash(new Date(1672531200000L)).hash();
+          "date_field " + new DocValueHasher().getHash(Instant.ofEpochMilli(1672531200000L)).hash();
       SimpleStatement stmt = SimpleStatement.newInstance(collectionReadCql, dateFilterValue);
       List<Row> rows = Arrays.asList(resultRow(0, "doc1", UUID.randomUUID(), doc1));
       AsyncResultSet results = new MockAsyncResultSet(KEY_TXID_JSON_COLUMNS, rows, null);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -874,7 +874,6 @@ public class FindOperationTest extends OperationTestBase {
       assertThat(result.errors()).isNullOrEmpty();
     }
 
-    @Disabled // Somehow fails with binding error?!
     @Test
     public void findWithSizeFilter() throws Exception {
       String collectionReadCql =

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -1548,7 +1548,6 @@ public class FindOperationTest extends OperationTestBase {
       assertThat(result.errors()).isNullOrEmpty();
     }
 
-    @Disabled
     @Test
     public void findAllSortWithSkip() throws Exception {
       String collectionReadCql =
@@ -1597,111 +1596,96 @@ public class FindOperationTest extends OperationTestBase {
                   "username": "user6"
                 }
                 """;
-      ValidatingStargateBridge.QueryAssert candidatesAssert =
-          withQuery(collectionReadCql)
-              .withPageSize(20)
-              .withColumnSpec(
-                  List.of(
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("tx_id")
-                          .setType(TypeSpecs.UUID)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("doc_json")
-                          .setType(TypeSpecs.VARCHAR)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_text_values['username']")
-                          .setType(TypeSpecs.VARCHAR)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_dbl_values['username']")
-                          .setType(TypeSpecs.DECIMAL)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_bool_values['username']")
-                          .setType(TypeSpecs.BOOLEAN)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_null_values['username']")
-                          .setType(TypeSpecs.VARCHAR)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_timestamp_values['username']")
-                          .setType(TypeSpecs.DATE)
-                          .build()))
-              .returning(
-                  List.of(
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc6"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc6),
-                          Values.of("user6"),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc4"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc4),
-                          Values.of("user4"),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc2"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc2),
-                          Values.of("user2"),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc1"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc1),
-                          Values.of("user1"),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc3"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc3),
-                          Values.of("user3"),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc5"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc5),
-                          Values.of("user5"),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL)));
+
+      SimpleStatement stmt = SimpleStatement.newInstance(collectionReadCql);
+      ColumnDefinitions columnDefs =
+          buildColumnDefs(
+              TestColumn.keyColumn(),
+              TestColumn.ofUuid("tx_id"),
+              TestColumn.ofVarchar("doc_json"),
+              TestColumn.ofVarchar("query_text_values['username']"),
+              TestColumn.ofDecimal("query_dbl_values['username']"),
+              TestColumn.ofBoolean("query_bool_values['username']"),
+              TestColumn.ofVarchar("query_null_values['username']"),
+              TestColumn.ofDate("query_timestamp_values['username']"));
+      List<Row> rows =
+          Arrays.asList(
+              resultRow(
+                  columnDefs,
+                  0,
+                  byteBufferForKey("doc6"),
+                  UUID.randomUUID(),
+                  doc6,
+                  "user6",
+                  null,
+                  null,
+                  null,
+                  null),
+              resultRow(
+                  columnDefs,
+                  1,
+                  byteBufferForKey("doc4"),
+                  UUID.randomUUID(),
+                  doc4,
+                  "user4",
+                  null,
+                  null,
+                  null,
+                  null),
+              resultRow(
+                  columnDefs,
+                  2,
+                  byteBufferForKey("doc2"),
+                  UUID.randomUUID(),
+                  doc2,
+                  "user2",
+                  null,
+                  null,
+                  null,
+                  null),
+              resultRow(
+                  columnDefs,
+                  3,
+                  byteBufferForKey("doc1"),
+                  UUID.randomUUID(),
+                  doc1,
+                  "user1",
+                  null,
+                  null,
+                  null,
+                  null),
+              resultRow(
+                  columnDefs,
+                  4,
+                  byteBufferForKey("doc3"),
+                  UUID.randomUUID(),
+                  doc3,
+                  "user3",
+                  null,
+                  null,
+                  null,
+                  null),
+              resultRow(
+                  columnDefs,
+                  5,
+                  byteBufferForKey("doc5"),
+                  UUID.randomUUID(),
+                  doc5,
+                  "user5",
+                  null,
+                  null,
+                  null,
+                  null));
+
+      AsyncResultSet results = new MockAsyncResultSet(columnDefs, rows, null);
+      final AtomicInteger callCount = new AtomicInteger();
+      QueryExecutor queryExecutor = mock(QueryExecutor.class);
+      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+          .then(
+              invocation -> {
+                callCount.incrementAndGet();
+                return Uni.createFrom().item(results);
+              });
 
       LogicalExpression implicitAnd = LogicalExpression.and();
       FindOperation operation =
@@ -1720,14 +1704,14 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor0)
+              .execute(queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
               .getItem();
 
       // assert query execution
-      candidatesAssert.assertExecuteCount().isOne();
+      assertThat(callCount.get()).isEqualTo(1);
 
       // then result
       CommandResult result = execute.get();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -1349,7 +1349,6 @@ public class FindOperationTest extends OperationTestBase {
       assertThat(result.errors()).isNullOrEmpty();
     }
 
-    @Disabled
     @Test
     public void findAllSortByDate() throws Exception {
       String collectionReadCql =
@@ -1417,111 +1416,96 @@ public class FindOperationTest extends OperationTestBase {
                       }
                     }
                     """;
-      ValidatingStargateBridge.QueryAssert candidatesAssert =
-          withQuery(collectionReadCql)
-              .withPageSize(20)
-              .withColumnSpec(
-                  List.of(
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("tx_id")
-                          .setType(TypeSpecs.UUID)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("doc_json")
-                          .setType(TypeSpecs.VARCHAR)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_text_values['sort_date']")
-                          .setType(TypeSpecs.VARCHAR)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_dbl_values['sort_date']")
-                          .setType(TypeSpecs.DECIMAL)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_bool_values['sort_date']")
-                          .setType(TypeSpecs.BOOLEAN)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_null_values['sort_date']")
-                          .setType(TypeSpecs.VARCHAR)
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("query_timestamp_values['sort_date']")
-                          .setType(TypeSpecs.DATE)
-                          .build()))
-              .returning(
-                  List.of(
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc6"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc6),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.of(1672531700000L)),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc4"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc4),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.of(1672531500000L)),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc2"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc2),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.of(1672531300000L)),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc1"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc1),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.of(1672531200000L)),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc3"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc3),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.of(1672531400000L)),
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc5"))),
-                          Values.of(UUID.randomUUID()),
-                          Values.of(doc5),
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.NULL,
-                          Values.of(1672531600000L))));
+
+      SimpleStatement stmt = SimpleStatement.newInstance(collectionReadCql);
+      ColumnDefinitions columnDefs =
+          buildColumnDefs(
+              TestColumn.keyColumn(),
+              TestColumn.ofUuid("tx_id"),
+              TestColumn.ofVarchar("doc_json"),
+              TestColumn.ofVarchar("query_text_values['sort_date']"),
+              TestColumn.ofDecimal("query_dbl_values['sort_date']"),
+              TestColumn.ofBoolean("query_bool_values['sort_date']"),
+              TestColumn.ofVarchar("query_null_values['sort_date']"),
+              TestColumn.ofDate("query_timestamp_values['sort_date']"));
+      List<Row> rows =
+          Arrays.asList(
+              resultRow(
+                  columnDefs,
+                  0,
+                  byteBufferForKey("doc6"),
+                  UUID.randomUUID(),
+                  doc6,
+                  null,
+                  null,
+                  null,
+                  null,
+                  1672531700000L),
+              resultRow(
+                  columnDefs,
+                  1,
+                  byteBufferForKey("doc4"),
+                  UUID.randomUUID(),
+                  doc4,
+                  null,
+                  null,
+                  null,
+                  null,
+                  1672531500000L),
+              resultRow(
+                  columnDefs,
+                  2,
+                  byteBufferForKey("doc2"),
+                  UUID.randomUUID(),
+                  doc2,
+                  null,
+                  null,
+                  null,
+                  null,
+                  1672531300000L),
+              resultRow(
+                  columnDefs,
+                  3,
+                  byteBufferForKey("doc1"),
+                  UUID.randomUUID(),
+                  doc1,
+                  null,
+                  null,
+                  null,
+                  null,
+                  1672531200000L),
+              resultRow(
+                  columnDefs,
+                  4,
+                  byteBufferForKey("doc3"),
+                  UUID.randomUUID(),
+                  doc3,
+                  null,
+                  null,
+                  null,
+                  null,
+                  1672531400000L),
+              resultRow(
+                  columnDefs,
+                  5,
+                  byteBufferForKey("doc5"),
+                  UUID.randomUUID(),
+                  doc5,
+                  null,
+                  null,
+                  null,
+                  null,
+                  1672531600000L));
+
+      AsyncResultSet results = new MockAsyncResultSet(columnDefs, rows, null);
+      final AtomicInteger callCount = new AtomicInteger();
+      QueryExecutor queryExecutor = mock(QueryExecutor.class);
+      when(queryExecutor.executeRead(eq(stmt), any(), anyInt()))
+          .then(
+              invocation -> {
+                callCount.incrementAndGet();
+                return Uni.createFrom().item(results);
+              });
 
       LogicalExpression implicitAnd = LogicalExpression.and();
       FindOperation operation =
@@ -1540,14 +1524,14 @@ public class FindOperationTest extends OperationTestBase {
 
       Supplier<CommandResult> execute =
           operation
-              .execute(queryExecutor0)
+              .execute(queryExecutor)
               .subscribe()
               .withSubscriber(UniAssertSubscriber.create())
               .awaitItem()
               .getItem();
 
       // assert query execution
-      candidatesAssert.assertExecuteCount().isOne();
+      assertThat(callCount.get()).isEqualTo(1);
 
       // then result
       CommandResult result = execute.get();

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
@@ -85,11 +85,12 @@ public class OperationTestBase {
     }
 
     static TestColumn keyColumn() {
-      List<RawType> keyTupleParams =
-          Arrays.asList(
-              RawType.PRIMITIVES.get(ProtocolConstants.DataType.TINYINT),
-              RawType.PRIMITIVES.get(ProtocolConstants.DataType.VARCHAR));
-      return of("key", new RawType.RawTuple(keyTupleParams));
+      return of(
+          "key",
+          new RawType.RawTuple(
+              Arrays.asList(
+                  RawType.PRIMITIVES.get(ProtocolConstants.DataType.TINYINT),
+                  RawType.PRIMITIVES.get(ProtocolConstants.DataType.VARCHAR))));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
@@ -31,12 +31,12 @@ public class OperationTestBase {
   protected static final TupleType DOC_KEY_TYPE =
       DataTypes.tupleOf(DataTypes.TINYINT, DataTypes.TEXT);
 
-  protected ColumnDefinitions buildColumnDefs(List<TestColumn> columns) {
-    return buildColumnDefs(KEYSPACE_NAME, COLLECTION_NAME, columns);
+  protected ColumnDefinitions buildColumnDefs(TestColumn... columns) {
+    return buildColumnDefs(Arrays.asList(columns));
   }
 
-  protected ColumnDefinitions buildColumnDefs(TestColumn... columns) {
-    return buildColumnDefs(KEYSPACE_NAME, COLLECTION_NAME, Arrays.asList(columns));
+  protected ColumnDefinitions buildColumnDefs(List<TestColumn> columns) {
+    return buildColumnDefs(KEYSPACE_NAME, COLLECTION_NAME, columns);
   }
 
   protected ColumnDefinitions buildColumnDefs(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
@@ -34,6 +34,10 @@ public class OperationTestBase {
     return buildColumnDefs(KEYSPACE_NAME, COLLECTION_NAME, columns);
   }
 
+  protected ColumnDefinitions buildColumnDefs(TestColumn... columns) {
+    return buildColumnDefs(KEYSPACE_NAME, COLLECTION_NAME, Arrays.asList(columns));
+  }
+
   protected ColumnDefinitions buildColumnDefs(
       String ks, String tableName, List<TestColumn> columns) {
     List<ColumnDefinition> columnDefs = new ArrayList<>();
@@ -59,11 +63,35 @@ public class OperationTestBase {
     return TypeCodecs.UUID.encode(value, ProtocolVersion.DEFAULT);
   }
 
+  protected ByteBuffer byteBufferFromAny(Object value) {
+    if (value == null) {
+      return byteBufferForNull();
+    }
+    if (value instanceof ByteBuffer) {
+      return (ByteBuffer) value;
+    }
+    if (value instanceof UUID) {
+      return byteBufferFrom((UUID) value);
+    }
+    if (value instanceof String) {
+      return byteBufferFrom((String) value);
+    }
+    if (value instanceof Long) {
+      return byteBufferFrom((Long) value);
+    }
+    throw new IllegalArgumentException(
+        "byteBufferFromAny() does not (yet?) support value of type: " + value.getClass());
+  }
+
   protected ByteBuffer byteBufferForKey(String key) {
     // Important! TINYINT requires Byte:
     TupleValue value =
         DOC_KEY_TYPE.newValue((byte) DocumentConstants.KeyTypeId.TYPE_ID_STRING, key);
     return TypeCodecs.tupleOf(DOC_KEY_TYPE).encode(value, ProtocolVersion.DEFAULT);
+  }
+
+  protected ByteBuffer byteBufferForNull() {
+    return ByteBuffer.wrap(new byte[0]);
   }
 
   /**
@@ -84,6 +112,18 @@ public class OperationTestBase {
 
     static TestColumn of(String name, RawType type) {
       return new TestColumn(name, type);
+    }
+
+    static TestColumn ofBoolean(String name) {
+      return of(name, RawType.PRIMITIVES.get(ProtocolConstants.DataType.BOOLEAN));
+    }
+
+    static TestColumn ofDate(String name) {
+      return of(name, RawType.PRIMITIVES.get(ProtocolConstants.DataType.DATE));
+    }
+
+    static TestColumn ofDecimal(String name) {
+      return of(name, RawType.PRIMITIVES.get(ProtocolConstants.DataType.DECIMAL));
     }
 
     static TestColumn ofLong(String name) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
@@ -27,6 +27,9 @@ public class OperationTestBase {
   protected final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
   protected final CommandContext CONTEXT = new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);
 
+  protected static final TupleType DOC_KEY_TYPE =
+      DataTypes.tupleOf(DataTypes.TINYINT, DataTypes.TEXT);
+
   protected ColumnDefinitions buildColumnDefs(List<TestColumn> columns) {
     return buildColumnDefs(KEYSPACE_NAME, COLLECTION_NAME, columns);
   }
@@ -57,10 +60,21 @@ public class OperationTestBase {
   }
 
   protected ByteBuffer byteBufferForKey(String key) {
-    TupleType tupleType = DataTypes.tupleOf(DataTypes.TINYINT, DataTypes.TEXT);
-    // important! TINYINT means Byte
-    TupleValue value = tupleType.newValue((byte) DocumentConstants.KeyTypeId.TYPE_ID_STRING, key);
-    return TypeCodecs.tupleOf(tupleType).encode(value, ProtocolVersion.DEFAULT);
+    // Important! TINYINT requires Byte:
+    TupleValue value =
+        DOC_KEY_TYPE.newValue((byte) DocumentConstants.KeyTypeId.TYPE_ID_STRING, key);
+    return TypeCodecs.tupleOf(DOC_KEY_TYPE).encode(value, ProtocolVersion.DEFAULT);
+  }
+
+  /**
+   * Factory method for constructing value for Document key of type {@code String}, to be used for
+   * {@code SimpleStatement} bound values.
+   *
+   * @param key String id of the document
+   * @return Bound value to use with {@code SimpleStatement}
+   */
+  protected TupleValue boundKeyForStatement(String key) {
+    return DOC_KEY_TYPE.newValue((byte) DocumentConstants.KeyTypeId.TYPE_ID_STRING, key);
   }
 
   protected record TestColumn(String name, RawType type) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.data.CqlVector;
 import com.datastax.oss.driver.api.core.data.TupleValue;
 import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import com.datastax.oss.driver.api.core.type.DataTypes;
@@ -103,6 +104,10 @@ public class OperationTestBase {
    */
   protected TupleValue boundKeyForStatement(String key) {
     return DOC_KEY_TYPE.newValue((byte) DocumentConstants.KeyTypeId.TYPE_ID_STRING, key);
+  }
+
+  protected CqlVector<Float> vectorForStatement(Float... value) {
+    return CqlVector.newInstance(value);
   }
 
   protected record TestColumn(String name, RawType type) {


### PR DESCRIPTION
**What this PR does**:

Change "FindOperationTest" to not use ValidatingBridge but instead mock QueryExecutor directly.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
