### PR TITLE
Fixes #822: only limit array size for indexed fields (ignore non-indexed)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -33,7 +33,7 @@ Here are some Stargate-relevant property groups that are necessary for correct s
 | `stargate.jsonapi.document.limits.max-document-properties`      | `int` | `2000`      | The maximum total number of properties all objects in a document can contain.        |
 | `stargate.jsonapi.document.limits.max-number-length`            | `int` | `100`       | The maximum length (in characters) of a single number value in a document.           |
 | `stargate.jsonapi.document.limits.max-string-length-in-bytes`   | `int` | `8000`      | The maximum length (in bytes) of a single string value in a document.                |
-| `stargate.jsonapi.document.limits.max-array-length`             | `int` | `1000`      | The maximum length (in elements) of a single array in a document.                    |
+| `stargate.jsonapi.document.limits.max-array-length`             | `int` | `1000`      | The maximum length (in elements) of a single indexable array in a document.          |
 | `stargate.jsonapi.document.limits.max-vector-embedding-length`  | `int` | `4096`      | The maximum length (in floats) of the $vector in a document.                         |
 
 ## Operations configuration

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -18,7 +18,7 @@ public interface DocumentLimitsConfig {
   /** Defines the default maximum document (nesting) depth */
   int DEFAULT_MAX_DOCUMENT_DEPTH = 16;
 
-  /** Defines the default maximum length (in elements) of a single Array value */
+  /** Defines the default maximum length (in elements) of a single indexable Array value */
   int DEFAULT_MAX_ARRAY_LENGTH = 1_000;
 
   /**
@@ -114,7 +114,9 @@ public interface DocumentLimitsConfig {
   @WithDefault("" + DEFAULT_MAX_STRING_LENGTH_IN_BYTES)
   int maxStringLengthInBytes();
 
-  /** @return Maximum length of an Array in document, defaults to {@code 1,000} elements. */
+  /**
+   * @return Maximum length of an indexable Array in document, defaults to {@code 1,000} elements.
+   */
   @Positive
   @WithDefault("" + DEFAULT_MAX_ARRAY_LENGTH)
   int maxArrayLength();

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -415,19 +415,13 @@ public class Shredder {
         if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(referringPropertyName)) {
           if (arrayValue.size() > limits.maxVectorEmbeddingLength()) {
             throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-                "%s: number of elements Vector embedding ('%s') has (%d) exceeds maximum allowed (%s)",
-                ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-                referringPropertyName,
-                arrayValue.size(),
-                limits.maxVectorEmbeddingLength());
+                "number of elements Vector embedding ('%s') has (%d) exceeds maximum allowed (%s)",
+                referringPropertyName, arrayValue.size(), limits.maxVectorEmbeddingLength());
           }
         } else {
           throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-              "%s: number of elements an indexable Array ('%s') has (%d) exceeds maximum allowed (%s)",
-              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-              referringPropertyName,
-              arrayValue.size(),
-              limits.maxArrayLength());
+              "number of elements an indexable Array ('%s') has (%d) exceeds maximum allowed (%s)",
+              referringPropertyName, arrayValue.size(), limits.maxArrayLength());
         }
       }
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -75,7 +75,7 @@ public class Shredder {
     // Now that we have the traversable document, verify it does not violate
     // structural limits, before serializing.
     // (note: value validation has to wait until no-indexing projection is applied)
-    new StructuralValidator(documentLimits).validate(docWithId);
+    new FullDocValidator(documentLimits).validate(docWithId);
 
     // Need to re-serialize document now that _id is normalized.
     // Also unifies escaping and gets rid of pretty-printing (if any) to save storage space.
@@ -107,7 +107,7 @@ public class Shredder {
     }
 
     // and now we can finally validate (String) value lengths
-    new ValueValidator(documentLimits).validate(indexableDocument);
+    new IndexableValueValidator(documentLimits).validate(indexableDocument);
 
     // And finally let's traverse the document to actually "shred" (build index fields)
     traverse(indexableDocument, b, JsonPath.rootBuilder());
@@ -249,11 +249,15 @@ public class Shredder {
     }
   }
 
