### PR TITLE
Fixes #745: increase max array length limit to 1,000 (from 100)

### DIFF
--- a/docs/jsonapi-spec.md
+++ b/docs/jsonapi-spec.md
@@ -415,7 +415,7 @@ The maximum size of field values are:
 
 #### Document Array Limits
 
-The maximum length of an array is 100 elements.
+The maximum length of an array is 1,000 elements.
 
 ### Equality handling with arrays and subdocs
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -20,7 +20,7 @@ public interface DocumentLimitsConfig {
   int DEFAULT_MAX_DOCUMENT_SIZE = 1_000_000;
 
   /** Defines the default maximum length (in elements) of a single Array value */
-  int DEFAULT_MAX_ARRAY_LENGTH = 100;
+  int DEFAULT_MAX_ARRAY_LENGTH = 1_000;
 
   /**
    * Defines the default maximum number of properties any single Object in JSON document can contain
@@ -101,7 +101,7 @@ public interface DocumentLimitsConfig {
   @WithDefault("" + DEFAULT_MAX_STRING_LENGTH_IN_BYTES)
   int maxStringLengthInBytes();
 
-  /** @return Maximum length of an array. */
+  /** @return Maximum length of an Array in document, defaults to {@code 1,000} elements. */
   @Positive
   @WithDefault("" + DEFAULT_MAX_ARRAY_LENGTH)
   int maxArrayLength();

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -529,7 +529,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
 
     @Test
     public void tryInsertTooBigArray() {
-      // Max array elements allowed is 100; add a few more
+      // Max array elements allowed is 1000; add a few more
       ObjectNode doc = MAPPER.createObjectNode();
       ArrayNode arr = doc.putArray("arr");
       final int ARRAY_LEN = MAX_ARRAY_LENGTH + 10;
@@ -561,7 +561,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
               is(
                   "Document size limitation violated: number of elements an Array has ("
                       + ARRAY_LEN
-                      + ") exceeds maximum allowed (100)"));
+                      + ") exceeds maximum allowed ("+MAX_ARRAY_LENGTH+")"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -561,7 +561,9 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
               is(
                   "Document size limitation violated: number of elements an Array has ("
                       + ARRAY_LEN
-                      + ") exceeds maximum allowed ("+MAX_ARRAY_LENGTH+")"));
+                      + ") exceeds maximum allowed ("
+                      + MAX_ARRAY_LENGTH
+                      + ")"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -175,15 +175,15 @@ public class ShredderDocLimitsTest {
 
     @Test
     public void allowDocWithManyArrayElements() {
-      // Max allowed 100, add 90
-      final ObjectNode doc = docWithNArrayElems("arr", 90);
+      // Max allowed 1000, test:
+      final ObjectNode doc = docWithNArrayElems("arr", docLimits.maxArrayLength());
       assertThat(shredder.shred(doc)).isNotNull();
     }
 
     @Test
     public void catchTooManyArrayElements() {
-      // Let's add 120 elements (max allowed: 100)
-      final ObjectNode doc = docWithNArrayElems("arr", 120);
+      final int arraySizeAboveMax = docLimits.maxArrayLength() + 1;
+      final ObjectNode doc = docWithNArrayElems("arr", arraySizeAboveMax);
       Exception e = catchException(() -> shredder.shred(doc));
       assertThat(e)
           .isNotNull()
@@ -191,7 +191,9 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " number of elements an Array has (120) exceeds maximum allowed ("
+              " number of elements an Array has ("
+                  + arraySizeAboveMax
+                  + ") exceeds maximum allowed ("
                   + docLimits.maxArrayLength()
                   + ")");
     }


### PR DESCRIPTION
**What this PR does**:

Increases limit for maximum array length to 1,000 (from 100)

**Which issue(s) this PR fixes**:
Fixes #745

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
