### PR TITLE
Build Docker image with profiling tools

### DIFF
--- a/.github/workflows/docker-image-publish.yaml
+++ b/.github/workflows/docker-image-publish.yaml
@@ -68,6 +68,11 @@ jobs:
         run: |
           ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' ${{ matrix.profile }}
 
+      - name: Build and push image for profiling (Amazon ECR)
+        run: |
+          ./mvnw -B -ntp clean package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.docker.buildx.platform=linux/amd64,linux/arm64 -Dquarkus.container-image.push=true -Dquarkus.container-image.registry=${{ secrets.ECR_REPOSITORY }} -Dquarkus.container-image.tag=${{ github.sha }} -Dquarkus.container-image.additional-tags='' -Dquarkus.container-image.name=jsonapi-profiling -Dquarkus.docker.dockerfile-jvm-path=src/main/docker/Dockerfile-profiling.jvm ${{ matrix.profile }}
+
+
   # signs docker image with cosign
   sign:
     name: Sign image
@@ -107,6 +112,20 @@ jobs:
         shell: bash
         env:
           COSIGN_IMAGE: ${{ secrets.ECR_REPOSITORY }}/stargateio/${{ matrix.image }}:${{ github.sha }}
+          COSIGN_PRIVATE_BASE64: ${{ secrets.COSIGN_PRIVATE_BASE64 }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          COSIGN_KEY_FILE: _cosign_key_
+          AUX_KEY: signedby
+          AUX_VALUE: stargate
+        run: |
+          echo $COSIGN_PRIVATE_BASE64 | base64 --decode > $COSIGN_KEY_FILE
+          echo "=== signing image [$COSIGN_IMAGE] ..."
+          cosign sign --key $COSIGN_KEY_FILE -a $AUX_KEY=$AUX_VALUE $COSIGN_IMAGE
+
+      - name: Sign profiling docker image
+        shell: bash
+        env:
+          COSIGN_IMAGE: ${{ secrets.ECR_REPOSITORY }}/stargateio/${{ matrix.image }}-profiling:${{ github.sha }}
           COSIGN_PRIVATE_BASE64: ${{ secrets.COSIGN_PRIVATE_BASE64 }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_KEY_FILE: _cosign_key_

--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ Or, if you want to create a native-runnable Docker image named `io.stargate/json
 ./mvnw clean package -Pnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true
 ```
 
+You can create a JVM-based Docker image (`stargateio/jsonapi-profiling`) with additional profiling tools by using:
+```shell script
+./mvnw -B -ntp package -DskipTests -Dquarkus.container-image.build=true -Dquarkus.container-image.name=jsonapi-profiling -Dquarkus.docker.dockerfile-jvm-path=src/main/docker/Dockerfile-profiling.jvm
+```
+
 If you want to learn more about building container images, please consult [Container images](https://quarkus.io/guides/container-image).
 
 ## Quarkus Extensions

--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -1,0 +1,39 @@
+####
+# Dockerfile for building API image with profiling tools included
+# based on less minimal UBI8 OpenJDK 17 image
+#
+###
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.17
+
+ENV LANGUAGE='en_US:en'
+
+ARG TARGETARCH
+
+ENV ARCH=arm64
+
+RUN if [ "TARGETARCH" = "amd64" ]; then \
+      export ARCH=x64; \
+    fi
+
+RUN mkdir -p /opt/profiler
+ARG PROFILE_TOOLS=profiler-$TARGETARCH
+
+USER root
+RUN microdnf update && microdnf install gzip
+
+USER jboss
+RUN mkdir -p /opt/profiler && curl -fsL https://github.com/async-profiler/async-profiler/releases/download/v2.9/async-profiler-2.9-linux-${ARCH}.tar.gz | tar zxvf - -C /opt/profiler --strip-components 1
+RUN mkdir -p /opt/sjk-plus && curl -o /opt/sjk-plus/sjk-plus-0.20.jar https://repo.datastax.com/artifactory/dse/org/gridkit/jvmtool/sjk-plus/0.20/sjk-plus-0.20.jar;
+
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/
+COPY --chown=185 target/quarkus-app/*.jar /deployments/
+COPY --chown=185 target/quarkus-app/app/ /deployments/app/
+COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8181
+USER 185
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+
+

--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -22,7 +22,7 @@ USER root
 RUN microdnf update && microdnf install gzip && microdnf install procps-ng
 
 USER jboss
-RUN mkdir -p /opt/profiler && curl -fsL https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-${ARCH}.tar.gz | tar zxvf - -C /opt/profiler --strip-components 1
+RUN mkdir -p /opt/profiler && curl -fsL https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz | tar zxvf - -C /opt/profiler --strip-components 1
 RUN mkdir -p /opt/sjk-plus && curl -o /opt/sjk-plus/sjk-plus-0.20.jar https://repo.datastax.com/artifactory/dse/org/gridkit/jvmtool/sjk-plus/0.20/sjk-plus-0.20.jar;
 
 # We make four distinct layers so if there are application changes the library layers can be re-used

--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -7,17 +7,6 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:1.17
 
 ENV LANGUAGE='en_US:en'
 
-ARG TARGETARCH
-
-ENV ARCH=arm64
-
-RUN if [ "TARGETARCH" = "amd64" ]; then \
-      export ARCH=x64; \
-    fi
-
-RUN mkdir -p /opt/profiler
-ARG PROFILE_TOOLS=profiler-$TARGETARCH
-
 USER root
 RUN microdnf update && microdnf install gzip && microdnf install procps-ng
 

--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -19,10 +19,10 @@ RUN mkdir -p /opt/profiler
 ARG PROFILE_TOOLS=profiler-$TARGETARCH
 
 USER root
-RUN microdnf update && microdnf install gzip
+RUN microdnf update && microdnf install gzip && microdnf install procps-ng
 
 USER jboss
-RUN mkdir -p /opt/profiler && curl -fsL https://github.com/async-profiler/async-profiler/releases/download/v2.9/async-profiler-2.9-linux-${ARCH}.tar.gz | tar zxvf - -C /opt/profiler --strip-components 1
+RUN mkdir -p /opt/profiler && curl -fsL https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-${ARCH}.tar.gz | tar zxvf - -C /opt/profiler --strip-components 1
 RUN mkdir -p /opt/sjk-plus && curl -o /opt/sjk-plus/sjk-plus-0.20.jar https://repo.datastax.com/artifactory/dse/org/gridkit/jvmtool/sjk-plus/0.20/sjk-plus-0.20.jar;
 
 # We make four distinct layers so if there are application changes the library layers can be re-used

--- a/src/main/docker/Dockerfile-profiling.jvm
+++ b/src/main/docker/Dockerfile-profiling.jvm
@@ -11,7 +11,7 @@ USER root
 RUN microdnf update && microdnf install gzip && microdnf install procps-ng
 
 USER jboss
-RUN mkdir -p /opt/profiler && curl -fsL https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz | tar zxvf - -C /opt/profiler --strip-components 1
+RUN mkdir -p /opt/profiler && curl -fsL https://github.com/async-profiler/async-profiler/releases/download/v2.9/async-profiler-2.9-linux-x64.tar.gz | tar zxvf - -C /opt/profiler --strip-components 1
 RUN mkdir -p /opt/sjk-plus && curl -o /opt/sjk-plus/sjk-plus-0.20.jar https://repo.datastax.com/artifactory/dse/org/gridkit/jvmtool/sjk-plus/0.20/sjk-plus-0.20.jar;
 
 # We make four distinct layers so if there are application changes the library layers can be re-used


### PR DESCRIPTION
This adds an option to build Docker images with profiling tools including the [async profiler](https://github.com/async-profiler/async-profiler) and [Swiss Java Knife](https://github.com/aragozin/jvm-tools). 

The new dockerfile is based on a JDK base image instead of a JRE base image, so the resulting images are about 2x larger. Having a JDK base image also means that tools like `jmap`, `jstack`, and `jstat` are available. You can execute these commands against a running JSON API container.

The PR also includes updates to CI workflow so that images can be pushed to internal staging areas.

Fixes #671 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
