### PR TITLE
Fixes #873: improve Bean Validation failure messages

### DIFF
--- a/docs/jsonapi-spec.md
+++ b/docs/jsonapi-spec.md
@@ -532,11 +532,11 @@ See [Multi-Document Failure Considerations](#multi-document-failure-consideratio
 
 #### countDocuments Command Response
 
-| Response Elements | Description                                             |
-| ----------------- | ------------------------------------------------------- |
-| `data`            | Not present                                             |
-| `status`          | Preset with fields: `count: <zero-or-positive-integer>` |
-| `errors`          | Present if errors occur.                                |
+| Response Elements | Description                                              |
+| ----------------- |----------------------------------------------------------|
+| `data`            | Not present                                              |
+| `status`          | Present with fields: `count: <zero-or-positive-integer>` |
+| `errors`          | Present if errors occur.                                 |
  
 If an error occurs the command will not return `status`.
 
@@ -683,11 +683,11 @@ The maximum amount of documents that can be deleted in a single operation is 20.
 
 #### deleteMany Command Response
 
-| Response Elements | Description                                                                          |
-| ----------------- | ------------------------------------------------------------------------------------ |
-| `data`            | Not present                                                                          |
-| `status`          | Preset with fields: `deletedCount: <zero-or-positive-integer>`, `moreData` with value `true` if there are more documents that match the delete `filter`, but were not deleted since the limit of documents to delete in the single operation was hit. |
-| `errors`          | Present if errors occur. |
+| Response Elements | Description                                                                                                                                                                                                                                            |
+| ----------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `data`            | Not present                                                                                                                                                                                                                                            |
+| `status`          | Present with fields: `deletedCount: <zero-or-positive-integer>`, `moreData` with value `true` if there are more documents that match the delete `filter`, but were not deleted since the limit of documents to delete in the single operation was hit. |
+| `errors`          | Present if errors occur.                                                                                                                                                                                                                               |
 
 If an error occurs the command will still return `status` as some documents may have been deleted.
 
@@ -714,11 +714,11 @@ See [Multi-Document Failure Considerations](#multi-document-failure-consideratio
 
 #### deleteOne Command Response
 
-| Response Elements | Description                                               |
-| ----------------- | --------------------------------------------------------- |
-| `data`            | Not present                                               |
-| `status`          | Preset with fields: `deletedCount: <zero-or-one-integer>` |
-| `errors`          | Present if errors occur.                                  |
+| Response Elements | Description                                                |
+| ----------------- |------------------------------------------------------------|
+| `data`            | Not present                                                |
+| `status`          | Present with fields: `deletedCount: <zero-or-one-integer>` |
+| `errors`          | Present if errors occur.                                   |
  
 If an error occurs the command will not return `status`.
 
@@ -905,7 +905,7 @@ If `<sort-clause>` is present, the maximum amount of documents that could be sor
 | Response Elements | Description                                                                                                                                        |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | `data`            | Present with fields : `document` only, see [findOneAndReplace Command Options](#findOneAndReplace-command-options) for controlling the projection. |
-| `status`          | Preset with fields: `upsertedId: <id of document upserted>`, if a document was upserted.                                                           |
+| `status`          | Present with fields: `upsertedId: <id of document upserted>`, if a document was upserted.                                                          |
 | `errors`          | Present if errors occur.                                                                                                                           |
 
 If an error occurs the command will not return `data` or `status`.
@@ -980,7 +980,7 @@ If `<sort-clause>` is present, the maximum amount of documents that could be sor
 | Response Elements | Description                                                                                                                                      |
 |-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
 | `data`            | Present with fields : `document` only, see [findOneAndUpdate Command Options](#findOneAndUpdate-command-options) for controlling the projection. |
-| `status`          | Preset with fields: `upsertedId: <json-value>` only if a document was upserted.                                                                  |
+| `status`          | Present with fields: `upsertedId: <json-value>` only if a document was upserted.                                                                 |
 | `errors`          | Present if errors occur.                                                                                                                         |
 
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ConstraintViolationExceptionMapper.java
@@ -37,7 +37,10 @@ public class ConstraintViolationExceptionMapper {
   private static CommandResult.Error getError(ConstraintViolation<?> violation) {
     String message = violation.getMessage();
     Path propertyPath = violation.getPropertyPath();
-    String msg = "Request invalid, the field %s not valid: %s.".formatted(propertyPath, message);
+    Object propertyValue = violation.getInvalidValue();
+    String msg =
+        "Request invalid, the field '%s' (value '%s') not valid: %s."
+            .formatted(propertyPath, propertyValue, message);
     return new CommandResult.Error(msg, ERROR_FIELDS, ERROR_FIELDS_METRICS_TAG, Response.Status.OK);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
@@ -47,8 +47,8 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("errors[0].message", is(not(blankString())))
-          .body("errors[0].exceptionClass", is("JsonParseException"));
+          .body("errors[0].exceptionClass", is("JsonParseException"))
+          .body("errors[0].message", is(not(blankString())));
     }
 
     @Test
@@ -69,10 +69,10 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
+          .body("errors[0].errorCode", is("NO_COMMAND_MATCHED"))
           .body(
               "errors[0].message",
-              startsWith("No \"unknownCommand\" command found as \"CollectionCommand\""))
-          .body("errors[0].errorCode", is("NO_COMMAND_MATCHED"));
+              startsWith("No \"unknownCommand\" command found as \"CollectionCommand\""));
     }
 
     @Test
@@ -94,10 +94,9 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .post(CollectionResource.BASE_PATH, "7_no_leading_number", collectionName)
           .then()
           .statusCode(200)
-          .body(
-              "errors[0].message",
-              startsWith("Request invalid, the field postCommand.namespace not valid"))
-          .body("errors[0].exceptionClass", is("ConstraintViolationException"));
+          .body("errors[0].exceptionClass", is("ConstraintViolationException"))
+          .body("errors[0].message", startsWith("Request invalid: field 'namespace' value"))
+          .body("errors[0].message", containsString("value \"7_no_leading_number\" not valid"));
     }
 
     @Test
@@ -119,10 +118,9 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .post(CollectionResource.BASE_PATH, namespaceName, "7_no_leading_number")
           .then()
           .statusCode(200)
-          .body(
-              "errors[0].message",
-              startsWith("Request invalid, the field postCommand.collection not valid"))
-          .body("errors[0].exceptionClass", is("ConstraintViolationException"));
+          .body("errors[0].exceptionClass", is("ConstraintViolationException"))
+          .body("errors[0].message", startsWith("Request invalid: field 'collection' value "))
+          .body("errors[0].message", containsString("value \"7_no_leading_number\" not valid"));
     }
 
     @Test
@@ -134,8 +132,8 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
           .then()
           .statusCode(200)
-          .body("errors[0].message", is(not(blankString())))
-          .body("errors[0].exceptionClass", is("ConstraintViolationException"));
+          .body("errors[0].exceptionClass", is("ConstraintViolationException"))
+          .body("errors[0].message", is(not(blankString())));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
@@ -95,8 +95,10 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .then()
           .statusCode(200)
           .body("errors[0].exceptionClass", is("ConstraintViolationException"))
-          .body("errors[0].message", startsWith("Request invalid: field 'namespace' value"))
-          .body("errors[0].message", containsString("value \"7_no_leading_number\" not valid"));
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "Request invalid: field 'namespace' value \"7_no_leading_number\" not valid. Problem: must match "));
     }
 
     @Test
