### PR TITLE
Fix #818: increase max doc depth allowed from 8 to 16

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -26,7 +26,7 @@ Here are some Stargate-relevant property groups that are necessary for correct s
 | Property                                                        | Type  | Default     | Description                                                                          |
 |-----------------------------------------------------------------|-------|-------------|--------------------------------------------------------------------------------------|
 | `stargate.jsonapi.document.limits.max-size`                     | `int` | `1_000_000` | The maximum size of (in characters) a single document.                               |
-| `stargate.jsonapi.document.limits.max-depth`                    | `int` | `8`         | The maximum document depth (nesting).                                                |
+| `stargate.jsonapi.document.limits.max-depth`                    | `int` | `16`        | The maximum document depth (nesting).                                                |
 | `stargate.jsonapi.document.limits.max-property-name-length`     | `int` | `100`       | The maximum length of property names in a document for an individual segment.        |
 | `stargate.jsonapi.document.limits.max-property-path-length`     | `int` | `250`       | The maximum length of property paths in a document (segments and separating periods) |
 | `stargate.jsonapi.document.limits.max-object-properties`        | `int` | `1000`      | The maximum number of properties any single object in a document can contain.        |

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -15,6 +15,9 @@ public interface DocumentLimitsConfig {
   /** Defines the default maximum document size. */
   int DEFAULT_MAX_DOCUMENT_SIZE = 1_000_000;
 
+  /** Defines the default maximum document (nesting) depth */
+  int DEFAULT_MAX_DOCUMENT_DEPTH = 16;
+
   /** Defines the default maximum length (in elements) of a single Array value */
   int DEFAULT_MAX_ARRAY_LENGTH = 1_000;
 
@@ -62,7 +65,7 @@ public interface DocumentLimitsConfig {
 
   /** @return Defines the maximum document depth (nesting), defaults to {@code 8 levels} */
   @Positive
-  @WithDefault("8")
+  @WithDefault("" + DEFAULT_MAX_DOCUMENT_DEPTH)
   int maxDepth();
 
   /**

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -72,11 +72,11 @@ public class ShredderDocLimitsTest {
 
     @Test
     public void allowDeepButNotTooDeepDoc() {
-      // We allow 7 levels of nesting so...
+      // We allow root + 15 levels of nesting so...
       final ObjectNode deepDoc = objectMapper.createObjectNode();
       deepDoc.put("_id", 123);
       ObjectNode ob = deepDoc;
-      for (int i = 0; i < 7; ++i) {
+      for (int i = 0; i < 15; ++i) {
         ob = ob.putObject("sub");
       }
 
@@ -85,7 +85,8 @@ public class ShredderDocLimitsTest {
 
     @Test
     public void catchTooDeepDoc() {
-      // Let's construct document with 20 levels of nesting (above our configs)
+      // Let's construct document with 20 levels of nesting: above our default
+      // max of 16 (currently)
       final ObjectNode deepDoc = objectMapper.createObjectNode();
       deepDoc.put("_id", 123);
 


### PR DESCRIPTION
**What this PR does**:

Increases default maximum allowed Document nesting depth to 16 (from 9)

**Which issue(s) this PR fixes**:
Fixes #818 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
