### PR TITLE
Setting ignore bridge flag to true by default

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,9 @@
 
 stargate:
 
+  data-store:
+    ignore-bridge: true
+
   database:
     limits:
       max-collections: 5


### PR DESCRIPTION
**What this PR does**:
Since the JSON API backend is changed to use cql driver instead of gRPC bridge service on the coordinator, setting the `stargate.data-store.ignore-bridge` flag to true by default will make it not to try to connect to the gRPC bridge service during the startup to get the database features and instead of that it will be returned from the configuration properties.


**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
