### PR TITLE
Increase default maximum HTTP body size at server level from 5MB to 20MB

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -11,6 +11,10 @@ Here are some Stargate-relevant property groups that are necessary for correct s
 * `quarkus.grpc.clients.bridge` - property group for defining the Bridge gRPC client (see [gRPC Client configuration](https://quarkus.io/guides/grpc-service-consumption#client-configuration) for all options)
 * `quarkus.cache.caffeine.keyspace-cache` - property group  for defining the keyspace cache used by [SchemaManager](../sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/schema/SchemaManager.java) (see [Caffeine cache configuration](https://quarkus.io/guides/cache#caffeine-configuration-properties) for all options)
 
+Other Quarkus properties that are specifically relevant for the service:
+
+* `quarkus.http.limits.max-body-size` - maximum HTTP payload size (in bytes) that the server will accept. Default is 20MB.
+
 ## Database limits configuration
 *Configuration for document limits, defined by [DatabaseLimitsConfig.java](src/main/java/io/stargate/sgv2/jsonapi/config/DatabaseLimitsConfig.java).*
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -84,10 +84,11 @@ quarkus:
           policy: authenticated
 
     limits:
-      # Let's limit low-level maximum HTTP request size to 5 megs: stricter limit (1 meg)
-      # is applied at the JSON API level. Low-level limits may result in EPIPE/413 errors
+      # Let's limit low-level maximum HTTP request size to 20 megs: stricter
+      # limit (4 meg per document) is applied at the JSON API level.
+      # Low-level limits may result in EPIPE/413 errors
       # whereas at higher level we can use regular JSON API error responses
-      max-body-size: 5M
+      max-body-size: 20M
 
     port: 8181
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -88,7 +88,7 @@ quarkus:
       # limit (4 meg per document) is applied at the JSON API level.
       # Low-level limits may result in EPIPE/413 errors
       # whereas at higher level we can use regular JSON API error responses
-      max-body-size: 20M
+      max-body-size: 1M
 
     port: 8181
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -88,7 +88,7 @@ quarkus:
       # limit (4 meg per document) is applied at the JSON API level.
       # Low-level limits may result in EPIPE/413 errors
       # whereas at higher level we can use regular JSON API error responses
-      max-body-size: 1M
+      max-body-size: 20M
 
     port: 8181
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.api.v1;
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 import static org.hamcrest.Matchers.blankString;
 import static org.hamcrest.Matchers.contains;
@@ -41,6 +42,8 @@ import org.junit.jupiter.api.TestClassOrder;
 @QuarkusTestResource(DseTestResource.class)
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase {
+  private final ObjectMapper MAPPER = new ObjectMapper();
+
   @AfterEach
   public void cleanUpData() {
     deleteAllDocuments();
@@ -512,8 +515,6 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
   @Nested
   @Order(2)
   class InsertOneConstraintChecking {
-    private final ObjectMapper MAPPER = new ObjectMapper();
-
     private static final int MAX_ARRAY_LENGTH = DocumentLimitsConfig.DEFAULT_MAX_ARRAY_LENGTH;
 
     @Test
@@ -903,51 +904,6 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .statusCode(200)
           .body("errors", is(nullValue()))
           .body("data.documents[0]", jsonEquals(doc.toString()));
-    }
-
-    private JsonNode createBigDoc(String docId, int minDocSize) throws IOException {
-      // While it'd be cleaner to build JsonNode representation, checking for
-      // size much more expensive so go low-tech instead
-      StringBuilder sb = new StringBuilder(minDocSize + 1000);
-      sb.append("{\"_id\":\"").append(docId).append('"');
-
-      boolean bigEnough = false;
-
-      // Since we add one property before loop, reduce max by 1.
-      // Target is around 1 meg; can have at most 2000 properties, and for
-      // big doc we don't want to exceed 1000 bytes per property.
-      // So let's make properties arrays of 4 Strings to get there.
-      final int ROOT_PROPS = 99;
-      final int LEAF_PROPS = 20; // so it's slightly under 2000 total properties, max
-      final String TEXT_1K = "abcd123 ".repeat(120); // 960 chars
-
-      // Use double loop to create a document with a lot of properties, 2-level nesting
-      for (int i = 0; i < ROOT_PROPS && !bigEnough; ++i) {
-        sb.append(",\n\"root").append(i).append("\":{");
-        // Add one short entry to simplify following loop
-        sb.append("\n \"subId\":").append(i);
-        for (int j = 0; j < LEAF_PROPS && !bigEnough; ++j) {
-          sb.append(",\n \"sub").append(j).append("\":");
-          sb.append('[');
-          sb.append('"').append(TEXT_1K).append("\",");
-          sb.append('"').append(TEXT_1K).append("\",");
-          sb.append('"').append(TEXT_1K).append("\",");
-          sb.append('"').append(TEXT_1K).append("\"");
-          sb.append(']');
-          bigEnough = sb.length() >= minDocSize;
-        }
-        sb.append("\n}");
-      }
-      sb.append("\n}");
-      if (!bigEnough) {
-        fail(
-            "Failed to create a document big enough, size: "
-                + sb.length()
-                + " bytes; needed "
-                + minDocSize);
-      }
-
-      return MAPPER.readTree(sb.toString());
     }
   }
 
@@ -1432,7 +1388,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
 
   @Nested
   @Order(4)
-  class InsertManyFailing {
+  class InsertManyLimitsChecking {
     @Test
     public void tryInsertTooLongNumber() {
       // Max number length: 100; use 110
@@ -1471,6 +1427,88 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
               startsWith("Document size limitation violated: Number value length"))
           .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"));
     }
+
+    @Test
+    public void insertBigButNotTooBigPayload() {
+      final int bigSize = DocumentLimitsConfig.DEFAULT_MAX_DOCUMENT_SIZE - 50_000;
+      // 5 x bit under 4 M should be just under limit
+      String json =
+          """
+                      {
+                        "insertMany": {
+                          "documents": [
+                            %s,
+                            %s,
+                            %s,
+                            %s,
+                            %s
+                          ]
+                        }
+                      }
+                      """
+              .formatted(
+                  createBigDoc("big1", bigSize).toString(),
+                  createBigDoc("big2", bigSize).toString(),
+                  createBigDoc("big3", bigSize).toString(),
+                  createBigDoc("big4", bigSize).toString(),
+                  createBigDoc("big5", bigSize).toString());
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200);
+    }
+
+    // Testing Quarkus max payload (20M); separate from Max Doc Size limit (4M)
+    // (so need 6 documents to exceed)
+    @Test
+    public void tryInsertTooBigPayload() {
+      final int bigSize = DocumentLimitsConfig.DEFAULT_MAX_DOCUMENT_SIZE - 50_000;
+      String json =
+          """
+                  {
+                    "insertMany": {
+                      "documents": [
+                        %s,
+                        %s,
+                        %s,
+                        %s,
+                        %s,
+                        %s
+                      ]
+                    }
+                  }
+                  """
+              .formatted(
+                  createBigDoc("toobig1", bigSize).toString(),
+                  createBigDoc("toobig2", bigSize).toString(),
+                  createBigDoc("toobig3", bigSize).toString(),
+                  createBigDoc("toobig4", bigSize).toString(),
+                  createBigDoc("toobig5", bigSize).toString(),
+                  createBigDoc("toobig6", bigSize).toString());
+      // Either we get 413 (Payload Too Large) due to Quarkus limit, or,
+      // java.net.SocketException: Broken Pipe
+      // in latter case, it's via "sneaky throw", unfortunately, so catch
+      // needs to be for Exception and only then verifying
+      try {
+        given()
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+            .contentType(ContentType.JSON)
+            .body(json)
+            .when()
+            .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+            .then()
+            .statusCode(403);
+      } catch (Exception e) {
+        // Sneaky throw, must catch any Exception, verify type separately
+        assertThat(e)
+            .isInstanceOf(java.net.SocketException.class)
+            .hasMessageStartingWith("Broken pipe");
+      }
+    }
   }
 
   @Nested
@@ -1484,6 +1522,55 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
     @Test
     public void checkInsertManyMetrics() {
       InsertIntegrationTest.super.checkMetrics("InsertManyCommand");
+    }
+  }
+
+  private JsonNode createBigDoc(String docId, int minDocSize) {
+    // While it'd be cleaner to build JsonNode representation, checking for
+    // size much more expensive so go low-tech instead
+    StringBuilder sb = new StringBuilder(minDocSize + 1000);
+    sb.append("{\"_id\":\"").append(docId).append('"');
+
+    boolean bigEnough = false;
+
+    // Since we add one property before loop, reduce max by 1.
+    // Target is around 1 meg; can have at most 2000 properties, and for
+    // big doc we don't want to exceed 1000 bytes per property.
+    // So let's make properties arrays of 4 Strings to get there.
+    final int ROOT_PROPS = 99;
+    final int LEAF_PROPS = 20; // so it's slightly under 2000 total properties, max
+    final String TEXT_1K = "abcd123 ".repeat(120); // 960 chars
+
+    // Use double loop to create a document with a lot of properties, 2-level nesting
+    for (int i = 0; i < ROOT_PROPS && !bigEnough; ++i) {
+      sb.append(",\n\"root").append(i).append("\":{");
+      // Add one short entry to simplify following loop
+      sb.append("\n \"subId\":").append(i);
+      for (int j = 0; j < LEAF_PROPS && !bigEnough; ++j) {
+        sb.append(",\n \"sub").append(j).append("\":");
+        sb.append('[');
+        sb.append('"').append(TEXT_1K).append("\",");
+        sb.append('"').append(TEXT_1K).append("\",");
+        sb.append('"').append(TEXT_1K).append("\",");
+        sb.append('"').append(TEXT_1K).append("\"");
+        sb.append(']');
+        bigEnough = sb.length() >= minDocSize;
+      }
+      sb.append("\n}");
+    }
+    sb.append("\n}");
+    if (!bigEnough) {
+      fail(
+          "Failed to create a document big enough, size: "
+              + sb.length()
+              + " bytes; needed "
+              + minDocSize);
+    }
+
+    try {
+      return MAPPER.readTree(sb.toString());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
   }
 }


### PR DESCRIPTION
**What this PR does**:

Increases Quarkus HTTP limit for maximum body size to 20 megs, to better align with increased maximum document size (4M) allowed at API level

**Which issue(s) this PR fixes**:
Fixes #856

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
