### PR TITLE
Fix to #790 implementation to ensure ["*"] is accepted as "allow" or "deny" list

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/impl/CreateCollectionCommand.java
@@ -154,6 +154,10 @@ public record CreateCollectionCommand(
       }
 
       public String findInvalidPath(List<String> paths) {
+        // Special case: single "*" is accepted
+        if (paths.size() == 1 && "*".equals(paths.get(0))) {
+          return null;
+        }
         for (String path : paths) {
           if (!DocumentConstants.Fields.VALID_PATH_PATTERN.matcher(path).matches()) {
             // One exception: $vector is allowed

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -387,10 +387,6 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
                         "createCollection": {
                           "name": "simple_collection_error1",
                           "options" : {
-                            "vector" : {
-                              "size" : 5,
-                              "function" : "cosine"
-                            },
                             "indexing" : {
                               "allow" : ["field1", "field1"]
                             }
@@ -423,10 +419,6 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
                   "createCollection": {
                     "name": "simple_collection_error2",
                     "options" : {
-                      "vector" : {
-                        "size" : 5,
-                        "function" : "cosine"
-                      },
                       "indexing" : {
                         "allow" : ["field1", "field2"],
                         "deny" : ["field1", "field2"]


### PR DESCRIPTION
**What this PR does**:

Improves "createCollection" validation, testing, to ensure single "*" is accepted as expected

**Which issue(s) this PR fixes**:
Fixes #790

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
