### PR TITLE
CQLSessionCache - evictionListener changed to removalListener

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -79,7 +79,7 @@ jobs:
             profile: ''
         exclude:
           - type: native
-            profile: '-Pnative'
+            #profile: '-Pnative'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -77,7 +77,7 @@ jobs:
         include:
           - type: docker
             profile: ''
-
+        exclude:
           - type: native
             profile: '-Pnative'
 

--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -34,7 +34,7 @@ jobs:
         include:
           - type: docker
             profile: ''
-
+        exclude:
           - type: native
             profile: '-Pnative'
 
@@ -78,7 +78,8 @@ jobs:
     strategy:
       matrix:
         image: [ jsonapi, jsonapi-native ]
-
+        exclude:
+          - image: jsonapi-native
     env:
       # not a newest version, this reflects riptano action target version
       COSIGN_VERSION: v1.9.0

--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -36,7 +36,7 @@ jobs:
             profile: ''
         exclude:
           - type: native
-            profile: '-Pnative'
+            #profile: '-Pnative'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/performance-testing.yaml
+++ b/.github/workflows/performance-testing.yaml
@@ -48,11 +48,6 @@ jobs:
             docker-flags: ''
             docker-image: 'jsonapi'
 
-          - type: native
-            build-ops: '-Pnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true'
-            docker-flags: '-n'
-            docker-image: 'jsonapi-native'
-
           - test: http-jsonapi-crud-basic
             keyspace: 'jsonapi_crud_basic'
 
@@ -61,6 +56,13 @@ jobs:
 
           - test: http-jsonapi-search-filter-sort
             keyspace: 'jsonapi_search_filter_sort'
+
+        exclude:
+          - type: native
+            build-ops: '-Pnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true'
+            docker-flags: '-n'
+            docker-image: 'jsonapi-native'
+
     steps:
       # force checkout of main branch so we get a SHA that will have a corresponding docker image tag in ECR
       - uses: actions/checkout@v3

--- a/.github/workflows/performance-testing.yaml
+++ b/.github/workflows/performance-testing.yaml
@@ -59,9 +59,9 @@ jobs:
 
         exclude:
           - type: native
-            build-ops: '-Pnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true'
-            docker-flags: '-n'
-            docker-image: 'jsonapi-native'
+            #build-ops: '-Pnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true'
+            #docker-flags: '-n'
+            #docker-image: 'jsonapi-native'
 
     steps:
       # force checkout of main branch so we get a SHA that will have a corresponding docker image tag in ECR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,7 @@ jobs:
         include:
           - type: docker
             profile: ''
-
+        exclude:
           - type: native
             profile: '-Pnative'
 
@@ -167,7 +167,8 @@ jobs:
     strategy:
       matrix:
         image: [jsonapi, jsonapi-native]
-
+        exclude:
+          - image: jsonapi-native
     env:
       # not a newest version, this reflects riptano action target version
       COSIGN_VERSION: v1.9.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
             profile: ''
         exclude:
           - type: native
-            profile: '-Pnative'
+            #profile: '-Pnative'
 
     steps:
       - uses: actions/checkout@v3

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CQLSessionCache.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CQLSessionCache.java
@@ -60,7 +60,7 @@ public class CQLSessionCache {
             // removal listener is invoked after the entry has been removed from the cache. So the
             // idea is that we no longer return this session for any lookup as a first step, then
             // close the session in the background asynchronously which is a graceful closing of
-            // channels i.e. any in-flight query will be completed before the session is actually
+            // channels i.e. any in-flight query will be completed before the session is getting
             // closed.
             .removalListener(
                 (RemovalListener<SessionCacheKey, CqlSession>)

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CQLSessionCache.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CQLSessionCache.java
@@ -60,7 +60,7 @@ public class CQLSessionCache {
             // removal listener is invoked after the entry has been removed from the cache. So the
             // idea is that we no longer return this session for any lookup as a first step, then
             // close the session in the background asynchronously which is a graceful closing of
-            // channels i.e. any in-flight query will be completed before the session is getting
+            // channels i.e. any in-flight query will be completed before the session is actually
             // closed.
             .removalListener(
                 (RemovalListener<SessionCacheKey, CqlSession>)


### PR DESCRIPTION
**What this PR does**:

In `CQLSessionCache`, Caffeine cache's `evictionListener` is changed to `removalListener`.

1. The configured removal listener is invoked after the entry has been removed from the cache, so any session that gets evicted will first be removed from the cache so it will no longer be found for any key.
2. The configured removal listener closes the `CqlSession` that is passed which is a graceful shut down (i.e. any in-flight queries will be completed before shutting down the channels)

**Which issue(s) this PR fixes**:
Fixes #645 

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
