### PR TITLE
Fixes #653: enable fast(er) parsing/writing of Doubles, BigDecimals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <stargate.version>${project.parent.version}</stargate.version>
     <!-- 17-May-2023, tatu: [json-api#172] Need at least Jackson 2.15.x -->
     <!-- 16-Nov-2023, tatu: but may use 2.16 now that it's available -->
-    <jackson.version>2.16.0</jackson.version>
+    <jackson.version>2.16.1</jackson.version>
     <failsafe.useModulePath>false</failsafe.useModulePath>
     <!-- Please update github workflows that build docker images if changing image/additional tags -->
     <quarkus.container-image.group>stargateio</quarkus.container-image.group>

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfiguration.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfiguration.java
@@ -39,6 +39,9 @@ public class ObjectMapperConfiguration {
         JsonFactory.builder()
             .streamReadConstraints(
                 StreamReadConstraints.builder().maxNumberLength(maxNumLen).build())
+            .enable(StreamReadFeature.USE_FAST_DOUBLE_PARSER)
+            .enable(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER)
+            .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
             .build();
     return JsonMapper.builder(jsonFactory)
         // important for retaining number accuracy!


### PR DESCRIPTION
**What this PR does**:

Enables Jackson read and write options for more optimized reading of floating-point numbers (see https://cowtowncoder.medium.com/jackson-2-16-faster-bigdecimal-reads-b65eb127b899 for more details)

**Which issue(s) this PR fixes**:
Fixes #653

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
