### PR TITLE
Convert "SerialConsistencyOverrideOperationTest" to not use ValidatingBridge

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
@@ -16,7 +16,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
-import io.stargate.sgv2.api.common.config.QueriesConfig;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
@@ -57,7 +56,6 @@ public class InsertOperationTest extends OperationTestBase {
 
   @Inject Shredder shredder;
   @Inject ObjectMapper objectMapper;
-  @Inject QueriesConfig queriesConfig;
 
   static final String INSERT_CQL =
       "INSERT INTO \"%s\".\"%s\""

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
@@ -1,18 +1,27 @@
 package io.stargate.sgv2.jsonapi.service.operation.model.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.bridge.grpc.TypeSpecs;
 import io.stargate.bridge.grpc.Values;
 import io.stargate.bridge.proto.QueryOuterClass;
-import io.stargate.sgv2.common.bridge.AbstractValidatingStargateBridgeTest;
 import io.stargate.sgv2.common.bridge.ValidatingStargateBridge;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
@@ -29,26 +38,25 @@ import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
 // import io.stargate.sgv2.jsonapi.service.testutil.DocumentUpdaterUtils;
 import io.stargate.sgv2.jsonapi.service.testutil.DocumentUpdaterUtils;
+import io.stargate.sgv2.jsonapi.service.testutil.MockAsyncResultSet;
+import io.stargate.sgv2.jsonapi.service.testutil.MockRow;
 import io.stargate.sgv2.jsonapi.service.updater.DocumentUpdater;
 import jakarta.inject.Inject;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.Disabled;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@Disabled
 @TestProfile(SerialConsistencyOverrideOperationTest.SerialConsistencyOverrideProfile.class)
-public class SerialConsistencyOverrideOperationTest extends AbstractValidatingStargateBridgeTest {
-  private static final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
-  private static final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
-  private static final CommandContext COMMAND_CONTEXT =
-      new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);
-  @Inject QueryExecutor queryExecutor;
+public class SerialConsistencyOverrideOperationTest extends OperationTestBase {
+  private final CommandContext COMMAND_CONTEXT = new CommandContext(KEYSPACE_NAME, COLLECTION_NAME);
   @Inject ObjectMapper objectMapper;
   @Inject Shredder shredder;
 
@@ -71,45 +79,42 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
     @Test
     public void delete() {
       UUID tx_id = UUID.randomUUID();
-
       String collectionReadCql =
           "SELECT key, tx_id FROM \"%s\".\"%s\" WHERE key = ? LIMIT 1"
               .formatted(KEYSPACE_NAME, COLLECTION_NAME);
-      ValidatingStargateBridge.QueryAssert readAssert =
-          withQuery(
-                  collectionReadCql,
-                  Values.of(
-                      CustomValueSerializers.getDocumentIdValue(DocumentId.fromString("doc1"))))
-              .withPageSize(1)
-              .withColumnSpec(
-                  List.of(
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
-                          .build(),
-                      QueryOuterClass.ColumnSpec.newBuilder()
-                          .setName("tx_id")
-                          .setType(TypeSpecs.UUID)
-                          .build()))
-              .returning(
-                  List.of(
-                      List.of(
-                          Values.of(
-                              CustomValueSerializers.getDocumentIdValue(
-                                  DocumentId.fromString("doc1"))),
-                          Values.of(tx_id))));
+
+      final ColumnDefinitions keyAndTxtIdColumns =
+          buildColumnDefs(TestColumn.keyColumn(), TestColumn.ofUuid("tx_id"));
+      SimpleStatement selectStmt =
+          SimpleStatement.newInstance(collectionReadCql, boundKeyForStatement("doc1"));
+      List<Row> selectRows =
+          Arrays.asList(resultRow(keyAndTxtIdColumns, 0, byteBufferForKey("doc1"), tx_id));
+      AsyncResultSet selectResults = new MockAsyncResultSet(keyAndTxtIdColumns, selectRows, null);
+      final AtomicInteger callCountSelect = new AtomicInteger();
+      QueryExecutor queryExecutor = mock(QueryExecutor.class);
+      when(queryExecutor.executeRead(eq(selectStmt), any(), anyInt()))
+          .then(
+              invocation -> {
+                callCountSelect.incrementAndGet();
+                return Uni.createFrom().item(selectResults);
+              });
 
       String collectionDeleteCql =
           "DELETE FROM \"%s\".\"%s\" WHERE key = ? IF tx_id = ?"
               .formatted(KEYSPACE_NAME, COLLECTION_NAME);
-      ValidatingStargateBridge.QueryAssert deleteAssert =
-          withQuery(
-                  collectionDeleteCql,
-                  Values.of(
-                      CustomValueSerializers.getDocumentIdValue(DocumentId.fromString("doc1"))),
-                  Values.of(tx_id))
-              .withSerialConsistency(QueryOuterClass.Consistency.LOCAL_SERIAL)
-              .returning(List.of(List.of(Values.of(true))));
+      final ColumnDefinitions columnsApplied = buildColumnDefs(TestColumn.ofBoolean("[applied]"));
+      SimpleStatement deleteStmt =
+          SimpleStatement.newInstance(collectionDeleteCql, boundKeyForStatement("doc1"), tx_id);
+      List<Row> deleteRows = Arrays.asList(resultRow(columnsApplied, 0, byteBufferFrom(true)));
+      AsyncResultSet deleteResults = new MockAsyncResultSet(columnsApplied, deleteRows, null);
+      final AtomicInteger callCountDelete = new AtomicInteger();
+      when(queryExecutor.executeWrite(eq(deleteStmt)))
+          .then(
+              invocation -> {
+                SimpleStatement stmt = invocation.getArgument(0);
+                callCountDelete.incrementAndGet();
+                return Uni.createFrom().item(deleteResults);
+              });
 
       LogicalExpression implicitAnd = LogicalExpression.and();
       implicitAnd.comparisonExpressions.add(new ComparisonExpression(null, null, null));
@@ -136,8 +141,8 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
               .getItem();
 
       // assert query execution
-      readAssert.assertExecuteCount().isOne();
-      deleteAssert.assertExecuteCount().isOne();
+      assertThat(callCountSelect.get()).isEqualTo(1);
+      assertThat(callCountDelete.get()).isEqualTo(1);
 
       // then result
       CommandResult result = execute.get();
@@ -154,7 +159,6 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
             + " (?, now(), ?, ?, ?, ?, ?, ?, ?, ?, ?)  IF NOT EXISTS";
 
     @Test
-    @Disabled
     public void insert() throws Exception {
       String document =
           """
@@ -171,6 +175,8 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
 
       JsonNode jsonNode = objectMapper.readTree(document);
       WritableShreddedDocument shredDocument = shredder.shred(jsonNode);
+
+      QueryExecutor queryExecutor = mock(QueryExecutor.class);
 
       String insertCql = INSERT_CQL.formatted(KEYSPACE_NAME, COLLECTION_NAME);
       ValidatingStargateBridge.QueryAssert insertAssert =
@@ -226,7 +232,6 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
   class ReadAndUpdate {
 
     @Test
-    @Disabled
     public void readAndUpdate() throws Exception {
       String collectionReadCql =
           "SELECT key, tx_id, doc_json FROM \"%s\".\"%s\" WHERE key = ? LIMIT 1"
@@ -361,6 +366,7 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
               1,
               3);
 
+      QueryExecutor queryExecutor = mock(QueryExecutor.class);
       Supplier<CommandResult> execute =
           operation
               .execute(queryExecutor)
@@ -381,5 +387,15 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
           .containsEntry(CommandStatus.MODIFIED_COUNT, 1);
       assertThat(result.errors()).isNull();
     }
+  }
+
+  private MockRow resultRow(ColumnDefinitions columnDefs, int index, Object... values) {
+    List<ByteBuffer> buffers = Stream.of(values).map(value -> byteBufferFromAny(value)).toList();
+    return new MockRow(columnDefs, index, buffers);
+  }
+
+  // /// !!! TEMPORARY
+  ValidatingStargateBridge.QueryExpectation withQuery(String query, Object... args) {
+    return null;
   }
 }


### PR DESCRIPTION
**What this PR does**:

Converts `SerialConsistencyOverrideOperationTest` to work without Bridge

**Which issue(s) this PR fixes**:

C2-3101

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
