### PR TITLE
Fixes #776: Update max object, document properties limits

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -25,13 +25,13 @@ public interface DocumentLimitsConfig {
   /**
    * Defines the default maximum number of properties any single Object in JSON document can contain
    */
-  int DEFAULT_MAX_OBJECT_PROPERTIES = 64;
+  int DEFAULT_MAX_OBJECT_PROPERTIES = 1000;
 
   /**
    * Defines the default maximum number of properties the whole JSON document can contain (including
    * Object- and Array-valued properties).
    */
-  int DEFAULT_MAX_DOC_PROPERTIES = 1000;
+  int DEFAULT_MAX_DOC_PROPERTIES = 2000;
 
   /** Defines the default maximum length of a single Number value (in characters) */
   int DEFAULT_MAX_NUMBER_LENGTH = 50;
@@ -84,7 +84,7 @@ public interface DocumentLimitsConfig {
 
   /**
    * @return Defines the maximum number of properties any single Object in JSON document can
-   *     contain, defaults to {@code 64} (note: this is not the total number of properties in the
+   *     contain, defaults to {@code 1,000} (note: this is not the total number of properties in the
    *     whole document, only on individual main or sub-document)
    */
   @Positive
@@ -93,16 +93,15 @@ public interface DocumentLimitsConfig {
 
   /**
    * @return Defines the maximum number of properties the whole JSON document can contain, defaults
-   *     to {@code 1000}, including Object- and Array-valued properties.
+   *     to {@code 2,000}, including Object- and Array-valued properties.
    */
   @Positive
   @WithDefault("" + DEFAULT_MAX_DOC_PROPERTIES)
   int maxDocumentProperties();
 
   /**
-   * @return Defines the max size of filter fields, defaults to {@code 64}, which is tha same as the
-   *     maximum number of properties of a single Json object. (note: this does not count the fields
-   *     in '$operation' such as $in, $all)
+   * @return Defines the max size of filter fields, defaults to {@code 64}. (note: this does not
+   *     count the fields in '$operation' such as $in, $all)
    */
   @Positive
   @WithDefault("" + DEFAULT_MAX_FILTER_SIZE)

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -829,10 +829,10 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
       final ObjectNode tooManyPropsDoc = MAPPER.createObjectNode();
       tooManyPropsDoc.put("_id", 123);
 
-      // About 1200, just needs to be above 1000
+      // About 2100, just needs to be above 2000
       for (int i = 0; i < 40; ++i) {
         ObjectNode branch = tooManyPropsDoc.putObject("root" + i);
-        for (int j = 0; j < 30; ++j) {
+        for (int j = 0; j < 51; ++j) {
           branch.put("prop" + j, j);
         }
       }
@@ -861,7 +861,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith("Document size limitation violated: total number of properties ("))
-          .body("errors[0].message", endsWith(" in document exceeds maximum allowed (1000)"));
+          .body("errors[0].message", endsWith(" in document exceeds maximum allowed (2000)"));
     }
 
     private void _verifyInsert(String docId, JsonNode doc) {
@@ -917,12 +917,12 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
       boolean bigEnough = false;
 
       // Since we add one property before loop, reduce max by 1.
-      // Target is around 1 meg; can have at most 1000 properties, and for
+      // Target is around 1 meg; can have at most 2000 properties, and for
       // big doc we don't want to exceed 1000 bytes per property.
       // So let's make properties arrays of 4 Strings to get there.
-      final int ROOT_PROPS = DocumentLimitsConfig.DEFAULT_MAX_OBJECT_PROPERTIES - 1;
-      final int LEAF_PROPS = 15; // so it's slightly under 1000 total properties, max
-      final String TEXT_2K = "abcd123 ".repeat(120); // 960 chars
+      final int ROOT_PROPS = 99;
+      final int LEAF_PROPS = 20; // so it's slightly under 2000 total properties, max
+      final String TEXT_1K = "abcd123 ".repeat(120); // 960 chars
 
       // Use double loop to create a document with a lot of properties, 2-level nesting
       for (int i = 0; i < ROOT_PROPS && !bigEnough; ++i) {
@@ -932,10 +932,10 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
         for (int j = 0; j < LEAF_PROPS && !bigEnough; ++j) {
           sb.append(",\n \"sub").append(j).append("\":");
           sb.append('[');
-          sb.append('"').append(TEXT_2K).append("\",");
-          sb.append('"').append(TEXT_2K).append("\",");
-          sb.append('"').append(TEXT_2K).append("\",");
-          sb.append('"').append(TEXT_2K).append("\"");
+          sb.append('"').append(TEXT_1K).append("\",");
+          sb.append('"').append(TEXT_1K).append("\",");
+          sb.append('"').append(TEXT_1K).append("\",");
+          sb.append('"').append(TEXT_1K).append("\"");
           sb.append(']');
           bigEnough = sb.length() >= minDocSize;
         }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -111,15 +111,17 @@ public class ShredderDocLimitsTest {
   class ValidationDocCountViolations {
     @Test
     public void allowDocWithManyObjectProps() {
-      // Max allowed is 64, so add 50
-      final ObjectNode doc = docWithNProps(50);
+      // Max allowed is 1,000
+      final ObjectNode doc = docWithNProps(docLimits.maxObjectProperties());
       assertThat(shredder.shred(doc)).isNotNull();
     }
 
     @Test
     public void catchTooManyObjectProps() {
-      // Max allowed 64, so fail with 100
-      final ObjectNode doc = docWithNProps(100);
+      // Max allowed 100, so fail with just one above
+      final int maxObProps = docLimits.maxObjectProperties();
+      final int tooManyProps = maxObProps + 1;
+      final ObjectNode doc = docWithNProps(tooManyProps);
 
       Exception e = catchException(() -> shredder.shred(doc));
       assertThat(e)
@@ -128,8 +130,10 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " number of properties an Object has (100) exceeds maximum allowed ("
-                  + docLimits.maxObjectProperties()
+              " number of properties an Object has ("
+                  + tooManyProps
+                  + ") exceeds maximum allowed ("
+                  + maxObProps
                   + ")");
     }
 
@@ -145,8 +149,8 @@ public class ShredderDocLimitsTest {
 
     @Test
     public void catchTooManyDocProps() {
-      // Max allowed 1000, create one with ~1200
-      final ObjectNode doc = docWithNestedProps(40, 30);
+      // Max allowed 2000, create one with bit more
+      final ObjectNode doc = docWithNestedProps(50, 41);
 
       Exception e = catchException(() -> shredder.shred(doc));
       assertThat(e)
@@ -155,7 +159,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " total number of properties (1241) in document exceeds maximum allowed ("
+              " total number of properties (2101) in document exceeds maximum allowed ("
                   + docLimits.maxDocumentProperties()
                   + ")");
     }


### PR DESCRIPTION
**What this PR does**:

Increases limits for max object properties (64 -> 1,000) and max document properties (1,000 -> 2,000)

**Which issue(s) this PR fixes**:
Fixes #776

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
