### PR TITLE
Fix to return 401 instead of 500

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/InvalidCredentialsProfile.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/InvalidCredentialsProfile.java
@@ -1,0 +1,16 @@
+package io.stargate.sgv2.jsonapi.service.cqldriver;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Map;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+public class InvalidCredentialsProfile implements QuarkusTestProfile {
+
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    return ImmutableMap.<String, String>builder()
+        .put("stargate.jsonapi.operations.database-config.fixed-token", "test-token")
+        .put("stargate.jsonapi.operations.database-config.password", "invalid-password")
+        .build();
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/InvalidCredentialsTests.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/cqldriver/InvalidCredentialsTests.java
@@ -1,0 +1,111 @@
+package io.stargate.sgv2.jsonapi.service.cqldriver;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.AllNodesFailedException;
+import com.datastax.oss.driver.api.core.CqlSession;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.api.common.StargateRequestInfo;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
+import io.stargate.sgv2.jsonapi.config.OperationsConfig;
+import io.stargate.sgv2.jsonapi.exception.mappers.ThrowableToErrorMapper;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(InvalidCredentialsProfile.class)
+public class InvalidCredentialsTests {
+
+  private static final String TENANT_ID_FOR_TEST = "test_tenant";
+
+  @Inject OperationsConfig operationsConfig;
+
+  private MeterRegistry meterRegistry;
+
+  /**
+   * List of sessions created in the tests. This is used to close the sessions after each test. This
+   * is needed because, though the sessions evicted from the cache are closed, the sessions left
+   * active on the cache are not closed, so we have to close them explicitly.
+   */
+  private List<CqlSession> sessionsCreatedInTests;
+
+  @BeforeEach
+  public void tearUpEachTest() {
+    meterRegistry = new SimpleMeterRegistry();
+    sessionsCreatedInTests = new ArrayList<>();
+  }
+
+  @AfterEach
+  public void tearDownEachTest() {
+    sessionsCreatedInTests.forEach(CqlSession::close);
+  }
+
+  @Test
+  public void testOSSCxCQLSessionCacheWithInvalidCredentials()
+      throws NoSuchFieldException, IllegalAccessException {
+    // set request info
+    StargateRequestInfo stargateRequestInfo = mock(StargateRequestInfo.class);
+    when(stargateRequestInfo.getTenantId()).thenReturn(Optional.of(TENANT_ID_FOR_TEST));
+    when(stargateRequestInfo.getCassandraToken())
+        .thenReturn(operationsConfig.databaseConfig().fixedToken());
+    CQLSessionCache cqlSessionCacheForTest = new CQLSessionCache(operationsConfig, meterRegistry);
+    Field stargateRequestInfoField =
+        cqlSessionCacheForTest.getClass().getDeclaredField("stargateRequestInfo");
+    stargateRequestInfoField.setAccessible(true);
+    stargateRequestInfoField.set(cqlSessionCacheForTest, stargateRequestInfo);
+    // set operation config
+    Field operationsConfigField =
+        cqlSessionCacheForTest.getClass().getDeclaredField("operationsConfig");
+    operationsConfigField.setAccessible(true);
+    operationsConfigField.set(cqlSessionCacheForTest, operationsConfig);
+    // Throwable
+    Throwable t = catchThrowable(cqlSessionCacheForTest::getSession);
+    assertThat(t).isInstanceOf(AllNodesFailedException.class);
+    CommandResult.Error error =
+        ThrowableToErrorMapper.getMapperWithMessageFunction().apply(t, t.getMessage());
+    assertThat(error).isNotNull();
+    assertThat(error.message()).contains("UNAUTHENTICATED: Invalid token");
+    assertThat(error.status()).isEqualTo(Response.Status.UNAUTHORIZED);
+    assertThat(cqlSessionCacheForTest.cacheSize()).isEqualTo(0);
+    // metrics test
+    Gauge cacheSizeMetric =
+        meterRegistry.find("cache.size").tag("cache", "cql_sessions_cache").gauge();
+    assertThat(cacheSizeMetric).isNotNull();
+    assertThat(cacheSizeMetric.value()).isEqualTo(0);
+    FunctionCounter cachePutMetric =
+        meterRegistry.find("cache.puts").tag("cache", "cql_sessions_cache").functionCounter();
+    assertThat(cachePutMetric).isNotNull();
+    assertThat(cachePutMetric.count()).isEqualTo(1);
+    FunctionCounter cacheLoadSuccessMetric =
+        meterRegistry
+            .find("cache.load")
+            .tag("cache", "cql_sessions_cache")
+            .tag("result", "success")
+            .functionCounter();
+    assertThat(cacheLoadSuccessMetric).isNotNull();
+    assertThat(cacheLoadSuccessMetric.count()).isEqualTo(0);
+    FunctionCounter cacheLoadFailureMetric =
+        meterRegistry
+            .find("cache.load")
+            .tag("cache", "cql_sessions_cache")
+            .tag("result", "failure")
+            .functionCounter();
+    assertThat(cacheLoadFailureMetric).isNotNull();
+    assertThat(cacheLoadFailureMetric.count()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
**What this PR does**:

Fix to return 401 instead of 500 when invalid/token or credentials are provided

**Which issue(s) this PR fixes**:
Fixes #707 

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
