### PR TITLE
Add no-index support for Shredder (part 1)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandContext.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/CommandContext.java
@@ -7,6 +7,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateClause;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
 import io.stargate.sgv2.jsonapi.service.embedding.DataVectorizer;
 import io.stargate.sgv2.jsonapi.service.embedding.operation.EmbeddingService;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import java.util.List;
 
 /**
@@ -14,21 +15,21 @@ import java.util.List;
  *
  * @param namespace The name of the namespace.
  * @param collection The name of the collection.
- * @param isVectorEnabled Whether the vector is enabled for the collection
- * @param similarityFunction The similarity function used for indexing the vector
+ * @param collectionSettings Settings for the collection, if Collection-specific command; if not,
+ *     "empty" Settings {see CollectionSettings#empty()}.
  */
 public record CommandContext(
     String namespace,
     String collection,
-    boolean isVectorEnabled,
-    CollectionSettings.SimilarityFunction similarityFunction,
+    CollectionSettings collectionSettings,
     EmbeddingService embeddingService) {
 
   public CommandContext(String namespace, String collection) {
-    this(namespace, collection, false, null, null);
+    this(namespace, collection, CollectionSettings.empty(), null);
   }
 
-  private static final CommandContext EMPTY = new CommandContext(null, null, false, null, null);
+  private static final CommandContext EMPTY =
+      new CommandContext(null, null, CollectionSettings.empty(), null);
 
   /**
    * @return Returns empty command context, having both {@link #namespace} and {@link #collection}
@@ -36,6 +37,18 @@ public record CommandContext(
    */
   public static CommandContext empty() {
     return EMPTY;
+  }
+
+  public CollectionSettings.SimilarityFunction similarityFunction() {
+    return collectionSettings.similarityFunction();
+  }
+
+  public boolean isVectorEnabled() {
+    return collectionSettings.vectorEnabled();
+  }
+
+  public DocumentProjector indexingProjector() {
+    return collectionSettings.indexingProjector();
   }
 
   public void tryVectorize(JsonNodeFactory nodeFactory, List<JsonNode> documents) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResource.java
@@ -179,12 +179,7 @@ public class CollectionResource {
                 }
 
                 CommandContext commandContext =
-                    new CommandContext(
-                        namespace,
-                        collection,
-                        collectionProperty.vectorEnabled(),
-                        collectionProperty.similarityFunction(),
-                        embeddingService);
+                    new CommandContext(namespace, collection, collectionProperty, embeddingService);
 
                 // call processor
                 return meteredCommandProcessor.processCommand(commandContext, command);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperation.java
@@ -174,7 +174,11 @@ public record ReadAndUpdateOperation(
               }
 
               final WritableShreddedDocument writableShreddedDocument =
-                  shredder().shred(documentUpdaterResponse.document(), readDocument.txnId());
+                  shredder()
+                      .shred(
+                          documentUpdaterResponse.document(),
+                          readDocument.txnId(),
+                          commandContext().indexingProjector());
 
               // Have to do this because shredder adds _id field to the document if it doesn't exist
               JsonNode updatedDocument = writableShreddedDocument.docJsonNode();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -82,17 +82,17 @@ public class DocumentProjector {
         return identityProjector();
       }
       // Case 1: inclusion-based projection
-      return new DocumentProjector(ProjectionLayer.buildLayers(allowed, null, false), true, false);
+      return new DocumentProjector(ProjectionLayer.buildLayersOverlapOk(allowed), true, false);
     }
     if (denied != null && !denied.isEmpty()) {
       // (special) Case 4:
       if (denied.size() == 1 && denied.contains("*")) {
         // Basically inclusion projector with nothing to include
         return new DocumentProjector(
-            ProjectionLayer.buildLayers(Collections.emptySet(), null, false), true, false);
+            ProjectionLayer.buildLayersOverlapOk(Collections.emptySet()), true, false);
       }
       // Case 2: exclusion-based projection
-      return new DocumentProjector(ProjectionLayer.buildLayers(denied, null, false), false, false);
+      return new DocumentProjector(ProjectionLayer.buildLayersOverlapOk(denied), false, false);
     }
     // Case 3: include-all (identity) projection
     return identityProjector();
