### PR TITLE
Fix #744: increase maximum property name length (48->100), add new path limit (250)

### DIFF
--- a/docs/jsonapi-spec.md
+++ b/docs/jsonapi-spec.md
@@ -385,7 +385,8 @@ nested document or array adds another level.
 
 #### Document Field Limits
 
-The maximum length of a [field name](#json-document-field-names) is 48 characters.
+The maximum length of a [field name](#json-document-field-names) is 100 characters.
+The maximum total Document path length for individual fields (see [Document Paths] section) is 250 characters.
 
 The maximum number of fields allowed in a single JSON object is 64.
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -74,10 +74,9 @@ public interface DocumentLimitsConfig {
 
   /**
    * @return Defines the maximum length of paths to properties in JSON documents, defaults to {@code
-   *     250 characters} (note: length is for individual name segments; full dotted names can be
-   *     longer). Note that this is the total length of the path (sequence of one or more individual
-   *     property names separated by comma): individual property name lengths are limited by {@link
-   *     #maxPropertyNameLength()}.
+   *     250 characters}. Note that this is the total length of the path (sequence of one or more
+   *     individual property names separated by comma): individual property name lengths are limited
+   *     by {@link #maxPropertyNameLength()}.
    */
   @Positive
   @WithDefault("" + DEFAULT_MAX_PROPERTY_PATH_LENGTH)

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -36,8 +36,14 @@ public interface DocumentLimitsConfig {
   /** Defines the default maximum length of a single Number value (in characters) */
   int DEFAULT_MAX_NUMBER_LENGTH = 50;
 
-  /** Defines the maximum length of property names in JSON documents */
-  int DEFAULT_MAX_PROPERTY_NAME_LENGTH = 48;
+  /** Defines the default maximum length of individual property names in JSON documents */
+  int DEFAULT_MAX_PROPERTY_NAME_LENGTH = 100;
+
+  /**
+   * Defines the default maximum total length of path to individual properties JSON documents:
+   * composed of individual Object property names separated by dots (".").
+   */
+  int DEFAULT_MAX_PROPERTY_PATH_LENGTH = 250;
 
   /**
    * Defines the default maximum length of a single String value: 8,000 bytes with 1.0.0-BETA-6 and
@@ -58,12 +64,24 @@ public interface DocumentLimitsConfig {
   int maxDepth();
 
   /**
-   * @return Defines the maximum length of property names in JSON documents, defaults to {@code 48
-   *     characters} (note: length is for individual name segments; full dotted names can be longer)
+   * @return Defines the maximum length of property names in JSON documents, defaults to {@code 100
+   *     characters} (note: length is for individual name segments; full dotted names can be longer,
+   *     see {@link #maxPropertyPathLength()}}
    */
   @Positive
   @WithDefault("" + DEFAULT_MAX_PROPERTY_NAME_LENGTH)
   int maxPropertyNameLength();
+
+  /**
+   * @return Defines the maximum length of paths to properties in JSON documents, defaults to {@code
+   *     250 characters} (note: length is for individual name segments; full dotted names can be
+   *     longer). Note that this is the total length of the path (sequence of one or more individual
+   *     property names separated by comma): individual property name lengths are limited by {@link
+   *     #maxPropertyNameLength()}.
+   */
+  @Positive
+  @WithDefault("" + DEFAULT_MAX_PROPERTY_PATH_LENGTH)
+  int maxPropertyPathLength();
 
   /**
    * @return Defines the maximum number of properties any single Object in JSON document can

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -217,7 +217,7 @@ public class Shredder {
 
     // Second: traverse to check for other constraints
     AtomicInteger totalProperties = new AtomicInteger(0);
-    validateObjectValue(limits, null, doc, 0, totalProperties);
+    validateObjectValue(limits, null, doc, 0, 0, totalProperties);
     if (totalProperties.get() > limits.maxDocumentProperties()) {
       throw new JsonApiException(
           ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
@@ -234,11 +234,14 @@ public class Shredder {
       String referringPropertyName,
       JsonNode value,
       int depth,
+      int parentPathLength,
       AtomicInteger totalProperties) {
     if (value.isObject()) {
-      validateObjectValue(limits, referringPropertyName, value, depth, totalProperties);
+      validateObjectValue(
+          limits, referringPropertyName, value, depth, parentPathLength, totalProperties);
     } else if (value.isArray()) {
-      validateArrayValue(limits, referringPropertyName, value, depth, totalProperties);
+      validateArrayValue(
+          limits, referringPropertyName, value, depth, parentPathLength, totalProperties);
     } else if (value.isTextual()) {
       validateStringValue(limits, value);
     }
@@ -249,6 +252,7 @@ public class Shredder {
       String referringPropertyName,
       JsonNode arrayValue,
       int depth,
+      int parentPathLength,
       AtomicInteger totalProperties) {
     ++depth;
     validateDocDepth(limits, depth);
@@ -278,7 +282,7 @@ public class Shredder {
     }
 
     for (JsonNode element : arrayValue) {
-      validateDocValue(limits, null, element, depth, totalProperties);
+      validateDocValue(limits, null, element, depth, parentPathLength, totalProperties);
     }
   }
 
@@ -287,6 +291,7 @@ public class Shredder {
       String referringPropertyName,
       JsonNode objectValue,
       int depth,
+      int parentPathLength,
       AtomicInteger totalProperties) {
     ++depth;
     validateDocDepth(limits, depth);
@@ -306,13 +311,16 @@ public class Shredder {
     var it = objectValue.fields();
     while (it.hasNext()) {
       var entry = it.next();
-      validateObjectKey(limits, entry.getKey(), entry.getValue(), depth);
-      validateDocValue(limits, entry.getKey(), entry.getValue(), depth, totalProperties);
+      final String key = entry.getKey();
+      validateObjectKey(limits, key, entry.getValue(), depth, parentPathLength);
+      // Path through property consists of segements separated by comma:
+      final int propPathLength = parentPathLength + 1 + key.length();
+      validateDocValue(limits, key, entry.getValue(), depth, propPathLength, totalProperties);
     }
   }
 
   private void validateObjectKey(
-      DocumentLimitsConfig limits, String key, JsonNode value, int depth) {
+      DocumentLimitsConfig limits, String key, JsonNode value, int depth, int parentPathLength) {
     if (key.length() > documentLimits.maxPropertyNameLength()) {
       throw new JsonApiException(
           ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
@@ -346,6 +354,17 @@ public class Shredder {
                 "%s: Property name ('%s') contains character(s) not allowed",
                 ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION.getMessage(), key));
       }
+    }
+    int totalPathLength = parentPathLength + key.length();
+    if (totalPathLength > documentLimits.maxPropertyPathLength()) {
+      throw new JsonApiException(
+          ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
+          String.format(
+              "%s: Property path length (%d) exceeds maximum allowed (%s) (path ends with '%s')",
+              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
+              totalPathLength,
+              limits.maxPropertyPathLength(),
+              key));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -629,29 +629,29 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
       ObjectNode prop2 = prop1.putObject("b".repeat(90));
       prop2.put("c".repeat(90), true);
       final String json =
-              """
+          """
                       {
                         "insertOne": {
                           "document": %s
                         }
                       }
                       """
-                      .formatted(doc);
+              .formatted(doc);
       given()
-              .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-              .contentType(ContentType.JSON)
-              .body(json)
-              .when()
-              .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-              .then()
-              .statusCode(200)
-              .body("errors", hasSize(1))
-              .body("errors[0].exceptionClass", is("JsonApiException"))
-              .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
-              .body(
-                      "errors[0].message",
-                      startsWith(
-                              "Document size limitation violated: Property path length (272) exceeds maximum allowed (250)"));
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("errors", hasSize(1))
+          .body("errors[0].exceptionClass", is("JsonApiException"))
+          .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "Document size limitation violated: Property path length (272) exceeds maximum allowed (250)"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -585,9 +585,11 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
 
     @Test
     public void tryInsertTooLongName() {
-      // Max property name: 48 characters, let's try 50
+      // Max property name: 100 characters, let's try 102
       ObjectNode doc = MAPPER.createObjectNode();
-      doc.put("prop_12345_123456789_123456789_123456789_123456789", 72);
+      doc.put(
+          "prop_12345_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_x",
+          72);
       final String json =
           """
                   {
@@ -611,7 +613,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith(
-                  "Document size limitation violated: Property name length (50) exceeds maximum allowed (48)"));
+                  "Document size limitation violated: Property name length (102) exceeds maximum allowed (100)"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -222,7 +222,7 @@ public class ShredderDocLimitsTest {
       doc.put("_id", 123);
       ObjectNode ob = doc.putObject("subdoc");
       final String propName =
-          "property_with_way_too_long_name_123456789_123456789_123456789_123456789";
+          "property_with_way_too_long_name_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789";
       ob.put(propName, true);
 
       Exception e = catchException(() -> shredder.shred(doc));

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -272,7 +272,7 @@ public class ShredderDocLimitsTest {
           .hasMessageEndingWith(
               " Property path length (259) exceeds maximum allowed ("
                   + docLimits.maxPropertyPathLength()
-                  + ") (name 'longPropertyName')");
+                  + ") (path ends with 'longPropertyName')");
       ;
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -217,6 +217,18 @@ public class ShredderDocLimitsTest {
     }
 
     @Test
+    public void allowNotTooLongPath() {
+      final ObjectNode doc = objectMapper.createObjectNode();
+      // Create 3-levels, 80 chars each, so 242 chars (3 names, 2 dots); below 250 max
+      ObjectNode ob1 = doc.putObject("abcd".repeat(20));
+      ObjectNode ob2 = ob1.putObject("defg".repeat(20));
+      ObjectNode ob3 = ob2.putObject("hijk".repeat(20));
+      // and then one short one, for 244 char total path
+      ob3.put("x", 123);
+      assertThat(shredder.shred(doc)).isNotNull();
+    }
+
+    @Test
     public void catchTooLongNames() {
       final ObjectNode doc = objectMapper.createObjectNode();
       doc.put("_id", 123);
@@ -239,6 +251,28 @@ public class ShredderDocLimitsTest {
                   + ") (name '"
                   + propName
                   + "')");
+      ;
+    }
+
+    @Test
+    public void catchTooLongPaths() {
+      final ObjectNode doc = objectMapper.createObjectNode();
+      // Create 3-levels, 80 chars each, so close to 250; and then one bit longer value
+      ObjectNode ob1 = doc.putObject("abcd".repeat(20));
+      ObjectNode ob2 = ob1.putObject("defg".repeat(20));
+      ObjectNode ob3 = ob2.putObject("hijk".repeat(20));
+      ob3.put("longPropertyName", 123);
+
+      Exception e = catchException(() -> shredder.shred(doc));
+      assertThat(e)
+          .isNotNull()
+          .isInstanceOf(JsonApiException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
+          .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
+          .hasMessageEndingWith(
+              " Property path length (259) exceeds maximum allowed ("
+                  + docLimits.maxPropertyPathLength()
+                  + ") (name 'longPropertyName')");
       ;
     }
 


### PR DESCRIPTION
**What this PR does**:

Increased default limit for maximum property name to 100 (from 48); adds new "total" (path) length limit of 250.

**Which issue(s) this PR fixes**:
Fixes #744

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
