### PR TITLE
Set json format logging as the default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-logging-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -113,3 +113,9 @@ quarkus:
     # Adding com.datastax.oss.driver.internal.core.metadata.MetadataManager to the list of classes that are initialized
     # at run time while building the native image. This is for the issue https://github.com/stargate/jsonapi/issues/597
     additional-build-args: --initialize-at-run-time=com.datastax.oss.driver.internal.core.metadata.MetadataManager
+
+"%dev":
+   quarkus:
+     log:
+       console:
+         json: false


### PR DESCRIPTION
**What this PR does**:
Set json format logging as the default and the formatted string format for dev profile

Below will be the new log format for the non dev profiles
```
{"timestamp":"2023-12-21T07:58:12.44+05:30","sequence":3412,"loggerClassName":"org.jboss.logging.Logger","loggerName":"io.quarkus.grpc.runtime.supports.Channels","level":"INFO","message":"Creating Netty gRPC channel ...","threadName":"Quarkus Main Thread","threadId":159,"mdc":{},"ndc":"","hostName":"kathiresan-selvaraj-c02gj191md6r","processName":"sgv2-jsonapi-dev.jar","processId":3317}
{"timestamp":"2023-12-21T07:58:12.464+05:30","sequence":3413,"loggerClassName":"org.slf4j.impl.Slf4jLogger","loggerName":"io.stargate.sgv2.api.common.properties.datastore.configuration.DataStorePropertiesConfiguration","level":"INFO","message":"DataStoreConfig.ignoreBridge() == true, will use pre-configured defaults","threadName":"Quarkus Main Thread","threadId":159,"mdc":{},"ndc":"","hostName":"kathiresan-selvaraj-c02gj191md6r","processName":"sgv2-jsonapi-dev.jar","processId":3317}
{"timestamp":"2023-12-21T07:58:12.551+05:30","sequence":3414,"loggerClassName":"org.jboss.logging.Logger","loggerName":"io.quarkus","level":"INFO","message":"Stargate JSON API 1.0.0-BETA-6-SNAPSHOT on JVM (powered by Quarkus 3.2.6.Final) started in 3.806s. Listening on: http://localhost:8181","threadName":"Quarkus Main Thread","threadId":159,"mdc":{},"ndc":"","hostName":"kathiresan-selvaraj-c02gj191md6r","processName":"sgv2-jsonapi-dev.jar","processId":3317}
```

instead of 
```
INFO  [Quarkus Main Thread] 2023-12-21 07:56:10,483 Channels.java:241 - Creating Netty gRPC channel ...
INFO  [Quarkus Main Thread] 2023-12-21 07:56:10,504 DataStorePropertiesConfiguration.java:56 - DataStoreConfig.ignoreBridge() == true, will use pre-configured defaults
INFO  [Quarkus Main Thread] 2023-12-21 07:56:10,581 Timing.java:109 - Stargate JSON API 1.0.0-BETA-6-SNAPSHOT on JVM (powered by Quarkus 3.2.6.Final) started in 3.791s. Listening on: http://localhost:8181
```


**Which issue(s) this PR fixes**:
Fixes #747 

**Checklist**
- [X] Changes manually tested
- [X] Automated Tests added/updated
- [X] Documentation added/updated
- [X] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
