### PR TITLE
Fixes #767: Second part of "no-index" changes: allow large non-indexed String values, implicit allow for "$vector"

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/projection/DocumentProjector.java
@@ -82,6 +82,10 @@ public class DocumentProjector {
         return identityProjector();
       }
       // Case 1: inclusion-based projection
+      // Minor complication: "$vector" needs to be included automatically
+      if (!allowed.contains(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD)) {
+        allowed.add(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD);
+      }
       return new DocumentProjector(ProjectionLayer.buildLayersOverlapOk(allowed), true, false);
     }
     if (denied != null && !denied.isEmpty()) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -226,6 +226,19 @@ public class Shredder {
     callback.shredVector(path, arr);
   }
 
+  private void validateDocumentSize(DocumentLimitsConfig limits, String docJson) {
+    // First: is the resulting document size (as serialized) too big?
+    if (docJson.length() > limits.maxSize()) {
+      throw new JsonApiException(
+          ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
+          String.format(
+              "%s: document size (%d chars) exceeds maximum allowed (%d)",
+              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
+              docJson.length(),
+              limits.maxSize()));
+    }
+  }
+
   private void validateDocumentStructure(DocumentLimitsConfig limits, ObjectNode doc) {
     // Second: traverse to check for other constraints
     AtomicInteger totalProperties = new AtomicInteger(0);
@@ -238,19 +251,6 @@ public class Shredder {
               ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
               totalProperties.get(),
               limits.maxDocumentProperties()));
