### PR TITLE
fix: multi filters for one field

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/LogicalExpression.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/LogicalExpression.java
@@ -69,6 +69,16 @@ public class LogicalExpression {
     comparisonExpressions.add(comparisonExpression);
   }
 
+  public void addComparisonExpressions(List<ComparisonExpression> comparisonExpressionList) {
+    for (ComparisonExpression comparisonExpression : comparisonExpressionList) {
+      if (comparisonExpression.getPath().equals(DocumentConstants.Fields.DOC_ID)) {
+        totalIdComparisonExpressionCount++;
+      }
+      totalComparisonExpressionCount++;
+      comparisonExpressions.add(comparisonExpression);
+    }
+  }
+
   public LogicalOperator getLogicalRelation() {
     return logicalRelation;
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/LogicalExpression.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/filter/LogicalExpression.java
@@ -62,6 +62,9 @@ public class LogicalExpression {
   }
 
   public void addComparisonExpression(ComparisonExpression comparisonExpression) {
+    // Two counters totalIdComparisonExpressionCount and totalComparisonExpressionCount
+    // They are for validating the filters
+    // e.g. no more than one ID filter, maximum filter amount
     if (comparisonExpression.getPath().equals(DocumentConstants.Fields.DOC_ID)) {
       totalIdComparisonExpressionCount++;
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializer.java
@@ -84,7 +84,7 @@ public class FilterClauseDeserializer extends StdDeserializer<FilterClause> {
       LogicalExpression logicalExpression, Map.Entry<String, JsonNode> entry) {
     if (entry.getValue().isObject()) {
       // inside of this entry, only implicit and, no explicit $and/$or
-      logicalExpression.addComparisonExpression(createComparisonExpression(entry));
+      logicalExpression.addComparisonExpressions(createComparisonExpressionList(entry));
     } else if (entry.getValue().isArray()) {
       LogicalExpression innerLogicalExpression = null;
       switch (entry.getKey()) {
@@ -242,9 +242,9 @@ public class FilterClauseDeserializer extends StdDeserializer<FilterClause> {
    * @param entry
    * @return
    */
-  private ComparisonExpression createComparisonExpression(Map.Entry<String, JsonNode> entry) {
-    ComparisonExpression expression =
-        new ComparisonExpression(entry.getKey(), new ArrayList<>(), null);
+  private List<ComparisonExpression> createComparisonExpressionList(
+      Map.Entry<String, JsonNode> entry) {
+    final List<ComparisonExpression> comparisonExpressionList = new ArrayList<>();
     // Check if the value is EJson date and add filter expression for date filter
     final Iterator<Map.Entry<String, JsonNode>> fields = entry.getValue().fields();
     while (fields.hasNext()) {
@@ -266,8 +266,10 @@ public class FilterClauseDeserializer extends StdDeserializer<FilterClause> {
                     "%s: filter clause path ('%s') contains character(s) not allowed",
                     ErrorCode.INVALID_FILTER_EXPRESSION.getMessage(), entry.getKey()));
           }
-          return ComparisonExpression.eq(
-              entry.getKey(), jsonNodeValue(entry.getKey(), entry.getValue()));
+          comparisonExpressionList.add(
+              ComparisonExpression.eq(
+                  entry.getKey(), jsonNodeValue(entry.getKey(), entry.getValue())));
+          return comparisonExpressionList;
         }
       }
       // if the key does not match pattern or the entry is not ($vector and $exist operator)
@@ -296,9 +298,12 @@ public class FilterClauseDeserializer extends StdDeserializer<FilterClause> {
                   operator.getOperator()));
         }
       }
+      ComparisonExpression expression =
+          new ComparisonExpression(entry.getKey(), new ArrayList<>(), null);
       expression.add(operator, valueObject);
+      comparisonExpressionList.add(expression);
     }
-    return expression;
+    return comparisonExpressionList;
   }
 
   /**

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializerTest.java
@@ -551,6 +551,53 @@ public class FilterClauseDeserializerTest {
     }
 
     @Test
+    public void mustHandleMultiFilterWithOneField() throws Exception {
+      String json =
+          """
+                {
+                   "name": {
+                       "$ne": "Tim",
+                       "$exists": true
+                   }
+                }
+              """;
+      final ComparisonExpression expectedResult1 =
+          new ComparisonExpression(
+              "name",
+              List.of(
+                  new ValueComparisonOperation(
+                      ValueComparisonOperator.NE, new JsonLiteral("Tim", JsonType.STRING))),
+              null);
+
+      final ComparisonExpression expectedResult2 =
+          new ComparisonExpression(
+              "name",
+              List.of(
+                  new ValueComparisonOperation(
+                      ElementComparisonOperator.EXISTS, new JsonLiteral(true, JsonType.BOOLEAN))),
+              null);
+
+      FilterClause filterClause = objectMapper.readValue(json, FilterClause.class);
+      assertThat(filterClause.logicalExpression().logicalExpressions).hasSize(0);
+      assertThat(filterClause.logicalExpression().comparisonExpressions).hasSize(2);
+      assertThat(
+              filterClause.logicalExpression().comparisonExpressions.get(0).getFilterOperations())
+          .isEqualTo(expectedResult1.getFilterOperations());
+      assertThat(filterClause.logicalExpression().comparisonExpressions.get(0).getPath())
+          .isEqualTo(expectedResult1.getPath());
+      assertThat(
+              filterClause
+                  .logicalExpression()
+                  .comparisonExpressions
+                  .get(1)
+                  .getFilterOperations()
+                  .get(0))
+          .isEqualTo(expectedResult2.getFilterOperations().get(0));
+      assertThat(filterClause.logicalExpression().comparisonExpressions.get(1).getPath())
+          .isEqualTo(expectedResult2.getPath());
+    }
+
+    @Test
     public void mustHandleIdFieldIn() throws Exception {
       String json = """
                {"_id" : {"$in": ["2", "3"]}}


### PR DESCRIPTION
Bug:
If a query run with multiple filter for the same field it's not resolved correctly.
Query {"find":{"filter":{"product_price":{"$ne":9.99, "$exists" : true}}}}, only one of the condition is resolved to filter. 

Solved by adding additional ComparisonExpression.

**Which issue(s) this PR fixes**:
Fixes[ #<763>](https://github.com/stargate/jsonapi/issues/763)

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
