### PR TITLE
Refactoring: clean up / unify Shredder-thrown JsonApiExceptions

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -61,11 +61,8 @@ public class Shredder {
     // Although we could otherwise allow non-Object documents, requirement
     // to have the _id (or at least place for it) means we cannot allow that.
     if (!doc.isObject()) {
-      throw new JsonApiException(
-          ErrorCode.SHRED_BAD_DOCUMENT_TYPE,
-          String.format(
-              "%s: Document to shred must be a JSON Object, instead got %s",
-              ErrorCode.SHRED_BAD_DOCUMENT_TYPE.getMessage(), doc.getNodeType()));
+      throw ErrorCode.SHRED_BAD_DOCUMENT_TYPE.toApiException(
+          "document to shred must be a JSON Object, instead got %s", doc.getNodeType());
     }
 
     final ObjectNode docWithId = normalizeDocumentId((ObjectNode) doc);
@@ -208,11 +205,7 @@ public class Shredder {
       } else if (value.isNull()) {
         callback.shredNull(path);
       } else {
-        throw new JsonApiException(
-            ErrorCode.SHRED_UNRECOGNIZED_NODE_TYPE,
-            String.format(
-                "%s: %s",
-                ErrorCode.SHRED_UNRECOGNIZED_NODE_TYPE.getMessage(), value.getNodeType()));
+        throw ErrorCode.SHRED_UNRECOGNIZED_NODE_TYPE.toApiException(value.getNodeType().toString());
       }
     }
   }
@@ -222,16 +215,11 @@ public class Shredder {
       return;
     }
     if (!value.isArray()) {
-      throw new JsonApiException(
-          ErrorCode.SHRED_BAD_DOCUMENT_VECTOR_TYPE,
-          String.format(
-              "%s: %s",
-              ErrorCode.SHRED_BAD_DOCUMENT_VECTOR_TYPE.getMessage(), value.getNodeType()));
+      throw ErrorCode.SHRED_BAD_DOCUMENT_VECTOR_TYPE.toApiException(value.getNodeType().toString());
     }
     ArrayNode arr = (ArrayNode) value;
     if (arr.size() == 0) {
-      throw new JsonApiException(
-          ErrorCode.SHRED_BAD_VECTOR_SIZE, ErrorCode.SHRED_BAD_VECTOR_SIZE.getMessage());
+      throw new JsonApiException(ErrorCode.SHRED_BAD_VECTOR_SIZE);
     }
     callback.shredVector(path, arr);
   }
@@ -239,13 +227,9 @@ public class Shredder {
   private void validateDocumentSize(DocumentLimitsConfig limits, String docJson) {
     // First: is the resulting document size (as serialized) too big?
     if (docJson.length() > limits.maxSize()) {
-      throw new JsonApiException(
-          ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-          String.format(
-              "%s: document size (%d chars) exceeds maximum allowed (%d)",
-              ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-              docJson.length(),
-              limits.maxSize()));
+      throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
+          "document size (%d chars) exceeds maximum allowed (%d)",
+          docJson.length(), limits.maxSize());
     }
   }
 
@@ -266,13 +250,9 @@ public class Shredder {
       // Second: traverse to check for other constraints
       validateObjectValue(null, doc, 0, 0);
       if (totalProperties.get() > limits.maxDocumentProperties()) {
-        throw new JsonApiException(
-            ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-            String.format(
-                "%s: total number of properties (%d) in document exceeds maximum allowed (%d)",
-                ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-                totalProperties.get(),
-                limits.maxDocumentProperties()));
+        throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
+            "total number of properties (%d) in document exceeds maximum allowed (%d)",
+            totalProperties.get(), limits.maxDocumentProperties());
       }
     }
 
@@ -303,13 +283,9 @@ public class Shredder {
 
       final int propCount = objectValue.size();
       if (propCount > limits.maxObjectProperties()) {
-        throw new JsonApiException(
-            ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-            String.format(
-                "%s: number of properties an Object has (%d) exceeds maximum allowed (%s)",
-                ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-                objectValue.size(),
-                limits.maxObjectProperties()));
+        throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
+            "number of properties an Object has (%d) exceeds maximum allowed (%s)",
+            objectValue.size(), limits.maxObjectProperties());
       }
       totalProperties.addAndGet(propCount);
 
