### PR TITLE
set the application name when creating CQL session

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CQLSessionCache.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CQLSessionCache.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,9 @@ public class CQLSessionCache {
   public static final String ASTRA = "astra";
   /** Database type OSS cassandra */
   public static final String CASSANDRA = "cassandra";
+
+  @ConfigProperty(name = "quarkus.application.name")
+  private String APPLICATION_NAME;
 
   @Inject
   public CQLSessionCache(OperationsConfig operationsConfig, MeterRegistry meterRegistry) {
@@ -115,12 +119,14 @@ public class CQLSessionCache {
           .withAuthCredentials(
               Objects.requireNonNull(databaseConfig.userName()),
               Objects.requireNonNull(databaseConfig.password()))
+          .withApplicationName(APPLICATION_NAME)
           .build();
     } else if (ASTRA.equals(databaseConfig.type())) {
       return new TenantAwareCqlSessionBuilder(stargateRequestInfo.getTenantId().orElseThrow())
           .withAuthCredentials(
               TOKEN, Objects.requireNonNull(stargateRequestInfo.getCassandraToken().orElseThrow()))
           .withLocalDatacenter(operationsConfig.databaseConfig().localDatacenter())
+          .withApplicationName(APPLICATION_NAME)
           .build();
     }
     throw new RuntimeException("Unsupported database type: " + databaseConfig.type());


### PR DESCRIPTION
JSON API was updated to use the CQL Driver instead of the bridge to communicate with the coordinator. In order to allow the coordinator to distinguish CQL traffic that comes from the coordinator, we should set the application name on the CqlSession. We can reuse the Quarkus application name for this.

Fixes #387 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
