### PR TITLE
Refactor exception mappers into single package (instead of split)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ConstraintViolationExceptionMapper.java
@@ -1,4 +1,4 @@
-package io.stargate.sgv2.jsonapi.api.exception;
+package io.stargate.sgv2.jsonapi.exception.mappers;
 
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import jakarta.validation.ConstraintViolation;

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/GenericExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/GenericExceptionMapper.java
@@ -1,8 +1,7 @@
-package io.stargate.sgv2.jsonapi.api.exception;
+package io.stargate.sgv2.jsonapi.exception.mappers;
 
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
-import io.stargate.sgv2.jsonapi.exception.mappers.ThrowableCommandResultSupplier;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/WebApplicationExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/WebApplicationExceptionMapper.java
@@ -1,10 +1,9 @@
-package io.stargate.sgv2.jsonapi.api.exception;
+package io.stargate.sgv2.jsonapi.exception.mappers;
 
 import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import io.stargate.sgv2.jsonapi.exception.ErrorCode;
 import io.stargate.sgv2.jsonapi.exception.JsonApiException;
-import io.stargate.sgv2.jsonapi.exception.mappers.ThrowableCommandResultSupplier;
 import jakarta.ws.rs.NotAllowedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.WebApplicationException;


### PR DESCRIPTION
**What this PR does**:

Unifies 2 separate exception mapper packages into one.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
