### PR TITLE
Add ITs to verify enforcement of "too long number" (InsertMany, FindOneAndUpdate, -Replace)

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
@@ -689,7 +689,7 @@ public class FindOneAndReplaceIntegrationTest extends AbstractCollectionIntegrat
   @Order(3)
   class FindOneAndReplaceFailing {
     @Test
-    public void byIdWithDifferentId() {
+    public void tryReplaceWithTooLongNumber() {
       String document =
           """
                 {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -686,6 +687,52 @@ public class FindOneAndReplaceIntegrationTest extends AbstractCollectionIntegrat
 
   @Nested
   @Order(3)
+  class FindOneAndReplaceFailing {
+    @Test
+    public void byIdWithDifferentId() {
+      String document =
+          """
+                {
+                  "_id": "tooLongNumber1",
+                  "value" : 123
+                }
+                """;
+      insertDoc(document);
+
+      // Max number length: 50; use 100
+      String tooLongNumStr = "1234567890".repeat(10);
+      String json =
+          """
+                {
+                  "findOneAndReplace": {
+                    "filter" : {"_id" : "tooLongNumber1"},
+                    "replacement" : {
+                        "_id" : "tooLongNumber1",
+                        "value" : %s
+                    }
+                  }
+                }
+                """
+              .formatted(tooLongNumStr);
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data", is(nullValue()))
+          .body("status", is(nullValue()))
+          .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
+          .body(
+              "errors[0].message",
+              startsWith("Document size limitation violated: Number value length"));
+    }
+  }
+
+  @Nested
+  @Order(99)
   class Metrics {
     @Test
     public void checkMetrics() {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateIntegrationTest.java
@@ -975,7 +975,7 @@ public class FindOneAndUpdateIntegrationTest extends AbstractCollectionIntegrati
     }
 
     @Test
-    public void updateWithTooLongNumber() {
+    public void tryUpdateWithTooLongNumber() {
       insertDoc(
           """
                       {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateIntegrationTest.java
@@ -973,6 +973,44 @@ public class FindOneAndUpdateIntegrationTest extends AbstractCollectionIntegrati
           .statusCode(200)
           .body("data.documents[0]", jsonEquals(inputDoc));
     }
+
+    @Test
+    public void updateWithTooLongNumber() {
+      insertDoc(
+          """
+                      {
+                        "_id": "update_doc_too_long_number",
+                        "value": 123
+                      }
+                      """);
+
+      // Max number length: 50; use 100
+      String tooLongNumStr = "1234567890".repeat(10);
+      String json =
+          """
+                      {
+                        "findOneAndUpdate": {
+                          "filter" : {"_id" : "update_doc_too_long_number"},
+                          "update" : {"$set" : {"value": %s}}
+                        }
+                      }
+                      """
+              .formatted(tooLongNumStr);
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data", is(nullValue()))
+          .body("status", is(nullValue()))
+          .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
+          .body(
+              "errors[0].message",
+              startsWith("Document size limitation violated: Number value length"));
+    }
   }
 
   @Nested
@@ -1794,7 +1832,7 @@ public class FindOneAndUpdateIntegrationTest extends AbstractCollectionIntegrati
   }
 
   @Nested
-  @Order(8)
+  @Order(99)
   class Metrics {
     @Test
     public void checkMetrics() {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -1372,6 +1372,49 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
   }
 
   @Nested
+  @Order(4)
+  class InsertManyFailing {
+    @Test
+    public void tryInsertTooLongNumber() {
+      // Max number length: 50; use 60
+      String tooLongNumStr = "1234567890".repeat(6);
+
+      String json =
+          """
+              {
+                "insertMany": {
+                  "documents": [
+                    {
+                      "_id": "manyTooLong1",
+                      "value": 123
+                    },
+                    {
+                      "_id": "manyTooLong2",
+                       "value": %s
+                    }
+                  ]
+                }
+              }
+              """
+              .formatted(tooLongNumStr);
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data", is(nullValue()))
+          .body(
+              "errors[0].message",
+              startsWith("Document size limitation violated: Number value length"))
+          .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"));
+    }
+  }
+
+  @Nested
   @Order(99)
   class Metrics {
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -1376,8 +1376,8 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
   class InsertManyFailing {
     @Test
     public void tryInsertTooLongNumber() {
-      // Max number length: 50; use 60
-      String tooLongNumStr = "1234567890".repeat(6);
+      // Max number length: 50; use 100
+      String tooLongNumStr = "1234567890".repeat(10);
 
       String json =
           """


### PR DESCRIPTION
**What this PR does**:

Adds integration tests for remaining insert/update operations, beyond `InsertOne` which is already covered.

**Which issue(s) this PR fixes**:
Fixes #724

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