@@ -119,8 +121,10 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .then()
           .statusCode(200)
           .body("errors[0].exceptionClass", is("ConstraintViolationException"))
-          .body("errors[0].message", startsWith("Request invalid: field 'collection' value "))
-          .body("errors[0].message", containsString("value \"7_no_leading_number\" not valid"));
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "Request invalid: field 'collection' value \"7_no_leading_number\" not valid. Problem: must match "));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResourceIntegrationTest.java
@@ -92,8 +92,10 @@ class NamespaceResourceIntegrationTest extends AbstractNamespaceIntegrationTestB
           .then()
           .statusCode(200)
           .body("errors[0].exceptionClass", is("ConstraintViolationException"))
-          .body("errors[0].message", startsWith("Request invalid: field 'namespace' value"))
-          .body("errors[0].message", containsString("value \"7_no_leading_number\" not valid"));
+          .body(
+              "errors[0].message",
+              startsWith(
+                  "Request invalid: field 'namespace' value \"7_no_leading_number\" not valid. Problem: must match "));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResourceIntegrationTest.java
@@ -44,8 +44,8 @@ class NamespaceResourceIntegrationTest extends AbstractNamespaceIntegrationTestB
           .post(NamespaceResource.BASE_PATH, namespaceName)
           .then()
           .statusCode(200)
