### PR TITLE
JsonTerm Refactoring for unit test

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/JsonTerm.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/JsonTerm.java
@@ -1,9 +1,10 @@
 package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 
-import io.stargate.sgv2.api.common.cql.builder.Marker;
+import io.stargate.bridge.grpc.Values;
+import io.stargate.sgv2.api.common.cql.builder.Literal;
 import java.util.Objects;
 
-public class JsonTerm extends Marker {
+public class JsonTerm extends Literal {
   static final String NULL_ERROR_MESSAGE = "Use Values.NULL to bind a null CQL value";
   private final Object key;
   private final Object value;
@@ -13,6 +14,7 @@ public class JsonTerm extends Marker {
   }
 
   public JsonTerm(Object key, Object value) {
+    super(Values.NULL);
     this.key = key;
     this.value = value;
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/JsonTerm.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/JsonTerm.java
@@ -4,6 +4,12 @@ import io.stargate.bridge.grpc.Values;
 import io.stargate.sgv2.api.common.cql.builder.Literal;
 import java.util.Objects;
 
+/**
+ * This class is an extension of the Literal class from
+ * sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/cql/builder/Term.java This is
+ * required as a placeholder to set values in query builder and extracted out to set the value in
+ * SimpleStatement positional values
+ */
 public class JsonTerm extends Literal {
   static final String NULL_ERROR_MESSAGE = "Use Values.NULL to bind a null CQL value";
   private final Object key;


### PR DESCRIPTION


**What this PR does**:
Converted JsonTerm to extend Literal instead of marker to solve the unit test issue.
QueryBuilder asserts for Literal value for the rhs in case where clause use map entry.


**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
