### PR TITLE
Fix #875: improve error message by including field name

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -353,7 +353,7 @@ public class Shredder {
       } else if (value.isArray()) {
         validateArrayValue(referringPropertyName, value);
       } else if (value.isTextual()) {
-        validateStringValue(value.textValue());
+        validateStringValue(referringPropertyName, value.textValue());
       }
     }
 
@@ -363,12 +363,12 @@ public class Shredder {
         if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(referringPropertyName)) {
           if (arrayValue.size() > limits.maxVectorEmbeddingLength()) {
             throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-                "number of elements Vector embedding ('%s') has (%d) exceeds maximum allowed (%d)",
+                "number of elements Vector embedding (field '%s') has (%d) exceeds maximum allowed (%d)",
                 referringPropertyName, arrayValue.size(), limits.maxVectorEmbeddingLength());
           }
         } else {
           throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-              "number of elements an indexable Array ('%s') has (%d) exceeds maximum allowed (%d)",
+              "number of elements an indexable Array (field '%s') has (%d) exceeds maximum allowed (%d)",
               referringPropertyName, arrayValue.size(), limits.maxArrayLength());
         }
       }
@@ -382,7 +382,7 @@ public class Shredder {
       final int propCount = objectValue.size();
       if (propCount > limits.maxObjectProperties()) {
         throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-            "number of properties an indexable Object ('%s') has (%d) exceeds maximum allowed (%s)",
+            "number of properties an indexable Object (field '%s') has (%d) exceeds maximum allowed (%s)",
             referringPropertyName, objectValue.size(), limits.maxObjectProperties());
       }
       totalProperties.addAndGet(propCount);
@@ -392,13 +392,13 @@ public class Shredder {
       }
     }
 
-    private void validateStringValue(String value) {
+    private void validateStringValue(String referringPropertyName, String value) {
       OptionalInt encodedLength =
           JsonUtil.lengthInBytesIfAbove(value, limits.maxStringLengthInBytes());
       if (encodedLength.isPresent()) {
         throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-            "indexed String value length (%d bytes) exceeds maximum allowed (%d bytes)",
-            encodedLength.getAsInt(), limits.maxStringLengthInBytes());
+            "indexed String value (field '%s') length (%d bytes) exceeds maximum allowed (%d bytes)",
+            referringPropertyName, encodedLength.getAsInt(), limits.maxStringLengthInBytes());
       }
     }
   }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
@@ -263,7 +263,7 @@ public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractNamespaceInt
           .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
           .body(
               "errors[0].message",
-              containsString("number of elements an indexable Array ('bigArray')"))
+              containsString("number of elements an indexable Array (field 'bigArray')"))
           .body("errors[0].message", containsString("exceeds maximum allowed"));
     }
 
@@ -335,7 +335,7 @@ public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractNamespaceInt
             .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
             .body(
                 "errors[0].message",
-                containsString("number of properties an indexable Object ('bigObject')"))
+                containsString("number of properties an indexable Object (field 'bigObject')"))
             .body("errors[0].message", containsString("exceeds maximum allowed"));
       }
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -560,7 +560,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               is(
-                  "Document size limitation violated: number of elements an indexable Array ('arr') has ("
+                  "Document size limitation violated: number of elements an indexable Array (field 'arr') has ("
                       + ARRAY_LEN
                       + ") exceeds maximum allowed ("
                       + MAX_ARRAY_LENGTH
@@ -715,7 +715,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith(
-                  "Document size limitation violated: indexed String value length (8056 bytes) exceeds maximum allowed"));
+                  "Document size limitation violated: indexed String value (field 'bigString') length (8056 bytes) exceeds maximum allowed"));
     }
 
     private String createBigString(int minLen) {
@@ -819,7 +819,8 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
               startsWith("Document size limitation violated: number of properties"))
           .body(
               "errors[0].message",
-              endsWith("indexable Object ('subdoc') has (1001) exceeds maximum allowed (1000)"));
+              endsWith(
+                  "indexable Object (field 'subdoc') has (1001) exceeds maximum allowed (1000)"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -147,7 +147,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " number of properties an indexable Object ('subdoc') has ("
+              " number of properties an indexable Object (field 'subdoc') has ("
                   + tooManyProps
                   + ") exceeds maximum allowed ("
                   + maxObProps
@@ -222,7 +222,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " number of elements an indexable Array ('arr') has ("
+              " number of elements an indexable Array (field 'arr') has ("
                   + arraySizeAboveMax
                   + ") exceeds maximum allowed ("
                   + docLimits.maxArrayLength()
@@ -312,7 +312,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " String value length ("
+              " String value (field 'arr') length ("
                   + tooLongLength
                   + " bytes) exceeds maximum allowed ("
                   + docLimits.maxStringLengthInBytes()
@@ -344,7 +344,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " String value length ("
+              " String value (field 'text') length ("
                   + (tooLongCharLength * 3)
                   + " bytes) exceeds maximum allowed ("
                   + docLimits.maxStringLengthInBytes()


### PR DESCRIPTION
**What this PR does**:

Improves document validation error message(s) by including field name for too-long-string

**Which issue(s) this PR fixes**:
Fixes #875

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
