### PR TITLE
(WIP) Convert `InsertOperationTest` to use native CQL not validating Bridge

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/serializer/CQLBindValues.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/serializer/CQLBindValues.java
@@ -30,18 +30,18 @@ public class CQLBindValues {
     return from.stream().map(val -> val.toString()).collect(Collectors.toSet());
   }
 
-  public static Set<String> getStringSetValue(Set<String> from) {
+  public static Set<String> getStringSetValue(Set<?> from) {
     return from.stream().map(val -> val.toString()).collect(Collectors.toSet());
   }
 
-  public static List<String> getListValue(List<JsonPath> from) {
+  public static List<String> getListValue(List<?> from) {
     return from.stream().map(val -> val.toString()).collect(Collectors.toList());
   }
 
-  public static Map<String, String> getStringMapValues(Map<JsonPath, String> from) {
+  public static Map<String, String> getStringMapValues(Map<JsonPath, ?> from) {
     final Map<String, String> to = new HashMap<>(from.size());
-    for (Map.Entry<JsonPath, String> entry : from.entrySet()) {
-      to.put(entry.getKey().toString(), entry.getValue());
+    for (Map.Entry<JsonPath, ?> entry : from.entrySet()) {
+      to.put(entry.getKey().toString(), entry.getValue().toString());
     }
     return to;
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -43,7 +43,6 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -869,7 +869,6 @@ public class FindOperationTest extends OperationTestBase {
       assertThat(result.errors()).isNullOrEmpty();
     }
 
-    @Disabled // fails on binding Collection value
     @Test
     public void findWithSizeFilter() throws Exception {
       String collectionReadCql =
@@ -934,7 +933,6 @@ public class FindOperationTest extends OperationTestBase {
       assertThat(result.errors()).isNullOrEmpty();
     }
 
-    @Disabled // fails on binding Map key
     @Test
     public void findWithArrayEqualFilter() throws Exception {
       // Due to trimming of indexes, former "array_equals" moved under "query_text_values":
@@ -1030,7 +1028,6 @@ public class FindOperationTest extends OperationTestBase {
       assertThat(result.errors()).isNullOrEmpty();
     }
 
-    @Disabled // fails on binding Map key
     @Test
     public void findWithSubDocEqualFilter() throws Exception {
       String collectionReadCql =

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/OperationTestBase.java
@@ -16,6 +16,8 @@ import com.datastax.oss.protocol.internal.response.result.ColumnSpec;
 import com.datastax.oss.protocol.internal.response.result.RawType;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
+import io.stargate.sgv2.jsonapi.service.cqldriver.serializer.CQLBindValues;
+import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,6 +54,10 @@ public class OperationTestBase {
     return DefaultColumnDefinitions.valueOf(columnDefs);
   }
 
+  protected ByteBuffer byteBufferFrom(boolean value) {
+    return TypeCodecs.BOOLEAN.encode(value, ProtocolVersion.DEFAULT);
+  }
+
   protected ByteBuffer byteBufferFrom(long value) {
     return TypeCodecs.BIGINT.encode(value, ProtocolVersion.DEFAULT);
   }
@@ -70,6 +76,9 @@ public class OperationTestBase {
     }
     if (value instanceof ByteBuffer) {
       return (ByteBuffer) value;
+    }
+    if (value instanceof Boolean) {
+      return byteBufferFrom((Boolean) value);
     }
     if (value instanceof UUID) {
       return byteBufferFrom((UUID) value);
@@ -103,7 +112,7 @@ public class OperationTestBase {
    * @return Bound value to use with {@code SimpleStatement}
    */
   protected TupleValue boundKeyForStatement(String key) {
-    return DOC_KEY_TYPE.newValue((byte) DocumentConstants.KeyTypeId.TYPE_ID_STRING, key);
+    return CQLBindValues.getDocumentIdValue(DocumentId.fromString(key));
   }
 
   protected CqlVector<Float> vectorForStatement(Float... value) {


### PR DESCRIPTION
**What this PR does**:

Converts "InsertOperationTest" to work with new CQL-based access

**Which issue(s) this PR fixes**:
Fixes C2-3098

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