-    }
-  }
-
-  private void validateDocumentSize(DocumentLimitsConfig limits, String docJson) {
-    // First: is the resulting document size (as serialized) too big?
-    if (docJson.length() > limits.maxSize()) {
-      throw new JsonApiException(
-          ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-          String.format(
-              "%s: document size (%d chars) exceeds maximum allowed (%d)",
-              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-              docJson.length(),
-              limits.maxSize()));
     }
   }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -95,7 +95,7 @@ public class Shredder {
 
     // We also need to handle special fields (currently just "$vector") which would
     // be dropped by "no-index" filter, but that require special handling
-    JsonNode vector = docWithId.remove(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD);
+    JsonNode vector = docWithId.get(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD);
     if (vector != null) {
       traverseVector(JsonPath.from(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD), vector, b);
     }
@@ -182,7 +182,11 @@ public class Shredder {
 
   private void traverseValue(JsonNode value, ShredListener callback, JsonPath.Builder pathBuilder) {
     final JsonPath path = pathBuilder.build();
-    if (path.toString().equals(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD)) {
+    final String pathAsString = path.toString();
+
+    if (pathAsString.equals(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD)) {
+      // Do nothing as $vector is handled separately
+    } else if (pathAsString.equals(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD)) {
       // Do nothing, vectorize field will just sit in doc json
     } else {
       if (value.isObject()) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -93,13 +93,6 @@ public class Shredder {
     final WritableShreddedDocument.Builder b =
         WritableShreddedDocument.builder(docId, txId, docJson, docWithId);
 
-    // We also need to handle special fields (currently just "$vector") which would
-    // be dropped by "no-index" filter, but that require special handling
-    JsonNode vector = docWithId.get(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD);
-    if (vector != null) {
-      traverseVector(JsonPath.from(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD), vector, b);
-    }
-
     // Before value validation, indexing, may need to drop "non-indexed" fields. But if so,
     // need to ensure we do not modify original document, so let's create a copy (may need
     // to be returned as "after" Document)
@@ -193,7 +186,7 @@ public class Shredder {
     final String pathAsString = path.toString();
 
     if (pathAsString.equals(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD)) {
-      // Do nothing as $vector is handled separately
+      traverseVector(path, value, callback);
     } else if (pathAsString.equals(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD)) {
       // Do nothing, vectorize field will just sit in doc json
     } else {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/CollectionSettingsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/configuration/CollectionSettingsTest.java
@@ -8,7 +8,8 @@ import io.quarkus.test.junit.TestProfile;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
 import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
 import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -19,7 +20,7 @@ public class CollectionSettingsTest {
   @Test
   public void ensureSingleProjectorCreation() {
     CollectionSettings.IndexingConfig indexingConfig =
-        new CollectionSettings.IndexingConfig(Collections.singleton("abc"), null);
+        new CollectionSettings.IndexingConfig(new HashSet<String>(Arrays.asList("abc")), null);
     CollectionSettings settings =
         new CollectionSettings("collectionName", false, -1, null, null, null, indexingConfig);
     DocumentProjector indexingProj = settings.indexingProjector();

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
@@ -1,0 +1,191 @@
+package io.stargate.sgv2.jsonapi.api.v1;
+
+import static io.restassured.RestAssured.given;
+import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.http.ContentType;
+import io.stargate.sgv2.jsonapi.config.constants.HttpConstants;
+import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+
+@QuarkusIntegrationTest
+@QuarkusTestResource(DseTestResource.class)
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractNamespaceIntegrationTestBase {
+  private static final String collectionName = "no_index_collection";
+
+  @Nested
+  @Order(1)
+  class CreateCollection {
+    @Test
+    public void createBaseCollection() {
+      String json =
+          """
+                 {
+                   "createCollection": {
+                     "name": "%s",
+                     "options": {
+                       "vector": {
+                         "size": 2,
+                         "function": "cosine"
+                       },
+                       "indexing" : {
+                         "allow" : ["_id", "name", "value"]
+                       }
+                     }
+                   }
+                 }
+                  """
+              .formatted(collectionName);
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+    }
+  }
+
+  @Nested
+  @Order(2)
+  class FindAndUpdateWithSet {
+    @Test
+    public void byIdAfterUpdate() {
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                      {
+                        "insertOne": {
+                          "document": {
+                            "_id": "update_doc_after",
+                            "name": "Joe",
+                            "age": 42,
+                            "enabled": false,
+                            "$vector" : [ 0.5, -0.25 ]
+                          }
+                        }
+                      }
+                      """)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200);
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+              {
+                "findOneAndUpdate": {
+                  "filter" : {"_id" : "update_doc_after"},
+                  "update" : {
+                    "$set" : {
+                      "enabled": true,
+                      "value": -1
+                    }
+                  },
+                  "options": {
+                    "returnDocument" : "after"
+                  }
+                }
+              }
+              """)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body(
+              "data.document",
+              jsonEquals(
+                  """
+                      {
+                        "_id": "update_doc_after",
+                        "name": "Joe",
+                        "age": 42,
+                        "enabled": true,
+                        "value": -1,
+                        "$vector" : [ 0.5, -0.25 ]
+                      }
+                      """))
+          .body("status.matchedCount", is(1))
+          .body("status.modifiedCount", is(1))
+          .body("errors", is(nullValue()));
+    }
+
+    @Test
+    public void byIdBeforeUpdate() {
+      final String DOC =
+          """
+              {
+              "_id": "update_doc_before",
+                "name": "Bob",
+                "age": 77,
+                "enabled": true,
+                "$vector" : [ 0.5, -0.25 ],
+                "value": 3
+              }
+              """;
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                              {
+                                "insertOne": {
+                                  "document": %s
+                                }
+                              }
+                              """.formatted(DOC)
+                  .formatted(DOC))
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200);
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                      {
+                        "findOneAndUpdate": {
+                          "filter" : {"_id" : "update_doc_before"},
+                          "update" : {
+                            "$set" : {
+                              "enabled": false,
+                              "value": 4
+                            }
+                          },
+                          "options": {
+                            "returnDocument": "before"
+                          }
+                        }
+                      }
+                      """)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data.document", jsonEquals(DOC))
+          .body("status.matchedCount", is(1))
+          .body("status.modifiedCount", is(1))
+          .body("errors", is(nullValue()));
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
@@ -151,7 +151,7 @@ public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractNamespaceInt
                                   "document": %s
                                 }
                               }
-                              """.formatted(DOC)
+                              """
                   .formatted(DOC))
           .when()
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/IndexingConfigIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/IndexingConfigIntegrationTest.java
@@ -818,13 +818,14 @@ public class IndexingConfigIntegrationTest extends AbstractCollectionIntegration
 
     @Test
     public void sortFieldNotInAllowMany() {
-      // explicitly allow "name" "address.city", implicitly deny "_id" "address.street" "$vector"
+      // explicitly allow "name" "address.city", implicitly deny "_id" "address.street";
+      // (and implicitly allow "$vector" as well)
       String sortData =
           """
                       {
                         "find": {
                           "sort": {
-                             "$vector" : [0.15, 0.1, 0.1, 0.35, 0.55]
+                             "address.street": 1
                           }
                         }
                       }
@@ -839,7 +840,7 @@ public class IndexingConfigIntegrationTest extends AbstractCollectionIntegration
           .statusCode(200)
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
-          .body("errors[0].message", endsWith("The sort path ('$vector') is not indexed"))
+          .body("errors[0].message", endsWith("The sort path ('address.street') is not indexed"))
           .body("errors[0].errorCode", is("UNINDEXED_SORT_PATH"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -757,7 +757,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith(
-                  "Document size limitation violated: String value length (8056 bytes) exceeds maximum allowed"));
+                  "Document size limitation violated: Indexed String value length (8056 bytes) exceeds maximum allowed"));
     }
 
     private String createBigString(int minLen) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
@@ -365,6 +365,7 @@ public class ShredderTest {
       assertThat(doc.id()).isEqualTo(DocumentId.fromNumber(BigDecimal.valueOf(123)));
       List<JsonPath> expPaths =
           Arrays.asList(
+              // NOTE: "$vector" is implicitly added to non-empty "allow" List
               JsonPath.from("$vector"),
               JsonPath.from("name"),
               JsonPath.from("metadata"),


### PR DESCRIPTION
**What this PR does**:

Completes changes needed by #767 by:

1. Adding more testing for Shredder
2. Fix the issue wrt dropping indexing of "$vector" (needs handling similar to `_id` for query projections, i.e. always index)
3. Changing validation to ignore length of non-Indexed Strings (only limited by max doc size)

These are resolved by refactoring validation logic into smaller parts, run at different times during shredding process.

**Which issue(s) this PR fixes**:
Fixes #767

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
