### PR TITLE
Un-Disable 3 tests that pass with recent `JsonTerm` fix

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -869,7 +869,6 @@ public class FindOperationTest extends OperationTestBase {
       assertThat(result.errors()).isNullOrEmpty();
     }
 
-    @Disabled // fails on binding Collection value
     @Test
     public void findWithSizeFilter() throws Exception {
       String collectionReadCql =
@@ -934,7 +933,6 @@ public class FindOperationTest extends OperationTestBase {
       assertThat(result.errors()).isNullOrEmpty();
     }
 
-    @Disabled // fails on binding Map key
     @Test
     public void findWithArrayEqualFilter() throws Exception {
       // Due to trimming of indexes, former "array_equals" moved under "query_text_values":
@@ -1030,7 +1028,6 @@ public class FindOperationTest extends OperationTestBase {
       assertThat(result.errors()).isNullOrEmpty();
     }
 
-    @Disabled // fails on binding Map key
     @Test
     public void findWithSubDocEqualFilter() throws Exception {
       String collectionReadCql =


### PR DESCRIPTION
**What this PR does**:

Completes conversion of `FindOperationTest` by un-Disabling 3 that were commented out due to problem with `JsonTerm`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
