### PR TITLE
Add validation of paths used for indexing "allow"/"deny" lists.

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.stargate.sgv2.jsonapi.api.model.command.NamespaceCommand;
+import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
 import jakarta.validation.constraints.*;
@@ -123,6 +124,14 @@ public record CreateCollectionCommand(
                 ErrorCode.INVALID_INDEXING_DEFINITION.getMessage()
                     + " - `allow` cannot contain duplicates");
           }
+          String invalid = findInvalidPath(allow());
+          if (invalid != null) {
+            throw new JsonApiException(
+                ErrorCode.INVALID_INDEXING_DEFINITION,
+                String.format(
+                    "%s - `allow` contains invalid path: '%s'",
+                    ErrorCode.INVALID_INDEXING_DEFINITION.getMessage(), invalid));
+          }
         }
 
         if (deny() != null) {
@@ -133,7 +142,24 @@ public record CreateCollectionCommand(
                 ErrorCode.INVALID_INDEXING_DEFINITION.getMessage()
                     + " - `deny` cannot contain duplicates");
           }
+          String invalid = findInvalidPath(deny());
+          if (invalid != null) {
+            throw new JsonApiException(
+                ErrorCode.INVALID_INDEXING_DEFINITION,
+                String.format(
+                    "%s - `deny` contains invalid path: '%s'",
+                    ErrorCode.INVALID_INDEXING_DEFINITION.getMessage(), invalid));
+          }
         }
+      }
+
+      public String findInvalidPath(List<String> paths) {
+        for (String path : paths) {
+          if (!DocumentConstants.Fields.VALID_PATH_PATTERN.matcher(path).matches()) {
+            return path;
+          }
+        }
+        return null;
       }
     }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
@@ -156,7 +156,10 @@ public record CreateCollectionCommand(
       public String findInvalidPath(List<String> paths) {
         for (String path : paths) {
           if (!DocumentConstants.Fields.VALID_PATH_PATTERN.matcher(path).matches()) {
-            return path;
+            // One exception: $vector is allowed
+            if (!DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(path)) {
+              return path;
+            }
           }
         }
         return null;

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -418,6 +418,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
+          // Brackets not allowed in field names
           .body(
               """
                     {
@@ -425,7 +426,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
                         "name": "collection_with_bad_allows",
                         "options" : {
                           "indexing" : {
-                            "allow" : ["field", "$eq"]
+                            "allow" : ["valid-field", "address[1].street"]
                           }
                         }
                       }
@@ -439,7 +440,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body("data", is(nullValue()))
           .body(
               "errors[0].message",
-              startsWith("Invalid indexing definition - `allow` contains invalid path: '$eq'"))
+              startsWith("Invalid indexing definition - `allow` contains invalid path: 'address[1].street'"))
           .body("errors[0].errorCode", is("INVALID_INDEXING_DEFINITION"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
     }
@@ -451,6 +452,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
           .contentType(ContentType.JSON)
           .body(
+              // Dollars not allowed in regular field names (can only start operators)
               """
                     {
                       "createCollection": {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -95,7 +95,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
                         "function" : "cosine"
                       },
                       "indexing" : {
-                        "allow" : ["field1", "field2", "address.city", "_id"]
+                        "allow" : ["field1", "field2", "address.city", "_id", "$vector"]
                       }
                     }
                   }
@@ -440,7 +440,8 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body("data", is(nullValue()))
           .body(
               "errors[0].message",
-              startsWith("Invalid indexing definition - `allow` contains invalid path: 'address[1].street'"))
+              startsWith(
+                  "Invalid indexing definition - `allow` contains invalid path: 'address[1].street'"))
           .body("errors[0].errorCode", is("INVALID_INDEXING_DEFINITION"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -329,6 +330,20 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
 
+      // delete the collection
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(deleteCollectionJson.formatted("simple_collection"))
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status.ok", is(1));
+    }
+
+    @Test
+    public void createCollectionWithIndexing() {
       // create vector collection with indexing allow option
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -395,6 +410,70 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .then()
           .statusCode(200)
           .body("status.ok", is(1));
+    }
+
+    @Test
+    public void failWithInvalidNameInIndexingAllows() {
+      // create a vector collection
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                    {
+                      "createCollection": {
+                        "name": "collection_with_bad_allows",
+                        "options" : {
+                          "indexing" : {
+                            "allow" : ["field", "$eq"]
+                          }
+                        }
+                      }
+                    }
+                    """)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status", is(nullValue()))
+          .body("data", is(nullValue()))
+          .body(
+              "errors[0].message",
+              startsWith("The provided collection name 'collection_with_bad_allows'"))
+          .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
+          .body("errors[0].exceptionClass", is("JsonApiException"));
+    }
+
+    @Test
+    public void failWithInvalidNameInIndexingDeny() {
+      // create a vector collection
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                    {
+                      "createCollection": {
+                        "name": "collection_with_bad_deny",
+                        "options" : {
+                          "indexing" : {
+                            "deny" : ["field", "$in"]
+                          }
+                        }
+                      }
+                    }
+                    """)
+          .when()
+          .post(NamespaceResource.BASE_PATH, namespaceName)
+          .then()
+          .statusCode(200)
+          .body("status", is(nullValue()))
+          .body("data", is(nullValue()))
+          .body(
+              "errors[0].message",
+              startsWith("The provided collection name 'collection_with_bad_deny'"))
+          .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
+          .body("errors[0].exceptionClass", is("JsonApiException"));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -439,8 +439,8 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body("data", is(nullValue()))
           .body(
               "errors[0].message",
-              startsWith("The provided collection name 'collection_with_bad_allows'"))
-          .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
+              startsWith("Invalid indexing definition - `allow` contains invalid path: '$eq'"))
+          .body("errors[0].errorCode", is("INVALID_INDEXING_DEFINITION"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
     }
 
@@ -471,8 +471,8 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body("data", is(nullValue()))
           .body(
               "errors[0].message",
-              startsWith("The provided collection name 'collection_with_bad_deny'"))
-          .body("errors[0].errorCode", is("INVALID_COLLECTION_NAME"))
+              startsWith("Invalid indexing definition - `deny` contains invalid path: '$in'"))
+          .body("errors[0].errorCode", is("INVALID_INDEXING_DEFINITION"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
     }
   }


### PR DESCRIPTION
**What this PR does**:

Adds validation of "indexing" options paths (in "allow" / "deny" lists), tests to verify.

**Which issue(s) this PR fixes**:
Fixes #790

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
