### PR TITLE
(incremental) Catch and re-throw Java CQL Driver fail exceptions as JsonApiException

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -130,7 +130,11 @@ public enum ErrorCode {
   VECTORIZE_SERVICE_TYPE_UNAVAILABLE("Vectorize service unavailable : "),
   VECTORIZE_USAGE_ERROR("Vectorize search can't be used with other sort clause"),
 
-  VECTORIZECONFIG_CHECK_FAIL("Internal server error: VectorizeConfig check fail");
+  VECTORIZECONFIG_CHECK_FAIL("Internal server error: VectorizeConfig check fail"),
+
+  UNAUTHORIZED_REQUEST("UNAUTHENTICATED: Invalid token"),
+  INVALID_QUERY("INVALID QUERY"),
+  OPERATION_TIMEOUT("OPERATION_TIMEOUT");
 
   private final String message;
 
@@ -144,5 +148,9 @@ public enum ErrorCode {
 
   public JsonApiException toApiException(String format, Object... args) {
     return new JsonApiException(this, message + ": " + String.format(format, args));
+  }
+
+  public JsonApiException toApiException() {
+    return new JsonApiException(this, message);
   }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/JsonApiException.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/JsonApiException.java
@@ -48,7 +48,7 @@ public class JsonApiException extends RuntimeException implements Supplier<Comma
     }
 
     // construct and return
-    CommandResult.Error error = getCommandResultError(message);
+    CommandResult.Error error = getCommandResultError(message, Response.Status.OK);
 
     // handle cause as well
     Throwable cause = getCause();
@@ -60,7 +60,7 @@ public class JsonApiException extends RuntimeException implements Supplier<Comma
     }
   }
 
-  public CommandResult.Error getCommandResultError(String message) {
+  public CommandResult.Error getCommandResultError(String message, Response.Status status) {
     Map<String, Object> fieldsForMetricsTag =
         Map.of("errorCode", errorCode.name(), "exceptionClass", this.getClass().getSimpleName());
     SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
@@ -72,7 +72,7 @@ public class JsonApiException extends RuntimeException implements Supplier<Comma
             ? Map.of(
                 "errorCode", errorCode.name(), "exceptionClass", this.getClass().getSimpleName())
             : Map.of("errorCode", errorCode.name());
-    return new CommandResult.Error(message, fieldsForMetricsTag, fields, Response.Status.OK);
+    return new CommandResult.Error(message, fieldsForMetricsTag, fields, status);
   }
 
   public ErrorCode getErrorCode() {


### PR DESCRIPTION
authentication failure from driver -> JsonApiException UNAUTHORIZED_REQUEST, 401
invalid query (e.g. vector dimension mismatch) -> JsonApiException INVALID_QUERY, 200
DriverTimeout, WriteTimeout, ReadTimeout -> JsonApiException OPERATION_TIMEOUT, 200


**What this PR does**:
partially fix #751 

This PR should be actively discussed, since driver exception like NoNodeAvailableException, is tricky to locate and map into JsonApiException

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
