### PR TITLE
increase max doc length limit: 1M -> 4M

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -25,7 +25,7 @@ Here are some Stargate-relevant property groups that are necessary for correct s
 
 | Property                                                        | Type  | Default     | Description                                                                          |
 |-----------------------------------------------------------------|-------|-------------|--------------------------------------------------------------------------------------|
-| `stargate.jsonapi.document.limits.max-size`                     | `int` | `1_000_000` | The maximum size of (in characters) a single document.                               |
+| `stargate.jsonapi.document.limits.max-size`                     | `int` | `4_000_000` | The maximum size of (in characters) a single document.                               |
 | `stargate.jsonapi.document.limits.max-depth`                    | `int` | `16`        | The maximum document depth (nesting).                                                |
 | `stargate.jsonapi.document.limits.max-property-name-length`     | `int` | `100`       | The maximum length of property names in a document for an individual segment.        |
 | `stargate.jsonapi.document.limits.max-property-path-length`     | `int` | `250`       | The maximum length of property paths in a document (segments and separating periods) |

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -13,7 +13,7 @@ import jakarta.validation.constraints.Positive;
 @ConfigMapping(prefix = "stargate.jsonapi.document.limits")
 public interface DocumentLimitsConfig {
   /** Defines the default maximum document size. */
-  int DEFAULT_MAX_DOCUMENT_SIZE = 1_000_000;
+  int DEFAULT_MAX_DOCUMENT_SIZE = 4_000_000;
 
   /** Defines the default maximum document (nesting) depth */
   int DEFAULT_MAX_DOCUMENT_DEPTH = 16;
@@ -57,7 +57,7 @@ public interface DocumentLimitsConfig {
   int DEFAULT_MAX_VECTOR_EMBEDDING_LENGTH = 4096;
 
   /**
-   * @return Defines the maximum document size, defaults to {@code 1 meg} (1 million characters).
+   * @return Defines the maximum document size, defaults to {@code 4 meg} (4 million characters).
    */
   @Positive
   @WithDefault("" + DEFAULT_MAX_DOCUMENT_SIZE)

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.quarkus.logging.Log;
 import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
@@ -238,9 +237,6 @@ public class Shredder {
   }
 
   private void validateDocumentSize(DocumentLimitsConfig limits, String docJson) {
-    Log.error("! " + docJson.length());
-    Log.error("!! " + limits.maxSize());
-
     // First: is the resulting document size (as serialized) too big?
     if (docJson.length() > limits.maxSize()) {
       throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.quarkus.logging.Log;
 import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
@@ -237,15 +238,14 @@ public class Shredder {
   }
 
   private void validateDocumentSize(DocumentLimitsConfig limits, String docJson) {
+    Log.error("! " + docJson.length());
+    Log.error("!! " + limits.maxSize());
+
     // First: is the resulting document size (as serialized) too big?
     if (docJson.length() > limits.maxSize()) {
-      throw new JsonApiException(
-          ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-          String.format(
-              "%s: document size (%d chars) exceeds maximum allowed (%d)",
-              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-              docJson.length(),
-              limits.maxSize()));
+      throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
+          "document size (%d chars) exceeds maximum allowed (%d)",
+          docJson.length(), limits.maxSize());
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -821,7 +821,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
           .body(
               "errors[0].message", startsWith("Document size limitation violated: document size ("))
-          .body("errors[0].message", endsWith(") exceeds maximum allowed (1000000)"));
+          .body("errors[0].message", endsWith(") exceeds maximum allowed (4000000)"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -37,16 +37,16 @@ public class ShredderDocLimitsTest {
   class ValidationDocSizeViolations {
     @Test
     public void allowBigButNotTooBigDoc() {
-      // Given we fail at 1 meg, let's try 800k (8 x 10 x 10k)
-      final ObjectNode bigDoc = createBigDoc(8, 10);
+      // Given we fail at 4 meg, let's try 600k (8 x 5 x 7.5k)
+      final ObjectNode bigDoc = createBigDoc(8, 5);
       assertThat(shredder.shred(bigDoc)).isNotNull();
     }
 
     @Test
     public void catchTooBigDoc() {
-      // Let's construct document above 1 meg limit (but otherwise legal), with
-      // 144 x 7.5k String values, divided in 12 sub documents of 12 properties
-      final ObjectNode bigDoc = createBigDoc(12, 12);
+      // Let's construct document above 4 meg limit (but otherwise legal), with
+      // (12x45) x 7.5k String values, divided in 12 sub documents of 45 properties
+      final ObjectNode bigDoc = createBigDoc(12, 45);
 
       Exception e = catchException(() -> shredder.shred(bigDoc));
       assertThat(e)

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -37,9 +37,14 @@ public class ShredderDocLimitsTest {
   class ValidationDocSizeViolations {
     @Test
     public void allowBigButNotTooBigDoc() {
-      // Given we fail at 4 meg, let's try 600k (8 x 5 x 7.5k)
+      // Given we fail at 4 meg
+      // let's try 600k (8 x 5 x 7.5k)
       final ObjectNode bigDoc = createBigDoc(8, 5);
       assertThat(shredder.shred(bigDoc)).isNotNull();
+
+      // let's also try 1m (12 x 12 x 7.5k)
+      final ObjectNode bigDoc1m = createBigDoc(12, 12);
+      assertThat(shredder.shred(bigDoc1m)).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
document max-size 1m characters -> 4m characters 

**Which issue(s) this PR fixes**:
Fixes #817 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