-          .body("errors[0].message", is(not(blankString())))
-          .body("errors[0].exceptionClass", is("JsonParseException"));
+          .body("errors[0].exceptionClass", is("JsonParseException"))
+          .body("errors[0].message", is(not(blankString())));
     }
 
     @Test
@@ -66,10 +66,10 @@ class NamespaceResourceIntegrationTest extends AbstractNamespaceIntegrationTestB
           .post(NamespaceResource.BASE_PATH, namespaceName)
           .then()
           .statusCode(200)
+          .body("errors[0].errorCode", is("NO_COMMAND_MATCHED"))
           .body(
               "errors[0].message",
-              startsWith("No \"unknownCommand\" command found as \"NamespaceCommand\""))
-          .body("errors[0].errorCode", is("NO_COMMAND_MATCHED"));
+              startsWith("No \"unknownCommand\" command found as \"NamespaceCommand\""));
     }
 
     @Test
@@ -91,10 +91,9 @@ class NamespaceResourceIntegrationTest extends AbstractNamespaceIntegrationTestB
           .post(NamespaceResource.BASE_PATH, "7_no_leading_number")
           .then()
           .statusCode(200)
-          .body(
-              "errors[0].message",
-              startsWith("Request invalid, the field postCommand.namespace not valid"))
-          .body("errors[0].exceptionClass", is("ConstraintViolationException"));
+          .body("errors[0].exceptionClass", is("ConstraintViolationException"))
+          .body("errors[0].message", startsWith("Request invalid: field 'namespace' value"))
+          .body("errors[0].message", containsString("value \"7_no_leading_number\" not valid"));
     }
 
     @Test
@@ -106,8 +105,8 @@ class NamespaceResourceIntegrationTest extends AbstractNamespaceIntegrationTestB
           .post(NamespaceResource.BASE_PATH, namespaceName)
           .then()
           .statusCode(200)
-          .body("errors[0].message", is(not(blankString())))
-          .body("errors[0].exceptionClass", is("ConstraintViolationException"));
+          .body("errors[0].exceptionClass", is("ConstraintViolationException"))
+          .body("errors[0].message", is(not(blankString())));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateManyIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateManyIntegrationTest.java
@@ -674,7 +674,7 @@ public class UpdateManyIntegrationTest extends AbstractCollectionIntegrationTest
           .body(
               "errors[0].message",
               is(
-                  "Request invalid, the field postCommand.command.updateClause not valid: must not be null."));
+                  "Request invalid: field 'command.updateClause' value `null` not valid. Problem: must not be null."));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
@@ -2042,7 +2042,7 @@ public class UpdateOneIntegrationTest extends AbstractCollectionIntegrationTestB
           .body(
               "errors[0].message",
               is(
-                  "Request invalid, the field postCommand.command.updateClause not valid: must not be null."));
+                  "Request invalid: field 'command.updateClause' value `null` not valid. Problem: must not be null."));
     }
 
     @Test


### PR DESCRIPTION
**What this PR does**:

Improves general failure message produced for Bean Validation constraints-validation failures: adds actual value, and improves messages layout slightly.

**Which issue(s) this PR fixes**:
Fixes #873

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
