### PR TITLE
Change the InsertManyCommand.Options.ordered to false as default

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/InsertManyCommand.java
@@ -37,6 +37,6 @@ public record InsertManyCommand(
       @Schema(
               description =
                   "When `true` the server will insert the documents in sequential order, ensuring each document is successfully inserted before starting the next. Additionally the command will \"fail fast\", failing the first document that fails to insert. When `false` the server is free to re-order the inserts and parallelize them for performance. In this mode more than one document may fail to be inserted (aka \"fail silently\" mode).",
-              defaultValue = "true")
-          Boolean ordered) {}
+              defaultValue = "false")
+          boolean ordered) {}
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperation.java
@@ -28,7 +28,7 @@ public record InsertOperation(
     implements ModifyOperation {
 
   public InsertOperation(CommandContext commandContext, WritableShreddedDocument document) {
-    this(commandContext, List.of(document), true);
+    this(commandContext, List.of(document), false);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertManyCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertManyCommandResolver.java
@@ -40,7 +40,8 @@ public class InsertManyCommandResolver implements CommandResolver<InsertManyComm
 
     // resolve ordered
     InsertManyCommand.Options options = command.options();
-    boolean ordered = null == options || !Boolean.FALSE.equals(options.ordered());
+
+    boolean ordered = null != options && Boolean.TRUE.equals(options.ordered());
 
     return new InsertOperation(ctx, shreddedDocuments, ordered);
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/ObjectMapperConfigurationTest.java
@@ -662,6 +662,7 @@ class ObjectMapperConfigurationTest {
                 assertThat(documents).hasSize(2);
                 final InsertManyCommand.Options options = insertManyCommand.options();
                 assertThat(options).isNotNull();
+                assertThat(options.ordered()).isFalse();
               });
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -1033,7 +1033,10 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
                   "_id": "doc5",
                   "username": "user5"
                 }
-              ]
+              ],
+              "options" : {
+                "ordered" : true
+              }
             }
           }
           """;
@@ -1089,7 +1092,10 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
                   "_id": "doc5",
                   "username": "user5"
                 }
-              ]
+              ],
+              "options" : {
+                "ordered" : true
+              }
             }
           }
           """;

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -397,7 +397,10 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
                                 "description": "Vision Vector Frame', 'A deep learning display that controls your mood",
                                 "$vector": [0.12, 0.05, 0.08, 0.32, 0.6]
                               }
-                            ]
+                            ],
+                            "options" : {
+                              "ordered" : true
+                            }
                          }
                       }
                       """;

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorizeSearchIntegrationTest.java
@@ -205,7 +205,10 @@ public class VectorizeSearchIntegrationTest extends AbstractNamespaceIntegration
                   "description": "A deep learning display that controls your mood",
                   "$vectorize": "A deep learning display that controls your mood"
                 }
-              ]
+              ],
+              "options" : {
+                "ordered" : true
+              }
            }
         }
         """;

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertManyCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertManyCommandResolverTest.java
@@ -64,7 +64,7 @@ public class InsertManyCommandResolverTest {
                 WritableShreddedDocument second = shredder.shred(command.documents().get(1));
 
                 assertThat(op.commandContext()).isEqualTo(commandContext);
-                assertThat(op.ordered()).isTrue();
+                assertThat(op.ordered()).isFalse();
                 assertThat(op.documents()).containsExactly(first, second);
               });
     }
@@ -102,7 +102,7 @@ public class InsertManyCommandResolverTest {
                 WritableShreddedDocument second = shredder.shred(command.documents().get(1));
 
                 assertThat(op.commandContext()).isEqualTo(commandContext);
-                assertThat(op.ordered()).isTrue();
+                assertThat(op.ordered()).isFalse();
                 assertThat(op.documents()).containsExactly(first, second);
               });
     }
@@ -144,7 +144,7 @@ public class InsertManyCommandResolverTest {
                 assertThat(second.queryVectorValues()).containsExactly(0.25f, 0.25f, 0.25f);
                 assertThat(op.commandContext())
                     .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
-                assertThat(op.ordered()).isTrue();
+                assertThat(op.ordered()).isFalse();
                 assertThat(op.documents()).containsExactly(first, second);
               });
     }
@@ -182,7 +182,7 @@ public class InsertManyCommandResolverTest {
                 WritableShreddedDocument second = shredder.shred(command.documents().get(1));
 
                 assertThat(op.commandContext()).isEqualTo(commandContext);
-                assertThat(op.ordered()).isTrue();
+                assertThat(op.ordered()).isFalse();
                 assertThat(op.documents()).containsExactly(first, second);
               });
     }
@@ -204,7 +204,7 @@ public class InsertManyCommandResolverTest {
                 }
               ],
               "options": {
-                "ordered": false
+                "ordered": true
               }
             }
           }
@@ -221,7 +221,7 @@ public class InsertManyCommandResolverTest {
                 WritableShreddedDocument second = shredder.shred(command.documents().get(1));
 
                 assertThat(op.commandContext()).isEqualTo(commandContext);
-                assertThat(op.ordered()).isFalse();
+                assertThat(op.ordered()).isTrue();
                 assertThat(op.documents()).containsExactly(first, second);
               });
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertOneCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertOneCommandResolverTest.java
@@ -57,7 +57,7 @@ class InsertOneCommandResolverTest {
                 WritableShreddedDocument expected = shredder.shred(command.document());
 
                 assertThat(op.commandContext()).isEqualTo(commandContext);
-                assertThat(op.ordered()).isTrue();
+                assertThat(op.ordered()).isFalse();
                 assertThat(op.documents()).singleElement().isEqualTo(expected);
               });
     }
@@ -86,7 +86,7 @@ class InsertOneCommandResolverTest {
                 WritableShreddedDocument expected = shredder.shred(command.document());
 
                 assertThat(op.commandContext()).isEqualTo(commandContext);
-                assertThat(op.ordered()).isTrue();
+                assertThat(op.ordered()).isFalse();
                 assertThat(op.documents()).singleElement().isEqualTo(expected);
               });
     }
@@ -118,7 +118,7 @@ class InsertOneCommandResolverTest {
                 assertThat(expected.queryVectorValues()).containsExactly(0.25f, 0.25f, 0.25f);
                 assertThat(op.commandContext())
                     .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
-                assertThat(op.ordered()).isTrue();
+                assertThat(op.ordered()).isFalse();
                 assertThat(op.documents()).singleElement().isEqualTo(expected);
               });
     }


### PR DESCRIPTION
**What this PR does**:
Change the InsertManyCommand.Options.ordered to false as default

**Which issue(s) this PR fixes**:
Fixes #761 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
