### PR TITLE
invalid $ operator use case, INVALID_REQUEST typo fix 

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializer.java
@@ -377,6 +377,12 @@ public class FilterClauseDeserializer extends StdDeserializer<FilterClause> {
                 throw new JsonApiException(
                     ErrorCode.INVALID_FILTER_EXPRESSION, "Date value has to be sent as epoch time");
               }
+            } else {
+              // handle an Invalid filter use case:
+              // { "address": { "street": { "$xx": xxx } } }
+              throw new JsonApiException(
+                  ErrorCode.INVALID_FILTER_EXPRESSION,
+                  String.format("Invalid use of %s operator", node.fields().next().getKey()));
             }
           } else {
             ObjectNode objectNode = (ObjectNode) node;

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/FilterClauseDeserializer.java
@@ -378,7 +378,7 @@ public class FilterClauseDeserializer extends StdDeserializer<FilterClause> {
                     ErrorCode.INVALID_FILTER_EXPRESSION, "Date value has to be sent as epoch time");
               }
             } else {
-              // handle an Invalid filter use case:
+              // handle an invalid filter use case:
               // { "address": { "street": { "$xx": xxx } } }
               throw new JsonApiException(
                   ErrorCode.INVALID_FILTER_EXPRESSION,

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
 
   FILTER_FIELDS_LIMIT_VIOLATION("Filter fields size limitation violated"),
 
-  INVALID_REQUST("Request not supported by the data store"),
+  INVALID_REQUEST("Request not supported by the data store"),
 
   INVALID_INDEXING_DEFINITION("Invalid indexing definition"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ThrowableToErrorMapper.java
@@ -72,7 +72,7 @@ public final class ThrowableToErrorMapper {
           if (message.contains("vector<float,")) { // TODO is there a better way?
             message = "Mismatched vector dimension";
           }
-          fields = Map.of("errorCode", ErrorCode.INVALID_REQUST.name());
+          fields = Map.of("errorCode", ErrorCode.INVALID_REQUEST.name());
           return new CommandResult.Error(message, fieldsForMetricsTag, fields, Response.Status.OK);
         } else if (throwable instanceof DriverTimeoutException
             || throwable instanceof WriteTimeoutException

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -1297,6 +1297,27 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
     }
 
     @Test
+    void invalidDollarOperatorPathExpression() {
+      String json =
+          """
+                  { "find": { "filter" : {"address" : {"city" : {"$eq" : "Beijing"}}}}}
+                  """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("status", is(nullValue()))
+          .body("data", is(nullValue()))
+          .body("errors[0].message", endsWith("Invalid use of $eq operator"))
+          .body("errors[0].errorCode", is("INVALID_FILTER_EXPRESSION"))
+          .body("errors[0].exceptionClass", is("JsonApiException"));
+    }
+
+    @Test
     public void exceedMaxFieldInFilter() {
       // Max allowed 64, so fail with 65
       String json = createJsonStringWithNFilterFields(65);

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -872,7 +872,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .statusCode(200)
           .body("errors", is(notNullValue()))
           .body("errors", hasSize(1))
-          .body("errors[0].errorCode", is("INVALID_REQUST"))
+          .body("errors[0].errorCode", is("INVALID_REQUEST"))
           .body(
               "errors[0].message",
               endsWith("Zero vectors cannot be indexed or queried with cosine similarity"));


### PR DESCRIPTION
**What this PR does**:
`{ "find": { "filter": { "address": { "street": { "$in" :["xxx"] } } } } }`
is a misuse of $ operator, if $in is intended here, should be
`{ "find": { "filter": { "address.street":  { "$in" :["xxx"] } } } }`

fix typo: INVALID_REQEST -> INVALID_REQUEST

**Which issue(s) this PR fixes**:
Fixes #798 #796

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
