### PR TITLE
Fix C2-3155: include actual property name that is too long in exception message

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -317,10 +317,11 @@ public class Shredder {
       throw new JsonApiException(
           ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
           String.format(
-              "%s: Property name length (%d) exceeds maximum allowed (%s)",
+              "%s: Property name length (%d) exceeds maximum allowed (%s) (name '%s')",
               ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
               key.length(),
-              limits.maxPropertyNameLength()));
+              limits.maxPropertyNameLength(),
+              key));
     }
     if (key.length() == 0) {
       // NOTE: validity failure, not size limit

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -610,7 +610,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
           .body(
               "errors[0].message",
-              is(
+              startsWith(
                   "Document size limitation violated: Property name length (50) exceeds maximum allowed (48)"));
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -236,7 +236,10 @@ public class ShredderDocLimitsTest {
                   + propName.length()
                   + ") exceeds maximum allowed ("
                   + docLimits.maxPropertyNameLength()
-                  + ")");
+                  + ") (name '"
+                  + propName
+                  + "')");
+      ;
     }
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Includes property name that violates maximum property name length limit in the exception message

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