@@ -326,22 +302,13 @@ public class Shredder {
 
     private void validateObjectKey(String key, JsonNode value, int depth, int parentPathLength) {
       if (key.length() > limits.maxPropertyNameLength()) {
-        throw new JsonApiException(
-            ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-            String.format(
-                "%s: Property name length (%d) exceeds maximum allowed (%s) (name '%s')",
-                ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-                key.length(),
-                limits.maxPropertyNameLength(),
-                key));
+        throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
+            "property name length (%d) exceeds maximum allowed (%s) (name '%s')",
+            key.length(), limits.maxPropertyNameLength(), key);
       }
       if (key.length() == 0) {
         // NOTE: validity failure, not size limit
-        throw new JsonApiException(
-            ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION,
-            String.format(
-                "%s: empty names not allowed",
-                ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION.getMessage()));
+        throw ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION.toApiException("empty names not allowed");
       }
       if (!DocumentConstants.Fields.VALID_NAME_PATTERN.matcher(key).matches()) {
         // Special names are accepted in some cases: for now only one such case for
@@ -353,33 +320,22 @@ public class Shredder {
         } else if (key.equals(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD) && depth == 1) {
           ; // Fine, looks like legit vectorize field
         } else {
-          throw new JsonApiException(
-              ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION,
-              String.format(
-                  "%s: Property name ('%s') contains character(s) not allowed",
-                  ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION.getMessage(), key));
+          throw ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION.toApiException(
+              "property name ('%s') contains character(s) not allowed", key);
         }
       }
       int totalPathLength = parentPathLength + key.length();
       if (totalPathLength > limits.maxPropertyPathLength()) {
-        throw new JsonApiException(
-            ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-            String.format(
-                "%s: Property path length (%d) exceeds maximum allowed (%s) (path ends with '%s')",
-                ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-                totalPathLength,
-                limits.maxPropertyPathLength(),
-                key));
+        throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
+            "property path length (%d) exceeds maximum allowed (%d) (path ends with '%s')",
+            totalPathLength, limits.maxPropertyPathLength(), key);
       }
     }
 
     private void validateDocDepth(DocumentLimitsConfig limits, int depth) {
       if (depth > limits.maxDepth()) {
-        throw new JsonApiException(
-            ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-            String.format(
-                "%s: document depth exceeds maximum allowed (%s)",
-                ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(), limits.maxDepth()));
+        throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
+            "document depth exceeds maximum allowed (%s)", limits.maxDepth());
       }
     }
   }
@@ -415,12 +371,12 @@ public class Shredder {
         if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(referringPropertyName)) {
           if (arrayValue.size() > limits.maxVectorEmbeddingLength()) {
             throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-                "number of elements Vector embedding ('%s') has (%d) exceeds maximum allowed (%s)",
+                "number of elements Vector embedding ('%s') has (%d) exceeds maximum allowed (%d)",
                 referringPropertyName, arrayValue.size(), limits.maxVectorEmbeddingLength());
           }
         } else {
           throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-              "number of elements an indexable Array ('%s') has (%d) exceeds maximum allowed (%s)",
+              "number of elements an indexable Array ('%s') has (%d) exceeds maximum allowed (%d)",
               referringPropertyName, arrayValue.size(), limits.maxArrayLength());
         }
       }
@@ -440,13 +396,9 @@ public class Shredder {
       OptionalInt encodedLength =
           JsonUtil.lengthInBytesIfAbove(value, limits.maxStringLengthInBytes());
       if (encodedLength.isPresent()) {
-        throw new JsonApiException(
-            ErrorCode.SHRED_DOC_LIMIT_VIOLATION,
-            String.format(
-                "%s: Indexed String value length (%d bytes) exceeds maximum allowed (%d bytes)",
-                ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage(),
-                encodedLength.getAsInt(),
-                limits.maxStringLengthInBytes()));
+        throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
+            "indexed String value length (%d bytes) exceeds maximum allowed (%d bytes)",
+            encodedLength.getAsInt(), limits.maxStringLengthInBytes());
       }
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -606,7 +606,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith(
-                  "Document size limitation violated: Property name length (102) exceeds maximum allowed (100)"));
+                  "Document size limitation violated: property name length (102) exceeds maximum allowed (100)"));
     }
 
     // Test for nested paths, to ensure longer paths work too.
@@ -653,7 +653,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith(
-                  "Document size limitation violated: Property path length (272) exceeds maximum allowed (250)"));
+                  "Document size limitation violated: property path length (272) exceeds maximum allowed (250)"));
     }
 
     @Test
@@ -757,7 +757,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith(
-                  "Document size limitation violated: Indexed String value length (8056 bytes) exceeds maximum allowed"));
+                  "Document size limitation violated: indexed String value length (8056 bytes) exceeds maximum allowed"));
     }
 
     private String createBigString(int minLen) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -263,7 +263,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " Property name length ("
+              "property name length ("
                   + propName.length()
                   + ") exceeds maximum allowed ("
                   + docLimits.maxPropertyNameLength()
@@ -289,7 +289,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " Property path length (259) exceeds maximum allowed ("
+              "property path length (259) exceeds maximum allowed ("
                   + docLimits.maxPropertyPathLength()
                   + ") (path ends with 'longPropertyName')");
       ;
@@ -440,7 +440,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              "Document key name constraints violated: Property name ('"
+              "Document key name constraints violated: property name ('"
                   + invalidName
                   + "') contains character(s) not allowed");
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
@@ -312,7 +312,7 @@ public class ShredderTest {
       assertThat(t)
           .isNotNull()
           .hasMessage(
-              "Bad document type to shred: Document to shred must be a JSON Object, instead got ARRAY")
+              "Bad document type to shred: document to shred must be a JSON Object, instead got ARRAY")
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_DOCUMENT_TYPE);
     }
 


### PR DESCRIPTION
**What this PR does**:

Cleans up the way `Shredder` throws `JsonApiException` to use "formatter-throws" method.

Also unifies some of minor deviations on messages, so that we have consistent casing for error messages etc.
(and try to do this earlier rather than later to avoid later breakages past 1.0 GA)

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
