### PR TITLE
Roll back version due to incorrectly tagged 2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [v2.0.0-BETA-6](https://github.com/stargate/jsonapi/tree/v2.0.0-BETA-6) (2023-12-05)
+## [v1.0.0-BETA-5](https://github.com/stargate/jsonapi/tree/v1.0.0-BETA-5) (2023-12-06)
 
-[Full Changelog](https://github.com/stargate/jsonapi/compare/v1.0.0-BETA-4...v2.0.0-BETA-6)
+[Full Changelog](https://github.com/stargate/jsonapi/compare/v1.0.0-BETA-4...v1.0.0-BETA-5)
 
 **Closed issues:**
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>2.1.0-BETA-6</version>
   </parent>
   <artifactId>sgv2-jsonapi</artifactId>
-  <version>1.0.0-BETA-6-SNAPSHOT</version>
+  <version>1.0.0-BETA-5-SNAPSHOT</version>
   <properties>
     <stargate.version>${project.parent.version}</stargate.version>
     <!-- 17-May-2023, tatu: [json-api#172] Need at least Jackson 2.15.x -->


### PR DESCRIPTION
**What this PR does**:

Fixes version in pom.xml to align with imminent re-release as 1.0.0-BETA-5

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
