### PR TITLE
Fixes #820: increase max path length limit to 1000 (from 250)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -28,7 +28,7 @@ Here are some Stargate-relevant property groups that are necessary for correct s
 |-----------------------------------------------------------------|-------|-------------|-----------------------------------------------------------------------------------------|
 | `stargate.jsonapi.document.limits.max-size`                     | `int` | `4_000_000` | The maximum size of (in characters) a single document.                                  |
 | `stargate.jsonapi.document.limits.max-depth`                    | `int` | `16`        | The maximum document depth (nesting).                                                   |
-| `stargate.jsonapi.document.limits.max-property-path-length`     | `int` | `250`       | The maximum length of property paths in a document (segments and separating periods)    |
+| `stargate.jsonapi.document.limits.max-property-path-length`     | `int` | `1000`       | The maximum length of property paths in a document (segments and separating periods)    |
 | `stargate.jsonapi.document.limits.max-object-properties`        | `int` | `1000`      | The maximum number of properties any single indexable object in a document can contain. |
 | `stargate.jsonapi.document.limits.max-document-properties`      | `int` | `2000`      | The maximum number of total indexed properties a document can contain.                        |
 | `stargate.jsonapi.document.limits.max-number-length`            | `int` | `100`       | The maximum length (in characters) of a single number value in a document.              |

--- a/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java
@@ -42,7 +42,7 @@ public interface DocumentLimitsConfig {
    * Defines the default maximum total length of path to individual properties in JSON documents:
    * composed of individual Object property names separated by dots (".").
    */
-  int DEFAULT_MAX_PROPERTY_PATH_LENGTH = 250;
+  int DEFAULT_MAX_PROPERTY_PATH_LENGTH = 1000;
 
   /**
    * Defines the default maximum length of a single String value: 8,000 bytes with 1.0.0-BETA-6 and

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -569,24 +569,25 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
     // Test for nested paths, to ensure longer paths work too.
     @Test
     public void insertLongestValidPath() {
-      // Need to hard-code knowledge of defaults here: max path is 250 (max single prop name 100)
-      // Since commas are also counted, let's do 4 x 60 (plus 3 commas) == 243 chars
+      // Need to hard-code knowledge of defaults here: max path is 1000
+      // Since periods are also counted, let's do 4 x 200 (plus 3 dots) == 803 chars
       ObjectNode doc = MAPPER.createObjectNode();
-      ObjectNode prop1 = doc.putObject("a123".repeat(15));
-      ObjectNode prop2 = prop1.putObject("b123".repeat(15));
-      ObjectNode prop3 = prop2.putObject("c123".repeat(15));
-      prop3.put("d123".repeat(15), 42);
+      ObjectNode prop1 = doc.putObject("a1234".repeat(40));
+      ObjectNode prop2 = prop1.putObject("b1234".repeat(40));
+      ObjectNode prop3 = prop2.putObject("c1234".repeat(40));
+      prop3.put("d1234".repeat(40), 42);
       doc.put(DocumentConstants.Fields.DOC_ID, "docWithLongPath");
       _verifyInsert("docWithLongPath", doc);
     }
 
     @Test
     public void tryInsertTooLongPath() {
-      // Max path: 250 characters. Exceed with 272
+      // Max path: 100 characters. Exceed with 4 x 250 + 3
       ObjectNode doc = MAPPER.createObjectNode();
-      ObjectNode prop1 = doc.putObject("a".repeat(90));
-      ObjectNode prop2 = prop1.putObject("b".repeat(90));
-      prop2.put("c".repeat(90), true);
+      ObjectNode prop1 = doc.putObject("a".repeat(250));
+      ObjectNode prop2 = prop1.putObject("b".repeat(250));
+      ObjectNode prop3 = prop2.putObject("c".repeat(250));
+      prop3.put("d".repeat(250), true);
       final String json =
           """
                       {
@@ -610,7 +611,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith(
-                  "Document size limitation violated: property path length (272) exceeds maximum allowed (250)"));
+                  "Document size limitation violated: property path length (1003) exceeds maximum allowed (1000)"));
     }
 
     @Test
@@ -675,8 +676,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
       ObjectNode doc = MAPPER.createObjectNode();
       final String docId = "docWithLongString";
       doc.put(DocumentConstants.Fields.DOC_ID, docId);
-      // 1M / 8k means at most 125 max length Strings; add 63 (with _id max of 64
-      // properties per Object)
+      // 1M / 8k means at most 125 max length Strings; add 63 (with _id 64)
       for (int i = 0; i < 63; ++i) {
         doc.put("text" + i, createBigString(strLen));
       }


### PR DESCRIPTION
**What this PR does**:
Increases maximum allowed path length to 1000 (from 250)

**Which issue(s) this PR fixes**:
Fixes #820 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