-  static class StructuralValidator {
+  /**
+   * Validator applied to the full document, before removing non-indexable fields. Used to ensure
+   * that it does not violate overall structural limits such as maximum nesting depth.
+   */
+  static class FullDocValidator {
     final DocumentLimitsConfig limits;
     final AtomicInteger totalProperties;
 
-    public StructuralValidator(DocumentLimitsConfig limits) {
+    public FullDocValidator(DocumentLimitsConfig limits) {
       this.limits = limits;
       totalProperties = new AtomicInteger(0);
     }
@@ -286,30 +290,7 @@ public class Shredder {
       ++depth;
       validateDocDepth(limits, depth);
 
-      if (arrayValue.size() > limits.maxArrayLength()) {
-        // One special case: vector embeddings allow larger size
-        if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(referringPropertyName)) {
-          if (arrayValue.size() > limits.maxVectorEmbeddingLength()) {
-            throw new JsonApiException(
-                ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-                String.format(
-                    "%s: number of elements Vector embedding ('%s') has (%d) exceeds maximum allowed (%s)",
-                    ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-                    referringPropertyName,
-                    arrayValue.size(),
-                    limits.maxVectorEmbeddingLength()));
-          }
-        } else {
-          throw new JsonApiException(
-              ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-              String.format(
-                  "%s: number of elements an Array has (%d) exceeds maximum allowed (%s)",
-                  ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-                  arrayValue.size(),
-                  limits.maxArrayLength()));
-        }
-      }
-
+      // Array value size limit only applied for indexable, none checked here
       for (JsonNode element : arrayValue) {
         validateValue(null, element, depth, parentPathLength);
       }
@@ -403,36 +384,61 @@ public class Shredder {
     }
   }
 
-  static class ValueValidator {
+  /**
+   * Secondary validator applied to the storable document after non-indexable fields (and branches)
+   * have been pruned.
+   */
+  static class IndexableValueValidator {
     final DocumentLimitsConfig limits;
 
-    public ValueValidator(DocumentLimitsConfig limits) {
+    public IndexableValueValidator(DocumentLimitsConfig limits) {
       this.limits = limits;
     }
 
     public void validate(ObjectNode doc) {
-      validateObjectValue(doc);
+      validateObjectValue(null, doc);
     }
 
-    private void validateValue(JsonNode value) {
+    private void validateValue(String referringPropertyName, JsonNode value) {
       if (value.isObject()) {
-        validateObjectValue(value);
+        validateObjectValue(referringPropertyName, value);
       } else if (value.isArray()) {
-        validateArrayValue(value);
+        validateArrayValue(referringPropertyName, value);
       } else if (value.isTextual()) {
         validateStringValue(value.textValue());
       }
     }
 
-    private void validateArrayValue(JsonNode arrayValue) {
+    private void validateArrayValue(String referringPropertyName, JsonNode arrayValue) {
+      if (arrayValue.size() > limits.maxArrayLength()) {
+        // One special case: vector embeddings allow larger size
+        if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(referringPropertyName)) {
+          if (arrayValue.size() > limits.maxVectorEmbeddingLength()) {
+            throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
+                "%s: number of elements Vector embedding ('%s') has (%d) exceeds maximum allowed (%s)",
+                ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
+                referringPropertyName,
+                arrayValue.size(),
+                limits.maxVectorEmbeddingLength());
+          }
+        } else {
+          throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
+              "%s: number of elements an indexable Array ('%s') has (%d) exceeds maximum allowed (%s)",
+              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
+              referringPropertyName,
+              arrayValue.size(),
+              limits.maxArrayLength());
+        }
+      }
+
       for (JsonNode element : arrayValue) {
-        validateValue(element);
+        validateValue(referringPropertyName, element);
       }
     }
 
-    private void validateObjectValue(JsonNode objectValue) {
-      for (JsonNode value : objectValue) {
-        validateValue(value);
+    private void validateObjectValue(String referringPropertyName, JsonNode objectValue) {
+      for (Map.Entry<String, JsonNode> entry : objectValue.properties()) {
+        validateValue(entry.getKey(), entry.getValue());
       }
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
@@ -3,12 +3,17 @@ package io.stargate.sgv2.jsonapi.api.v1;
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
+import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
 import io.stargate.sgv2.jsonapi.config.constants.HttpConstants;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
 import org.junit.jupiter.api.ClassOrderer;
@@ -22,6 +27,8 @@ import org.junit.jupiter.api.TestClassOrder;
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractNamespaceIntegrationTestBase {
   private static final String collectionName = "no_index_collection";
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   @Nested
   @Order(1)
@@ -39,7 +46,7 @@ public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractNamespaceInt
                          "function": "cosine"
                        },
                        "indexing" : {
-                         "allow" : ["_id", "name", "value"]
+                         "allow" : ["_id", "name", "value", "indexed"]
                        }
                      }
                    }
@@ -186,6 +193,108 @@ public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractNamespaceInt
           .body("status.matchedCount", is(1))
           .body("status.modifiedCount", is(1))
           .body("errors", is(nullValue()));
+    }
+  }
+
+  @Nested
+  @Order(3)
+  @TestClassOrder(ClassOrderer.OrderAnnotation.class)
+  class ArraySizeLimit {
+    @Test
+    @Order(1)
+    public void allowNonIndexedBigArray() {
+      insertEmptyDoc("array_size_too_big_doc");
+      final String arrayJson = bigArray(DocumentLimitsConfig.DEFAULT_MAX_ARRAY_LENGTH + 10);
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                    {
+                      "findOneAndUpdate": {
+                        "filter" : {"_id" : "array_size_too_big_doc"},
+                        "update" : {
+                          "$set" : {
+                            "notIndexed.bigArray": %s
+                          }
+                        }
+                      }
+                    }
+                    """
+                  .formatted(arrayJson))
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("errors", is(nullValue()))
+          .body("status.matchedCount", is(1))
+          .body("status.modifiedCount", is(1));
+    }
+
+    @Test
+    @Order(2)
+    public void failOnIndexedTooBigArray() {
+      insertEmptyDoc("array_size_ok_doc");
+      final String arrayJson = bigArray(DocumentLimitsConfig.DEFAULT_MAX_ARRAY_LENGTH + 10);
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                            {
+                              "findOneAndUpdate": {
+                                "filter" : {"_id" : "array_size_ok_doc"},
+                                "update" : {
+                                  "$set" : {
+                                    "indexed.bigArray": %s
+                                  }
+                                }
+                              }
+                            }
+                            """
+                  .formatted(arrayJson))
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data", is(nullValue()))
+          .body("status", is(nullValue()))
+          .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
+          .body(
+              "errors[0].message",
+              containsString("number of elements an indexable Array ('bigArray')"))
+          .body("errors[0].message", containsString("exceeds maximum allowed"));
+    }
+
+    private void insertEmptyDoc(String docId) {
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(
+              """
+                        {
+                          "insertOne": {
+                            "document": {
+                              "_id": "%s"
+                            }
+                          }
+                        }
+                        """
+                  .formatted(docId))
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("status.insertedIds", hasSize(1))
+          .body("status.insertedIds[0]", is(docId));
+    }
+
+    private final String bigArray(int elementCount) {
+      final ArrayNode array = MAPPER.createArrayNode();
+      for (int i = 0; i < elementCount; i++) {
+        array.add(i);
+      }
+      return array.toString();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -559,7 +559,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               is(
-                  "Document size limitation violated: number of elements an Array has ("
+                  "Document size limitation violated: number of elements an indexable Array ('arr') has ("
                       + ARRAY_LEN
                       + ") exceeds maximum allowed ("
                       + MAX_ARRAY_LENGTH

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -14,9 +14,11 @@ import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import io.stargate.sgv2.jsonapi.service.projection.DocumentProjector;
 import jakarta.inject.Inject;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -183,6 +185,16 @@ public class ShredderDocLimitsTest {
       // Max allowed 1000, test:
       final ObjectNode doc = docWithNArrayElems("arr", docLimits.maxArrayLength());
       assertThat(shredder.shred(doc)).isNotNull();
+    }
+
+    // Test to verify that max-array-size limit only imposed on indexable fields
+    @Test
+    public void allowDocWithHugeArrayNoIndex() {
+      // Max allowed 1000 normally, but if array not-indexed, not limited
+      final ObjectNode doc = docWithNArrayElems("no_index", docLimits.maxArrayLength() + 100);
+      DocumentProjector indexProjector =
+          DocumentProjector.createForIndexing(null, Collections.singleton("no_index"));
+      assertThat(shredder.shred(doc, null, indexProjector)).isNotNull();
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -208,7 +208,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " number of elements an Array has ("
+              " number of elements an indexable Array ('arr') has ("
                   + arraySizeAboveMax
                   + ") exceeds maximum allowed ("
                   + docLimits.maxArrayLength()


### PR DESCRIPTION
**What this PR does**:

Removes validation of max-array-size on non-indexed fields

**Which issue(s) this PR fixes**:
Fixes #822

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
