### PR TITLE
Fixes #819: remove max limit for Object property name (leaving full path max)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -28,7 +28,6 @@ Here are some Stargate-relevant property groups that are necessary for correct s
 |-----------------------------------------------------------------|-------|-------------|-----------------------------------------------------------------------------------------|
 | `stargate.jsonapi.document.limits.max-size`                     | `int` | `4_000_000` | The maximum size of (in characters) a single document.                                  |
 | `stargate.jsonapi.document.limits.max-depth`                    | `int` | `16`        | The maximum document depth (nesting).                                                   |
-| `stargate.jsonapi.document.limits.max-property-name-length`     | `int` | `100`       | The maximum length of property names in a document for an individual segment.           |
 | `stargate.jsonapi.document.limits.max-property-path-length`     | `int` | `250`       | The maximum length of property paths in a document (segments and separating periods)    |
 | `stargate.jsonapi.document.limits.max-object-properties`        | `int` | `1000`      | The maximum number of properties any single indexable object in a document can contain. |
 | `stargate.jsonapi.document.limits.max-document-properties`      | `int` | `2000`      | The maximum total number of properties all objects in a document can contain.           |

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -39,11 +39,8 @@ public interface DocumentLimitsConfig {
   /** Defines the default maximum length of a single Number value (in characters) */
   int DEFAULT_MAX_NUMBER_LENGTH = 100;
 
-  /** Defines the default maximum length of individual property names in JSON documents */
-  int DEFAULT_MAX_PROPERTY_NAME_LENGTH = 100;
-
   /**
-   * Defines the default maximum total length of path to individual properties JSON documents:
+   * Defines the default maximum total length of path to individual properties in JSON documents:
    * composed of individual Object property names separated by dots (".").
    */
   int DEFAULT_MAX_PROPERTY_PATH_LENGTH = 250;
@@ -71,15 +68,6 @@ public interface DocumentLimitsConfig {
   @Positive
   @WithDefault("" + DEFAULT_MAX_DOCUMENT_DEPTH)
   int maxDepth();
-
-  /**
-   * @return Defines the maximum length of property names in JSON documents, defaults to {@code 100
-   *     characters} (note: length is for individual name segments; full dotted names can be longer,
-   *     see {@link #maxPropertyPathLength()}}
-   */
-  @Positive
-  @WithDefault("" + DEFAULT_MAX_PROPERTY_NAME_LENGTH)
-  int maxPropertyNameLength();
 
   /**
    * @return Defines the maximum length of paths to properties in JSON documents, defaults to {@code

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -296,11 +296,6 @@ public class Shredder {
     }
 
     private void validateObjectKey(String key, JsonNode value, int depth, int parentPathLength) {
-      if (key.length() > limits.maxPropertyNameLength()) {
-        throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-            "property name length (%d) exceeds maximum allowed (%s) (name '%s')",
-            key.length(), limits.maxPropertyNameLength(), key);
-      }
       if (key.length() == 0) {
         // NOTE: validity failure, not size limit
         throw ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION.toApiException("empty names not allowed");

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -566,49 +566,6 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
                       + ")"));
     }
 
-    @Test
-    public void insertLongestValidName() {
-      final String LONGEST_NAME = "a".repeat(DocumentLimitsConfig.DEFAULT_MAX_PROPERTY_NAME_LENGTH);
-      ObjectNode doc = MAPPER.createObjectNode();
-      doc.put(DocumentConstants.Fields.DOC_ID, "docWithLongName");
-      // Max property name: 100 characters
-      doc.put(LONGEST_NAME, "stuff");
-      _verifyInsert("docWithLongName", doc);
-    }
-
-    @Test
-    public void tryInsertTooLongName() {
-      // Max property name: 100 characters, let's try 102
-      ObjectNode doc = MAPPER.createObjectNode();
-      doc.put(
-          "prop_12345_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_x",
-          72);
-      final String json =
-          """
-                  {
-                    "insertOne": {
-                      "document": %s
-                    }
-                  }
-                  """
-              .formatted(doc);
-      given()
-          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
-          .contentType(ContentType.JSON)
-          .body(json)
-          .when()
-          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
-          .then()
-          .statusCode(200)
-          .body("errors", hasSize(1))
-          .body("errors[0].exceptionClass", is("JsonApiException"))
-          .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
-          .body(
-              "errors[0].message",
-              startsWith(
-                  "Document size limitation violated: property name length (102) exceeds maximum allowed (100)"));
-    }
-
     // Test for nested paths, to ensure longer paths work too.
     @Test
     public void insertLongestValidPath() {

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -262,32 +262,6 @@ public class ShredderDocLimitsTest {
     }
 
     @Test
-    public void catchTooLongNames() {
-      final ObjectNode doc = objectMapper.createObjectNode();
-      doc.put("_id", 123);
-      ObjectNode ob = doc.putObject("subdoc");
-      final String propName =
-          "property_with_way_too_long_name_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789";
-      ob.put(propName, true);
-
-      Exception e = catchException(() -> shredder.shred(doc));
-      assertThat(e)
-          .isNotNull()
-          .isInstanceOf(JsonApiException.class)
-          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
-          .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
-          .hasMessageEndingWith(
-              "property name length ("
-                  + propName.length()
-                  + ") exceeds maximum allowed ("
-                  + docLimits.maxPropertyNameLength()
-                  + ") (name '"
-                  + propName
-                  + "')");
-      ;
-    }
-
-    @Test
     public void catchTooLongPaths() {
       final ObjectNode doc = objectMapper.createObjectNode();
       // Create 3-levels, 80 chars each, so close to 250; and then one bit longer value


### PR DESCRIPTION
**What this PR does**:

Removes now-redunant "maximum property name length" limit, as we have "maximum path" limit that is sufficient.
(also removes related tests)

**Which issue(s) this PR fixes**:
Fixes #819

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
