### PR TITLE
Fix #710: use byte-length for max String value, not characters

### DIFF
--- a/docs/jsonapi-spec.md
+++ b/docs/jsonapi-spec.md
@@ -408,10 +408,10 @@ has 3 fields: `root`, `root.branch`, and `root.branch.leaf`, for purposes of thi
 
 The maximum size of field values are:
 
-| JSON Type | Maximum Value                              |
-|-----------|--------------------------------------------|
-| `string`  | Maximum length of 8,000 unicode characters |
-| `number`  | Maximum length of 50 number characters     |
+| JSON Type | Maximum Value                                 |
+|-----------|-----------------------------------------------|
+| `string`  | Maximum length of 8,000 bytes (UTF-8 encoded) |
+| `number`  | Maximum length of 50 number characters        |
 
 #### Document Array Limits
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,12 +71,16 @@
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -40,10 +40,10 @@ public interface DocumentLimitsConfig {
   int DEFAULT_MAX_PROPERTY_NAME_LENGTH = 48;
 
   /**
-   * Defines the default maximum length of a single String value: 8,000 characters with 1.0.0-BETA-6
-   * and later (16,000 before)
+   * Defines the default maximum length of a single String value: 8,000 bytes with 1.0.0-BETA-6 and
+   * later (16,000 characters before)
    */
-  int DEFAULT_MAX_STRING_LENGTH = 8_000;
+  int DEFAULT_MAX_STRING_LENGTH_IN_BYTES = 8_000;
 
   /**
    * @return Defines the maximum document size, defaults to {@code 1 meg} (1 million characters).
@@ -96,10 +96,10 @@ public interface DocumentLimitsConfig {
   @WithDefault("" + DEFAULT_MAX_NUMBER_LENGTH)
   int maxNumberLength();
 
-  /** @return Defines the maximum length of a single String value. */
+  /** @return Defines the maximum length of a single String value (in bytes). */
   @Positive
-  @WithDefault("" + DEFAULT_MAX_STRING_LENGTH)
-  int maxStringLength();
+  @WithDefault("" + DEFAULT_MAX_STRING_LENGTH_IN_BYTES)
+  int maxStringLengthInBytes();
 
   /** @return Maximum length of an array. */
   @Positive

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -16,6 +16,7 @@ import jakarta.inject.Inject;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -349,14 +350,16 @@ public class Shredder {
 
   private void validateStringValue(DocumentLimitsConfig limits, JsonNode stringValue) {
     final String value = stringValue.textValue();
-    if (value.length() > limits.maxStringLength()) {
+    OptionalInt encodedLength =
+        JsonUtil.lengthInBytesIfAbove(value, limits.maxStringLengthInBytes());
+    if (encodedLength.isPresent()) {
       throw new JsonApiException(
           ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
           String.format(
-              "%s: String value length (%d) exceeds maximum allowed (%s)",
+              "%s: String value length (%d bytes) exceeds maximum allowed (%d bytes)",
               ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-              value.length(),
-              limits.maxStringLength()));
+              encodedLength.getAsInt(),
+              limits.maxStringLengthInBytes()));
     }
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/util/JsonUtil.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/util/JsonUtil.java
@@ -149,6 +149,13 @@ public class JsonUtil {
   }
 
   /**
+   * Utility method to check whether UTF-8 encoded length of given String is above given maximum
+   * length, and if so, return actual length (in bytes); otherwise return {@code
+   * OptionalInt.empty()}. This is faster than encoding String as byte[] and checking length as it
+   * not only avoids unnecessary allocation of potentially long String, but also avoids exact
+   * calculation for shorter Strings where we can determine that size cannot exceed the limit (since
+   * we know that UTF-8 encoded length is at most 3x of char length).
+   *
    * @param value String to check
    * @param maxLengthInBytes Maximum length in bytes allowed (inclusive)
    * @return {@code OptionalInt.empty()} if {@code value} is at most {@code maxLengthInBytes};

--- a/src/main/java/io/stargate/sgv2/jsonapi/util/JsonUtil.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/util/JsonUtil.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeCreator;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Utf8;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import io.stargate.sgv2.jsonapi.service.shredding.model.DocumentId;
@@ -11,6 +12,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalInt;
 
 public class JsonUtil {
   public static final String EJSON_VALUE_KEY_DATE = "$date";
@@ -144,5 +146,25 @@ public class JsonUtil {
 
   public static Date createDateFromDocumentId(DocumentId documentId) {
     return new Date((Long) ((Map) documentId.value()).get(EJSON_VALUE_KEY_DATE));
+  }
+
+  /**
+   * @param value String to check
+   * @param maxLengthInBytes Maximum length in bytes allowed (inclusive)
+   * @return {@code OptionalInt.empty()} if {@code value} is at most {@code maxLengthInBytes};
+   *     actual length if above {@code maxLengthInBytes}.
+   */
+  public static OptionalInt lengthInBytesIfAbove(String value, int maxLengthInBytes) {
+    // First, a quick and cheap check: maximum expansion is 3x, so avoid check if
+    // we know it cannot expand enough to be too long
+    final int charLen = value.length();
+    if ((charLen * 3) > maxLengthInBytes) {
+      // Otherwise calculate actual length, but avoid byte[] allocation:
+      int byteLen = Utf8.encodedLength(value);
+      if (byteLen > maxLengthInBytes) {
+        return OptionalInt.of(byteLen);
+      }
+    }
+    return OptionalInt.empty();
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -703,7 +703,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith(
-                  "Document size limitation violated: String value length (8056) exceeds maximum allowed"));
+                  "Document size limitation violated: String value length (8056 bytes) exceeds maximum allowed"));
     }
 
     private String createBigString(int minLen) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -658,7 +658,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
 
     @Test
     public void insertLongestValidString() {
-      final int strLen = DocumentLimitsConfig.DEFAULT_MAX_STRING_LENGTH - 20;
+      final int strLen = DocumentLimitsConfig.DEFAULT_MAX_STRING_LENGTH_IN_BYTES - 20;
 
       // Issue with SAI max String length should not require more than 1 doc, so:
       ObjectNode doc = MAPPER.createObjectNode();
@@ -675,7 +675,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
     @Test
     public void tryInsertTooLongString() {
       final String tooLongString =
-          createBigString(DocumentLimitsConfig.DEFAULT_MAX_STRING_LENGTH + 50);
+          createBigString(DocumentLimitsConfig.DEFAULT_MAX_STRING_LENGTH_IN_BYTES + 50);
       String json =
           """
                         {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -252,8 +252,8 @@ public class ShredderDocLimitsTest {
       final ObjectNode doc = objectMapper.createObjectNode();
       doc.put("_id", 123);
       ArrayNode arr = doc.putArray("arr");
-      // Let's add 50_000 char one (exceeds max of 16_000)
-      String str = RandomStringUtils.randomAscii(50_000);
+      // Let's add 10_000 char one (exceeds max of 8_000)
+      String str = RandomStringUtils.randomAscii(10_000);
       arr.add(str);
 
       Exception e = catchException(() -> shredder.shred(doc));
@@ -263,9 +263,9 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " String value length (50000) exceeds maximum allowed ("
-                  + docLimits.maxStringLength()
-                  + ")");
+              " String value length (10000 bytes) exceeds maximum allowed ("
+                  + docLimits.maxStringLengthInBytes()
+                  + " bytes)");
     }
 
     // Since max-number-len is handled at low-level, it's not strictly speaking

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -16,6 +16,7 @@ import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import jakarta.inject.Inject;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -242,18 +243,19 @@ public class ShredderDocLimitsTest {
     public void allowNotTooLongStringValues() {
       final ObjectNode doc = objectMapper.createObjectNode();
       doc.put("_id", 123);
-      // Max is 16_000 so do a bit less
-      doc.put("text", RandomStringUtils.randomAscii(7_500));
+      // Use ASCII to keep chars == bytes, use length of just slight below max allowed
+      doc.put("text", RandomStringUtils.randomAscii(docLimits.maxStringLengthInBytes() - 100));
       assertThat(shredder.shred(doc)).isNotNull();
     }
 
     @Test
-    public void catchTooLongStringValues() {
+    public void catchTooLongStringValueAscii() {
       final ObjectNode doc = objectMapper.createObjectNode();
       doc.put("_id", 123);
       ArrayNode arr = doc.putArray("arr");
-      // Let's add 10_000 char one (exceeds max of 8_000)
-      String str = RandomStringUtils.randomAscii(10_000);
+      // Use ASCII to keep chars == bytes, use length of just above max allowed
+      final int tooLongLength = docLimits.maxStringLengthInBytes() + 100;
+      String str = RandomStringUtils.randomAscii(tooLongLength);
       arr.add(str);
 
       Exception e = catchException(() -> shredder.shred(doc));
@@ -263,7 +265,41 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " String value length (10000 bytes) exceeds maximum allowed ("
+              " String value length ("
+                  + tooLongLength
+                  + " bytes) exceeds maximum allowed ("
+                  + docLimits.maxStringLengthInBytes()
+                  + " bytes)");
+    }
+
+    // Test to ensure that maximum String length validation catches case where
+    // character length is below maximum byte length but byte length is above it.
+    @Test
+    public void catchTooLongStringValueUTF8() {
+      final ObjectNode doc = objectMapper.createObjectNode();
+      doc.put("_id", 123);
+      // Repeat a 3-byte sequence enough times to exceed maximum
+      final int tooLongCharLength = (docLimits.maxStringLengthInBytes() / 3) + 20;
+      // Unicode char "न" (Devanagari script, U+0928), requires 3 bytes to encode
+      String tooLongString = "\u0928".repeat(tooLongCharLength);
+      doc.put("text", tooLongString);
+
+      // First just validate constraints: String we have has character length BELOW
+      // max length, and byte length ABOVE max length:
+      assertThat(tooLongString).hasSizeLessThan(docLimits.maxStringLengthInBytes());
+      assertThat(tooLongString.getBytes(StandardCharsets.UTF_8))
+          .hasSizeGreaterThan(docLimits.maxStringLengthInBytes());
+
+      Exception e = catchException(() -> shredder.shred(doc));
+      assertThat(e)
+          .isNotNull()
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
+          .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
+          .hasMessageEndingWith(
+              " String value length ("
+                  + (tooLongCharLength * 3)
+                  + " bytes) exceeds maximum allowed ("
                   + docLimits.maxStringLengthInBytes()
                   + " bytes)");
     }


### PR DESCRIPTION
**What this PR does**:

Changes validation of max String value length to use UTF-8 encoded byte length, instead of Java characters: this because that's what SAI uses.

**Which issue(s) this PR fixes**:
Fixes #710

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