@@ -186,13 +186,13 @@ public class DocumentProjector {
       if (inclusions > 0) { // inclusion-based projection
         // doc-id included unless explicitly excluded
         return new DocumentProjector(
-            ProjectionLayer.buildLayers(paths, slices, !Boolean.FALSE.equals(idInclusion)),
+            ProjectionLayer.buildLayersNoOverlap(paths, slices, !Boolean.FALSE.equals(idInclusion)),
             true,
             includeSimilarityScore);
       } else { // exclusion-based
         // doc-id excluded only if explicitly excluded
         return new DocumentProjector(
-            ProjectionLayer.buildLayers(paths, slices, Boolean.FALSE.equals(idInclusion)),
+            ProjectionLayer.buildLayersNoOverlap(paths, slices, Boolean.FALSE.equals(idInclusion)),
             false,
             includeSimilarityScore);
       }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -70,21 +70,31 @@ public class DocumentProjector {
     // 1. Non-empty "allowed" (but empty/null "denied") -> build inclusion projection
     // 2. Non-empty "denied" (but empty/null "allowed") -> build exclusion projection
     // 3. Empty/null "allowed" and "denied" -> return identity projection
-    // We need not (and should not) do further validation here
+    // as well as 2 special cases:
+    // 4. Empty "allowed" and single "*" entry for "denied" -> return exclude-all projection
+    // 5. Empty "deny" and single "*" entry for "allowed" -> return include-all ("identity")
+    // projection
+    // We need not (and should not) do further validation here.
+    // Note that (5) is effectively same as (3) and included for sake of uniformity
     if (allowed != null && !allowed.isEmpty()) {
+      // (special) Case 5:
+      if (allowed.size() == 1 && allowed.contains("*")) {
+        return identityProjector();
+      }
+      // Case 1: inclusion-based projection
       return new DocumentProjector(ProjectionLayer.buildLayers(allowed, null, false), true, false);
     }
     if (denied != null && !denied.isEmpty()) {
-      // One special case: single "*" entry for exclusions means "exclude add" (that is, include
-      // nothing).
-      // This is reverse of identity projector.
+      // (special) Case 4:
       if (denied.size() == 1 && denied.contains("*")) {
         // Basically inclusion projector with nothing to include
         return new DocumentProjector(
             ProjectionLayer.buildLayers(Collections.emptySet(), null, false), true, false);
       }
+      // Case 2: exclusion-based projection
       return new DocumentProjector(ProjectionLayer.buildLayers(denied, null, false), false, false);
     }
+    // Case 3: include-all (identity) projection
     return identityProjector();
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -83,7 +83,7 @@ public class DocumentProjector {
         return new DocumentProjector(
             ProjectionLayer.buildLayers(Collections.emptySet(), null, false), true, false);
       }
-      return new DocumentProjector(ProjectionLayer.buildLayers(allowed, null, false), false, false);
+      return new DocumentProjector(ProjectionLayer.buildLayers(denied, null, false), false, false);
     }
     return identityProjector();
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Helper class that implements functionality needed to support projections on documents fetched via
@@ -48,7 +49,7 @@ public class DocumentProjector {
       JsonNode projectionDefinition, boolean includeSimilarity) {
     if (projectionDefinition == null) {
       if (includeSimilarity) {
-        return IDENTITY_PROJECTOR_WITH_SIMILARITY;
+        return identityProjectorWithSimilarity();
       } else {
         return identityProjector();
       }
@@ -63,11 +64,16 @@ public class DocumentProjector {
     return PathCollector.collectPaths(projectionDefinition, includeSimilarity).buildProjector();
   }
 
+  public static DocumentProjector createForIndexing(Set<String> allowed, Set<String> denied) {
+    // !!! TO IMPLEMENT
+    return identityProjector();
+  }
+
   public static DocumentProjector identityProjector() {
     return IDENTITY_PROJECTOR;
   }
 
-  public static DocumentProjector getIdentityProjectorWithSimilarity() {
+  public static DocumentProjector identityProjectorWithSimilarity() {
     return IDENTITY_PROJECTOR;
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -74,7 +74,7 @@ public class DocumentProjector {
   }
 
   public static DocumentProjector identityProjectorWithSimilarity() {
-    return IDENTITY_PROJECTOR;
+    return IDENTITY_PROJECTOR_WITH_SIMILARITY;
   }
 
   public boolean isInclusion() {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -72,19 +72,18 @@ public class DocumentProjector {
     // 3. Empty/null "allowed" and "denied" -> return identity projection
     // We need not (and should not) do further validation here
     if (allowed != null && !allowed.isEmpty()) {
-      return new DocumentProjector(
-          ProjectionLayer.buildLayers(allowed, null, false), true, false);
+      return new DocumentProjector(ProjectionLayer.buildLayers(allowed, null, false), true, false);
     }
     if (denied != null && !denied.isEmpty()) {
-      // One special case: single "*" entry for exclusions means "exclude add" (that is, include nothing).
+      // One special case: single "*" entry for exclusions means "exclude add" (that is, include
+      // nothing).
       // This is reverse of identity projector.
       if (denied.size() == 1 && denied.contains("*")) {
         // Basically inclusion projector with nothing to include
         return new DocumentProjector(
-                ProjectionLayer.buildLayers(Collections.emptySet(), null, false), true, false);
+            ProjectionLayer.buildLayers(Collections.emptySet(), null, false), true, false);
       }
-      return new DocumentProjector(
-              ProjectionLayer.buildLayers(allowed, null, false), false, false);
+      return new DocumentProjector(ProjectionLayer.buildLayers(allowed, null, false), false, false);
     }
     return identityProjector();
   }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -137,6 +137,32 @@ public class DocumentProjector {
     }
   }
 
+  /**
+   * Method to call to check if given path (dotted path, that is, dot-separated segments) would be
+   * included by this Projection. That is, either
+   *
+   * <ul>
+   *   <li>This is inclusion projection, and path is covered by an inclusion path
+   *   <li>This is exclusion projection, and path is NOT covered by any exclusion path
+   * </ul>
+   *
+   * @param path Dotted path (possibly nested) to check
+   * @return {@code true} if path is included; {@code false} if not.
+   */
+  public boolean isPathIncluded(String path) {
+    // First: if we have no layers, we are identity projector and include everything
+    if (rootLayer == null) {
+      return true;
+    }
+    // Otherwise need to split path, evaluate; but note reversal wrt include/exclude
+    // projections
+    if (inclusion) {
+      return rootLayer.isPathIncluded(path);
+    } else {
+      return !rootLayer.isPathIncluded(path);
+    }
+  }
+
   // Mostly for deserialization tests
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
@@ -59,8 +59,10 @@ class ProjectionLayer {
     }
     // Slices similar to path but processed differently (and while "exclusions"
     // in a way do not count as ones wrt compatibility)
-    for (SliceDef slice : slices) {
-      buildSlicer(slice, root);
+    if (slices != null) {
+      for (SliceDef slice : slices) {
+        buildSlicer(slice, root);
+      }
     }
 
     // May need to add doc-id inclusion/exclusion as well

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/ProjectionLayer.java
@@ -166,6 +166,35 @@ class ProjectionLayer {
   }
 
   /**
+   * Method called to check if given path is included in the projection for which this is the root
+   * layer: this is done by traversing layers until determination can be made.
+   *
+   * @param path Dot-notation path to check
+   * @return {@code true} if path is included; {@code false} if not.
+   */
+  public boolean isPathIncluded(String path) {
+    final String[] segments = DOT.split(path);
+    return isPathIncluded(segments, 0);
+  }
+
+  private boolean isPathIncluded(String[] segments, int index) {
+    // If we are at a terminal layer, we are done
+    if (isTerminal) {
+      return true;
+    }
+    // Otherwise if we are at the end of path, we are not included
+    if (index == segments.length) {
+      return false;
+    }
+    // Otherwise we need to traverse further
+    ProjectionLayer next = nextLayers.get(segments[index]);
+    if (next == null) {
+      return false;
+    }
+    return next.isPathIncluded(segments, index + 1);
+  }
+
+  /**
    * Method called to apply Inclusion-based projection, in which everything to be included is
    * enumerated, and the rest need to be removed (this includes document id as well as regular
    * properties).

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertManyCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertManyCommandResolver.java
@@ -5,6 +5,7 @@ import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.InsertManyCommand;
 import io.stargate.sgv2.jsonapi.service.operation.model.Operation;
 import io.stargate.sgv2.jsonapi.service.operation.model.impl.InsertOperation;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import io.stargate.sgv2.jsonapi.service.resolver.model.CommandResolver;
 import io.stargate.sgv2.jsonapi.service.shredding.Shredder;
 import io.stargate.sgv2.jsonapi.service.shredding.model.WritableShreddedDocument;
@@ -35,8 +36,9 @@ public class InsertManyCommandResolver implements CommandResolver<InsertManyComm
     // Vectorize documents
     ctx.tryVectorize(objectMapper.getNodeFactory(), command.documents());
 
+    final DocumentProjector projection = ctx.indexingProjector();
     final List<WritableShreddedDocument> shreddedDocuments =
-        command.documents().stream().map(shredder::shred).toList();
+        command.documents().stream().map(doc -> shredder.shred(doc, null, projection)).toList();
 
     // resolve ordered
     InsertManyCommand.Options options = command.options();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertOneCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/InsertOneCommandResolver.java
@@ -34,7 +34,8 @@ public class InsertOneCommandResolver implements CommandResolver<InsertOneComman
   public Operation resolveCommand(CommandContext ctx, InsertOneCommand command) {
     // Vectorize document
     ctx.tryVectorize(objectMapper.getNodeFactory(), List.of(command.document()));
-    WritableShreddedDocument shreddedDocument = shredder.shred(command.document());
+    WritableShreddedDocument shreddedDocument =
+        shredder.shred(command.document(), null, ctx.indexingProjector());
     return new InsertOperation(ctx, shreddedDocument);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/CollectionSettingsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/CollectionSettingsTest.java
@@ -1,0 +1,37 @@
+package io.stargate.sgv2.jsonapi.api.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class CollectionSettingsTest {
+  final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void ensureSingleProjectorCreation() {
+    CollectionSettings.IndexingConfig indexingConfig =
+        new CollectionSettings.IndexingConfig(Collections.singleton("abc"), null);
+    CollectionSettings settings =
+        new CollectionSettings("collectionName", false, -1, null, null, null, indexingConfig);
+    DocumentProjector indexingProj = settings.indexingProjector();
+    assertThat(indexingProj)
+        .isNotNull()
+        // Should get the same instance second time due to memoization
+        .isSameAs(settings.indexingProjector())
+        // and third :)
+        .isSameAs(settings.indexingProjector());
+
+    // And should also work as expected: "abc" and below included; the rest, not
+    assertThat(indexingProj.isPathIncluded("abc.x")).isTrue();
+    assertThat(indexingProj.isPathIncluded("_id")).isFalse();
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -1312,7 +1312,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("status.insertedIds", contains("5", 5))
+          .body("status.insertedIds", containsInAnyOrder("5", 5))
           .body("data", is(nullValue()))
           .body("errors", is(nullValue()));
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -1398,7 +1398,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("status.insertedIds", contains("doc4", "doc5"))
+          .body("status.insertedIds", containsInAnyOrder("doc4", "doc5"))
           .body("data", is(nullValue()))
           .body("errors", is(nullValue()));
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/TestEmbeddingService.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/TestEmbeddingService.java
@@ -11,8 +11,14 @@ public class TestEmbeddingService implements EmbeddingService {
       new CommandContext(
           "namespace",
           "collection",
-          true,
-          CollectionSettings.SimilarityFunction.COSINE,
+          new CollectionSettings(
+              "collection",
+              true,
+              3,
+              CollectionSettings.SimilarityFunction.COSINE,
+              null,
+              null,
+              null),
           new TestEmbeddingService());
 
   @Override

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -54,7 +54,17 @@ public class FindOperationTest extends OperationTestBase {
 
   private final CommandContext VECTOR_COMMAND_CONTEXT =
       new CommandContext(
-          KEYSPACE_NAME, COLLECTION_NAME, true, CollectionSettings.SimilarityFunction.COSINE, null);
+          KEYSPACE_NAME,
+          COLLECTION_NAME,
+          new CollectionSettings(
+              COLLECTION_NAME,
+              true,
+              -1,
+              CollectionSettings.SimilarityFunction.COSINE,
+              null,
+              null,
+              null),
+          null);
 
   private final ColumnDefinitions KEY_TXID_JSON_COLUMNS =
       buildColumnDefs(

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/InsertOperationTest.java
@@ -49,7 +49,17 @@ public class InsertOperationTest extends OperationTestBase {
 
   private final CommandContext COMMAND_CONTEXT_VECTOR =
       new CommandContext(
-          KEYSPACE_NAME, COLLECTION_NAME, true, CollectionSettings.SimilarityFunction.COSINE, null);
+          KEYSPACE_NAME,
+          COLLECTION_NAME,
+          new CollectionSettings(
+              COLLECTION_NAME,
+              true,
+              -1,
+              CollectionSettings.SimilarityFunction.COSINE,
+              null,
+              null,
+              null),
+          null);
 
   private final ColumnDefinitions COLUMNS_APPLIED =
       buildColumnDefs(TestColumn.ofBoolean("[applied]"));

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -60,7 +60,17 @@ public class ReadAndUpdateOperationTest extends OperationTestBase {
 
   private static final CommandContext COMMAND_VECTOR_CONTEXT =
       new CommandContext(
-          KEYSPACE_NAME, COLLECTION_NAME, true, CollectionSettings.SimilarityFunction.COSINE, null);
+          KEYSPACE_NAME,
+          COLLECTION_NAME,
+          new CollectionSettings(
+              COLLECTION_NAME,
+              true,
+              -1,
+              CollectionSettings.SimilarityFunction.COSINE,
+              null,
+              null,
+              null),
+          null);
 
   @Inject Shredder shredder;
   @Inject ObjectMapper objectMapper;

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorForIndexingTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorForIndexingTest.java
@@ -1,0 +1,74 @@
+package io.stargate.sgv2.jsonapi.service.projection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.util.*;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(NoGlobalResourcesTestProfile.Impl.class)
+public class DocumentProjectorForIndexingTest {
+  @Inject ObjectMapper objectMapper;
+
+  @Nested
+  class AllowFiltering {
+    @Test
+    public void testSimpleRootAllow() {
+      assertAllowProjection(
+          Arrays.asList("d", "b"),
+          """
+                        { "a": 5, "b": 6, "c": 7, "d": 8 }
+                    """,
+          """
+                        { "b": 6, "d": 8 }
+                    """);
+    }
+  }
+
+  @Nested
+  class DenyFiltering {
+    @Test
+    public void testSimpleRootDeny() {
+      assertDenyProjection(
+          Arrays.asList("d", "b"),
+          """
+                        { "a": 5, "b": 6, "c": 7, "d": 8 }
+                    """,
+          """
+                        { "a": 5, "c": 7 }
+                    """);
+    }
+  }
+
+  private void assertAllowProjection(List<String> allows, String inputDoc, String expectedDoc) {
+    DocumentProjector projector =
+        DocumentProjector.createForIndexing(new LinkedHashSet<>(allows), Collections.emptySet());
+    try {
+      JsonNode input = objectMapper.readTree(inputDoc);
+      projector.applyProjection(input);
+      assertThat(input).isEqualTo(objectMapper.readTree(expectedDoc));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void assertDenyProjection(List<String> denies, String inputDoc, String expectedDoc) {
+    DocumentProjector projector =
+        DocumentProjector.createForIndexing(Collections.emptySet(), new LinkedHashSet<>(denies));
+    try {
+      JsonNode input = objectMapper.readTree(inputDoc);
+      projector.applyProjection(input);
+      assertThat(input).isEqualTo(objectMapper.readTree(expectedDoc));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorForIndexingTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorForIndexingTest.java
@@ -31,6 +31,25 @@ public class DocumentProjectorForIndexingTest {
                         { "b": 6, "d": 8 }
                     """);
     }
+
+    @Test
+    public void testSimpleNestedAllow() {
+      assertAllowProjection(
+          Arrays.asList("a.y", "c"),
+          """
+                      {
+                        "a": { "x":1, "y":2 },
+                        "b": { "x":3, "y":4 },
+                        "c": { "x":2, "y":3 }
+                      }
+                  """,
+          """
+                        {
+                          "a": { "y":2 },
+                          "c": { "x":2, "y":3 }
+                        }
+                    """);
+    }
   }
 
   @Nested
@@ -45,6 +64,50 @@ public class DocumentProjectorForIndexingTest {
           """
                         { "a": 5, "c": 7 }
                     """);
+    }
+
+    @Test
+    public void testSimpleNestedDeny() {
+      assertDenyProjection(
+          Arrays.asList("a.y", "c"),
+          """
+                      {
+                        "a": { "x":1, "y":2 },
+                        "b": { "x":3, "y":4 },
+                        "c": { "x":2, "y":3 }
+                      }
+                  """,
+          """
+                        {
+                          "a": { "x":1 },
+                          "b": { "x":3, "y":4 }
+                        }
+                    """);
+    }
+  }
+
+  @Nested
+  class SpecialCases {
+    @Test
+    public void testAllowAll() {
+      final String DOC =
+          """
+              { "a": 5, "b": { "enabled": true}, "c": 7, "d": [ { "value": 42} ] }
+          """;
+      // First with empty Sets:
+      assertAllowProjection(Arrays.asList(), DOC, DOC);
+      // And then "*" notation
+      assertAllowProjection(Arrays.asList("*"), DOC, DOC);
+    }
+
+    @Test
+    public void testDenyAll() {
+      final String DOC =
+          """
+              { "a": 5, "b": { "enabled": true}, "c": 7, "d": [ { "value": 42} ] }
+          """;
+      // Only "*" notation available
+      assertDenyProjection(Arrays.asList("*"), DOC, "{ }");
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorForIndexingTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorForIndexingTest.java
@@ -188,6 +188,12 @@ public class DocumentProjectorForIndexingTest {
       DocumentProjector nestedProj = createAllowProjection(Arrays.asList("a.b"));
       assertIsIncluded(nestedProj, "a.b", "a.b.c", "a.b.longer.path.for.sure");
       assertIsNotIncluded(nestedProj, "a", "b", "c", "a.c", "a.x", "a.x.y.z", "_id");
+
+      // Let's also check overlapping (redundant) case; most generic used (specific ignored)
+      // same as just "c":
+      DocumentProjector overlapProj = createAllowProjection(Arrays.asList("c", "c.x"));
+      assertIsIncluded(overlapProj, "c", "c.abc", "c.d.e.f");
+      assertIsNotIncluded(overlapProj, "a", "b", "d", "a.c", "a.x.y.z", "_id");
     }
 
     @Test
@@ -201,6 +207,12 @@ public class DocumentProjectorForIndexingTest {
       assertIsNotIncluded(
           nestedProj, "a.b", "a.b.c", "a.b.longer.path.for.sure", "a.noindex", "a.noindex.x");
       assertIsIncluded(nestedProj, "a", "b", "_id", "a.c", "a.x", "a.x.y.z");
+
+      // Let's also check overlapping (redundant) case; most generic used (specific ignored)
+      // same as just "c":
+      DocumentProjector overlapProj = createDenyProjection(Arrays.asList("c", "c.x"));
+      assertIsNotIncluded(overlapProj, "c", "c.abc", "c.d.e.f");
+      assertIsIncluded(overlapProj, "a", "b", "d", "a.c", "a.x.y.z", "_id");
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorForIndexingTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjectorForIndexingTest.java
@@ -21,11 +21,11 @@ public class DocumentProjectorForIndexingTest {
   @Nested
   class AllowFiltering {
     @Test
-    public void testSimpleRootAllow() {
+    public void testRootAllow() {
       assertAllowProjection(
-          Arrays.asList("d", "b"),
+          Arrays.asList("d", "b", "y"), // "y" won't match anything
           """
-                        { "a": 5, "b": 6, "c": 7, "d": 8 }
+                        { "_id":123, "a": 5, "b": 6, "c": 7, "d": 8 }
                     """,
           """
                         { "b": 6, "d": 8 }
@@ -33,11 +33,11 @@ public class DocumentProjectorForIndexingTest {
     }
 
     @Test
-    public void testSimpleNestedAllow() {
+    public void testNestedAllow() {
       assertAllowProjection(
-          Arrays.asList("a.y", "c"),
+          Arrays.asList("a.y", "c", "x"), // "x" won't match anything
           """
-                      {
+                      { "_id":123,
                         "a": { "x":1, "y":2 },
                         "b": { "x":3, "y":4 },
                         "c": { "x":2, "y":3 }
@@ -50,39 +50,105 @@ public class DocumentProjectorForIndexingTest {
                         }
                     """);
     }
+
+    // Unlike with projection, overlapping paths are accepted for Indexing
+    @Test
+    public void testOverlappingAllow() {
+      final String INPUT_DOC =
+          """
+                          {
+                            "_id":123,
+                            "a": {
+                               "b" : {
+                                  "z" : true,
+                                  "abc": 123
+                                }
+                             },
+                             "b" : 123
+                          }
+                      """;
+      final String EXP_OUTPUT =
+          """
+                          {
+                            "a": {
+                               "b" : {
+                                  "z" : true,
+                                  "abc": 123
+                                }
+                             }
+                          }
+                      """;
+
+      // Try with overlapping paths
+      assertAllowProjection(Arrays.asList("a", "a.b"), INPUT_DOC, EXP_OUTPUT);
+      assertAllowProjection(Arrays.asList("a.b", "a"), INPUT_DOC, EXP_OUTPUT);
+      assertAllowProjection(Arrays.asList("a.b.z", "a.b"), INPUT_DOC, EXP_OUTPUT);
+      assertAllowProjection(Arrays.asList("a.b", "a.b.z"), INPUT_DOC, EXP_OUTPUT);
+      assertAllowProjection(Arrays.asList("a.b.z", "a"), INPUT_DOC, EXP_OUTPUT);
+    }
   }
 
   @Nested
   class DenyFiltering {
     @Test
-    public void testSimpleRootDeny() {
+    public void testRootDeny() {
       assertDenyProjection(
-          Arrays.asList("d", "b"),
+          Arrays.asList("d", "b", "x"), // "x" won't match anything
           """
-                        { "a": 5, "b": 6, "c": 7, "d": 8 }
+                        { "_id":123, "a": 5, "b": 6, "c": 7, "d": 8 }
                     """,
           """
-                        { "a": 5, "c": 7 }
+                        { "_id":123, "a": 5, "c": 7 }
                     """);
     }
 
     @Test
-    public void testSimpleNestedDeny() {
+    public void testNestedDeny() {
       assertDenyProjection(
-          Arrays.asList("a.y", "c"),
+          Arrays.asList("a.y", "c", "z"), // "z" non-matching
           """
-                      {
+                      { "_id":123,
                         "a": { "x":1, "y":2 },
                         "b": { "x":3, "y":4 },
                         "c": { "x":2, "y":3 }
                       }
                   """,
           """
-                        {
+                        { "_id":123,
                           "a": { "x":1 },
                           "b": { "x":3, "y":4 }
                         }
                     """);
+    }
+
+    @Test
+    public void testOverlappingDeny() {
+      final String INPUT_DOC =
+          """
+                          {
+                            "_id":123,
+                            "a": {
+                               "b" : {
+                                  "z" : true,
+                                  "abc": 123
+                                }
+                             },
+                             "b" : 123
+                          }
+                      """;
+      final String EXP_OUTPUT =
+          """
+                          {
+                            "_id":123,
+                             "b" : 123
+                          }
+                      """;
+
+      // Try with overlapping paths
+      assertDenyProjection(Arrays.asList("a", "a.b"), INPUT_DOC, EXP_OUTPUT);
+      assertDenyProjection(Arrays.asList("a.b", "a"), INPUT_DOC, EXP_OUTPUT);
+      assertDenyProjection(Arrays.asList("a.b.z", "a"), INPUT_DOC, EXP_OUTPUT);
+      assertDenyProjection(Arrays.asList("a", "a.b.z"), INPUT_DOC, EXP_OUTPUT);
     }
   }
 


### PR DESCRIPTION
**What this PR does**:

Adds index allow/deny handling to `Shredder` based on `IndexingConfig` added via CreateCollection

**Which issue(s) this PR fixes**:
Fixes #767

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
