### PR TITLE
improve error msg, too many indexes and can not create a collection

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -225,8 +225,9 @@ public record CreateCollectionOperation(
       throw new JsonApiException(
           ErrorCode.TOO_MANY_INDEXES,
           String.format(
-              "%s: cannot create a new collection; %d indexes already created in database, maximum %d",
+              "%s: cannot create a new collection; need %d indexes to create the collection; %d indexes already created in database, maximum %d",
               ErrorCode.TOO_MANY_INDEXES.getMessage(),
+              dbLimitsConfig.indexesNeededPerCollection(),
               saisUsed,
               dbLimitsConfig.indexesAvailablePerDatabase()));
     }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -223,12 +223,11 @@ public record CreateCollectionOperation(
     if ((saisUsed + dbLimitsConfig.indexesNeededPerCollection())
         > dbLimitsConfig.indexesAvailablePerDatabase()) {
       throw ErrorCode.TOO_MANY_INDEXES.toApiException(
-          String.format(
-              "%s: cannot create a new collection; need %d indexes to create the collection; %d indexes already created in database, maximum %d",
-              ErrorCode.TOO_MANY_INDEXES.getMessage(),
-              dbLimitsConfig.indexesNeededPerCollection(),
-              saisUsed,
-              dbLimitsConfig.indexesAvailablePerDatabase()));
+          "%s: cannot create a new collection; need %d indexes to create the collection; %d indexes already created in database, maximum %d",
+          ErrorCode.TOO_MANY_INDEXES.getMessage(),
+          dbLimitsConfig.indexesNeededPerCollection(),
+          saisUsed,
+          dbLimitsConfig.indexesAvailablePerDatabase());
     }
 
     return null;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -222,8 +222,7 @@ public record CreateCollectionOperation(
     int saisUsed = allTables.stream().mapToInt(table -> table.getIndexes().size()).sum();
     if ((saisUsed + dbLimitsConfig.indexesNeededPerCollection())
         > dbLimitsConfig.indexesAvailablePerDatabase()) {
-      throw new JsonApiException(
-          ErrorCode.TOO_MANY_INDEXES,
+      throw ErrorCode.TOO_MANY_INDEXES.toApiException(
           String.format(
               "%s: cannot create a new collection; need %d indexes to create the collection; %d indexes already created in database, maximum %d",
               ErrorCode.TOO_MANY_INDEXES.getMessage(),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -223,8 +223,7 @@ public record CreateCollectionOperation(
     if ((saisUsed + dbLimitsConfig.indexesNeededPerCollection())
         > dbLimitsConfig.indexesAvailablePerDatabase()) {
       throw ErrorCode.TOO_MANY_INDEXES.toApiException(
-          "%s: cannot create a new collection; need %d indexes to create the collection; %d indexes already created in database, maximum %d",
-          ErrorCode.TOO_MANY_INDEXES.getMessage(),
+          "cannot create a new collection; need %d indexes to create the collection; %d indexes already created in database, maximum %d",
           dbLimitsConfig.indexesNeededPerCollection(),
           saisUsed,
           dbLimitsConfig.indexesAvailablePerDatabase());

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionTooManyIndexesIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionTooManyIndexesIntegrationTest.java
@@ -88,6 +88,7 @@ class CreateCollectionTooManyIndexesIntegrationTest extends AbstractNamespaceInt
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
           .body(
+              "errors[0].message",
               matchesPattern(
                   "Too many indexes: cannot create a new collection; need \\d+ indexes to create the collection; \\d+ indexes already created in database, maximum \\d+"))
           .body("errors[0].errorCode", is("TOO_MANY_INDEXES"))

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionTooManyIndexesIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionTooManyIndexesIntegrationTest.java
@@ -88,9 +88,8 @@ class CreateCollectionTooManyIndexesIntegrationTest extends AbstractNamespaceInt
           .body("status", is(nullValue()))
           .body("data", is(nullValue()))
           .body(
-              "errors[0].message",
               matchesPattern(
-                  "Too many indexes: cannot create a new collection; \\d+ indexes already created in database, maximum \\d+"))
+                  "Too many indexes: cannot create a new collection; need \\d+ indexes to create the collection; \\d+ indexes already created in database, maximum \\d+"))
           .body("errors[0].errorCode", is("TOO_MANY_INDEXES"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
 


### PR DESCRIPTION
**What this PR does**:
Improve error msg when there is too many indexes in db, and can not create a json api collection
Fix: {"message": "Too many indexes: cannot create a new collection; need 10 indexes to create the collection; 44 indexes already created in database, maximum 50", "errorCode": "TOO_MANY_INDEXES"}

**Which issue(s) this PR fixes**:
Fixes #830

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
