### PR TITLE
Bug fix for array size filter for `0` length

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -23,7 +23,6 @@ Here are some Stargate-relevant property groups that are necessary for correct s
 ## Document limits configuration
 *Configuration for document limits, defined by [DocumentLimitsConfig.java](src/main/java/io/stargate/sgv2/jsonapi/config/DocumentLimitsConfig.java).*
 
-<<<<<<< HEAD
 | Property                                                        | Type  | Default     | Description                                                                             |
 |-----------------------------------------------------------------|-------|-------------|-----------------------------------------------------------------------------------------|
 | `stargate.jsonapi.document.limits.max-size`                     | `int` | `4_000_000` | The maximum size of (in characters) a single document.                                  |

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/matcher/FilterableResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/matcher/FilterableResolver.java
@@ -313,7 +313,7 @@ public abstract class FilterableResolver<T extends Command & Filterable> {
         // Negative means check array_size[?] != ?
         int size = bigDecimal.intValue();
         DBFilterBase.MapFilterBase.Operator operator;
-        if (size > 0) {
+        if (size >= 0) {
           operator = DBFilterBase.MapFilterBase.Operator.MAP_EQUALS;
         } else {
           operator = DBFilterBase.MapFilterBase.Operator.MAP_NOT_EQUALS;

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
@@ -196,6 +196,43 @@ public class FindCommandResolverTest {
     }
 
     @Test
+    public void arraySizeFilter() throws Exception {
+      String json =
+          """
+          {
+            "find": {
+              "filter" : {"tags" : { "$size" : 0}}
+            }
+          }
+          """;
+
+      FindCommand findCommand = objectMapper.readValue(json, FindCommand.class);
+      Operation operation = resolver.resolveCommand(commandContext, findCommand);
+
+      assertThat(operation)
+          .isInstanceOfSatisfying(
+              FindOperation.class,
+              find -> {
+                DBFilterBase filter =
+                    new DBFilterBase.SizeFilter("tags", DBFilterBase.MapFilterBase.Operator.MAP_EQUALS, 0);
+                assertThat(find.objectMapper()).isEqualTo(objectMapper);
+                assertThat(find.commandContext()).isEqualTo(commandContext);
+                assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());
+                assertThat(find.pageSize()).isEqualTo(operationsConfig.defaultPageSize());
+                assertThat(find.limit()).isEqualTo(Integer.MAX_VALUE);
+                assertThat(find.pageState()).isNull();
+                assertThat(find.readType()).isEqualTo(ReadType.DOCUMENT);
+                assertThat(find.skip()).isZero();
+                assertThat(find.maxSortReadLimit()).isZero();
+                assertThat(find.singleResponse()).isFalse();
+                assertThat(find.orderBy()).isNull();
+                assertThat(
+                        find.logicalExpression().comparisonExpressions.get(0).getDbFilters().get(0))
+                    .isEqualTo(filter);
+              });
+    }
+
+    @Test
     public void byIdInAndOtherConditionTogether() throws Exception {
       String json =
           """

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/FindCommandResolverTest.java
@@ -214,7 +214,8 @@ public class FindCommandResolverTest {
               FindOperation.class,
               find -> {
                 DBFilterBase filter =
-                    new DBFilterBase.SizeFilter("tags", DBFilterBase.MapFilterBase.Operator.MAP_EQUALS, 0);
+                    new DBFilterBase.SizeFilter(
+                        "tags", DBFilterBase.MapFilterBase.Operator.MAP_EQUALS, 0);
                 assertThat(find.objectMapper()).isEqualTo(objectMapper);
                 assertThat(find.commandContext()).isEqualTo(commandContext);
                 assertThat(find.projection()).isEqualTo(DocumentProjector.identityProjector());


### PR DESCRIPTION
**What this PR does**:
Bug fix for array size filter for `0` length

**Which issue(s) this PR fixes**:
Fixes #862 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
