### PR TITLE
add tenantId to driver metrics

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -11,6 +11,10 @@ Here are some Stargate-relevant property groups that are necessary for correct s
 * `quarkus.grpc.clients.bridge` - property group for defining the Bridge gRPC client (see [gRPC Client configuration](https://quarkus.io/guides/grpc-service-consumption#client-configuration) for all options)
 * `quarkus.cache.caffeine.keyspace-cache` - property group  for defining the keyspace cache used by [SchemaManager](../sgv2-quarkus-common/src/main/java/io/stargate/sgv2/api/common/schema/SchemaManager.java) (see [Caffeine cache configuration](https://quarkus.io/guides/cache#caffeine-configuration-properties) for all options)
 
+Other Quarkus properties that are specifically relevant for the service:
+
+* `quarkus.http.limits.max-body-size` - maximum HTTP payload size (in bytes) that the server will accept. Default is 20MB.
+
 ## Database limits configuration
 *Configuration for document limits, defined by [DatabaseLimitsConfig.java](src/main/java/io/stargate/sgv2/jsonapi/config/DatabaseLimitsConfig.java).*
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CustomTaggingMetricIdGenerator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CustomTaggingMetricIdGenerator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.stargate.sgv2.jsonapi.service.cqldriver;
+
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metrics.NodeMetric;
+import com.datastax.oss.driver.api.core.metrics.SessionMetric;
+import com.datastax.oss.driver.internal.core.metrics.DefaultMetricId;
+import com.datastax.oss.driver.internal.core.metrics.MetricId;
+import com.datastax.oss.driver.internal.core.metrics.MetricIdGenerator;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+/**
+ * A {@link MetricIdGenerator} that generates metric identifiers using a combination of names and
+ * tags.
+ *
+ * <p>Session metric identifiers contain a name starting with "session." and ending with the metric
+ * path, and a tag with the key "session" and the value of the current session name.
+ *
+ * <p>Node metric identifiers contain a name starting with "nodes." and ending with the metric path,
+ * and two tags: one with the key "session" and the value of the current session name, the other
+ * with the key "node" and the value of the current node endpoint.
+ */
+public class CustomTaggingMetricIdGenerator implements MetricIdGenerator {
+
+  private final String sessionName;
+  private final String sessionPrefix;
+  private final String nodePrefix;
+  private final String tenantId;
+
+  @SuppressWarnings("unused")
+  public CustomTaggingMetricIdGenerator(DriverContext context) {
+    sessionName = context.getSessionName();
+    String prefix =
+        Objects.requireNonNull(
+            context
+                .getConfig()
+                .getDefaultProfile()
+                .getString(DefaultDriverOption.METRICS_ID_GENERATOR_PREFIX, ""));
+    sessionPrefix = prefix.isEmpty() ? "session." : prefix + ".session.";
+    nodePrefix = prefix.isEmpty() ? "nodes." : prefix + ".nodes.";
+    tenantId =
+        ((TenantAwareCqlSessionBuilder.TenantAwareDriverContext) context)
+            .getStartupOptions()
+            .get("TENANT_ID");
+  }
+
+  @NonNull
+  @Override
+  public MetricId sessionMetricId(@NonNull SessionMetric metric) {
+    return new DefaultMetricId(
+        sessionPrefix + metric.getPath(),
+        ImmutableMap.of("session", sessionName, "tenant", tenantId));
+  }
+
+  @NonNull
+  @Override
+  public MetricId nodeMetricId(@NonNull Node node, @NonNull NodeMetric metric) {
+    return new DefaultMetricId(
+        nodePrefix + metric.getPath(),
+        ImmutableMap.of(
+            "session", sessionName, "node", node.getEndPoint().toString(), "tenant", tenantId));
+  }
+}

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CustomTaggingMetricIdGenerator.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/CustomTaggingMetricIdGenerator.java
@@ -1,18 +1,3 @@
-/*
- * Copyright DataStax, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.stargate.sgv2.jsonapi.service.cqldriver;
 
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
@@ -28,15 +13,16 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Objects;
 
 /**
- * A {@link MetricIdGenerator} that generates metric identifiers using a combination of names and
- * tags.
+ * Customized Tagging Metric ID Generator for Driver Metric
  *
  * <p>Session metric identifiers contain a name starting with "session." and ending with the metric
- * path, and a tag with the key "session" and the value of the current session name.
+ * path, a tag with the key "session" and the value of the current session name, a tag with the key
+ * 'tenant' and the value of current tenantId.
  *
  * <p>Node metric identifiers contain a name starting with "nodes." and ending with the metric path,
- * and two tags: one with the key "session" and the value of the current session name, the other
- * with the key "node" and the value of the current node endpoint.
+ * and 3 tags: a tag with the key "session" and the value of the current session name, a tag with
+ * the key "node" and the value of the current node endpoint, a tag with the key 'tenant' and the
+ * value of current tenantId.
  */
 public class CustomTaggingMetricIdGenerator implements MetricIdGenerator {
 
@@ -59,7 +45,7 @@ public class CustomTaggingMetricIdGenerator implements MetricIdGenerator {
     tenantId =
         ((TenantAwareCqlSessionBuilder.TenantAwareDriverContext) context)
             .getStartupOptions()
-            .get("TENANT_ID");
+            .get(TenantAwareCqlSessionBuilder.TENANT_ID_PROPERTY_KEY);
   }
 
   @NonNull

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/TenantAwareCqlSessionBuilder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/TenantAwareCqlSessionBuilder.java
@@ -18,7 +18,7 @@ public class TenantAwareCqlSessionBuilder extends CqlSessionBuilder {
    * Property key that will be used to pass the tenant ID to the CQLSession via
    * TenantAwareDriverContext
    */
-  private static final String TENANT_ID_PROPERTY_KEY = "TENANT_ID";
+  public static final String TENANT_ID_PROPERTY_KEY = "TENANT_ID";
   /** Tenant ID that will be passed to the CQLSession via TenantAwareDriverContext */
   private final String tenantId;
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -14,7 +14,7 @@ datastax-java-driver {
   }
   advanced.metrics {
     id-generator{
-      class = TaggingMetricIdGenerator
+      class = io.stargate.sgv2.jsonapi.service.cqldriver.CustomTaggingMetricIdGenerator
     }
     factory.class = MicrometerMetricsFactory
     session {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -84,10 +84,11 @@ quarkus:
           policy: authenticated
 
     limits:
-      # Let's limit low-level maximum HTTP request size to 5 megs: stricter limit (1 meg)
-      # is applied at the JSON API level. Low-level limits may result in EPIPE/413 errors
+      # Let's limit low-level maximum HTTP request size to 20 megs: stricter
+      # limit (4 meg per document) is applied at the JSON API level.
+      # Low-level limits may result in EPIPE/413 errors
       # whereas at higher level we can use regular JSON API error responses
-      max-body-size: 5M
+      max-body-size: 20M
 
     port: 8181
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractNamespaceIntegrationTestBase.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/AbstractNamespaceIntegrationTestBase.java
@@ -10,6 +10,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.jsonapi.config.constants.HttpConstants;
 import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.AfterAll;
@@ -110,6 +111,27 @@ public abstract class AbstractNamespaceIntegrationTestBase {
                         && line.contains("vector_enabled=\"false\""))
             .toList();
     assertThat(countMetrics.size()).isGreaterThan(0);
+  }
+
+  public static void checkDriverMetricsTenantId() {
+    String metrics = given().when().get("/metrics").then().statusCode(200).extract().asString();
+    Optional<String> nodeLevelDriverMetricTenantId =
+        metrics
+            .lines()
+            .filter(
+                line ->
+                    line.startsWith("nodes_cql_messages_seconds_bucket") && line.contains("tenant"))
+            .findFirst();
+    assertThat(nodeLevelDriverMetricTenantId.isPresent()).isTrue();
+    Optional<String> sessionLevelDriverMetricTenantId =
+        metrics
+            .lines()
+            .filter(
+                line ->
+                    line.startsWith("session_cql_requests_seconds_bucket")
+                        && line.contains("tenant"))
+            .findFirst();
+    assertThat(sessionLevelDriverMetricTenantId.isPresent()).isTrue();
   }
 
   public static void checkVectorMetrics(String commandName, String sortType) {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CountIntegrationTest.java
@@ -811,6 +811,7 @@ public class CountIntegrationTest extends AbstractCollectionIntegrationTestBase 
     @Test
     public void checkMetrics() {
       CountIntegrationTest.super.checkMetrics("CountDocumentsCommand");
+      CountIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateCollectionIntegrationTest.java
@@ -596,6 +596,7 @@ class CreateCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
     @Test
     public void checkMetrics() {
       CreateCollectionIntegrationTest.super.checkMetrics("CreateCollectionCommand");
+      CreateCollectionIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateNamespaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateNamespaceIntegrationTest.java
@@ -162,6 +162,7 @@ class CreateNamespaceIntegrationTest extends AbstractNamespaceIntegrationTestBas
     @Test
     public void checkMetrics() {
       CreateNamespaceIntegrationTest.super.checkMetrics("CreateNamespaceCommand");
+      CreateNamespaceIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteCollectionIntegrationTest.java
@@ -129,6 +129,7 @@ class DeleteCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
     @Test
     public void checkMetrics() {
       DeleteCollectionIntegrationTest.super.checkMetrics("DeleteCollectionCommand");
+      DeleteCollectionIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteManyIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteManyIntegrationTest.java
@@ -468,6 +468,7 @@ public class DeleteManyIntegrationTest extends AbstractCollectionIntegrationTest
     @Test
     public void checkMetrics() {
       DeleteManyIntegrationTest.super.checkMetrics("DeleteManyCommand");
+      DeleteManyIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteOneIntegrationTest.java
@@ -526,6 +526,7 @@ public class DeleteOneIntegrationTest extends AbstractCollectionIntegrationTestB
     @Test
     public void checkMetrics() {
       DeleteOneIntegrationTest.super.checkMetrics("DeleteOneCommand");
+      DeleteOneIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DropNamespaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DropNamespaceIntegrationTest.java
@@ -181,6 +181,7 @@ class DropNamespaceIntegrationTest extends AbstractNamespaceIntegrationTestBase 
     @Test
     public void checkMetrics() {
       DropNamespaceIntegrationTest.super.checkMetrics("DropNamespaceCommand");
+      DropNamespaceIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -1971,6 +1971,7 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
     @Test
     public void checkMetrics() {
       FindIntegrationTest.super.checkMetrics("FindCommand");
+      FindIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindNamespacesIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindNamespacesIntegrationTest.java
@@ -55,6 +55,7 @@ class FindNamespacesIntegrationTest extends AbstractNamespaceIntegrationTestBase
     @Test
     public void checkMetrics() {
       FindNamespacesIntegrationTest.super.checkMetrics("FindNamespacesCommand");
+      FindNamespacesIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndDeleteIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndDeleteIntegrationTest.java
@@ -315,6 +315,7 @@ public class FindOneAndDeleteIntegrationTest extends AbstractCollectionIntegrati
     @Test
     public void checkMetrics() {
       FindOneAndDeleteIntegrationTest.super.checkMetrics("FindOneAndDeleteCommand");
+      FindOneAndDeleteIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndReplaceIntegrationTest.java
@@ -737,6 +737,7 @@ public class FindOneAndReplaceIntegrationTest extends AbstractCollectionIntegrat
     @Test
     public void checkMetrics() {
       FindOneAndReplaceIntegrationTest.super.checkMetrics("FindOneAndReplaceCommand");
+      FindOneAndReplaceIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateIntegrationTest.java
@@ -1837,6 +1837,7 @@ public class FindOneAndUpdateIntegrationTest extends AbstractCollectionIntegrati
     @Test
     public void checkMetrics() {
       FindOneAndUpdateIntegrationTest.super.checkMetrics("FindOneAndUpdateCommand");
+      FindOneAndUpdateIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
@@ -757,6 +757,7 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
     @Test
     public void checkMetrics() {
       FindOneIntegrationTest.super.checkMetrics("FindOneCommand");
+      FindOneIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -1518,6 +1518,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
     @Test
     public void checkInsertOneMetrics() {
       InsertIntegrationTest.super.checkMetrics("InsertOneCommand");
+      InsertIntegrationTest.super.checkDriverMetricsTenantId();
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -3,6 +3,7 @@ package io.stargate.sgv2.jsonapi.api.v1;
 import static io.restassured.RestAssured.given;
 import static io.stargate.sgv2.common.IntegrationTestUtils.getAuthToken;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 import static org.hamcrest.Matchers.blankString;
 import static org.hamcrest.Matchers.contains;
@@ -41,6 +42,8 @@ import org.junit.jupiter.api.TestClassOrder;
 @QuarkusTestResource(DseTestResource.class)
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase {
+  private final ObjectMapper MAPPER = new ObjectMapper();
+
   @AfterEach
   public void cleanUpData() {
     deleteAllDocuments();
@@ -512,8 +515,6 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
   @Nested
   @Order(2)
   class InsertOneConstraintChecking {
-    private final ObjectMapper MAPPER = new ObjectMapper();
-
     private static final int MAX_ARRAY_LENGTH = DocumentLimitsConfig.DEFAULT_MAX_ARRAY_LENGTH;
 
     @Test
@@ -903,51 +904,6 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .statusCode(200)
           .body("errors", is(nullValue()))
           .body("data.documents[0]", jsonEquals(doc.toString()));
-    }
-
-    private JsonNode createBigDoc(String docId, int minDocSize) throws IOException {
-      // While it'd be cleaner to build JsonNode representation, checking for
-      // size much more expensive so go low-tech instead
-      StringBuilder sb = new StringBuilder(minDocSize + 1000);
-      sb.append("{\"_id\":\"").append(docId).append('"');
-
-      boolean bigEnough = false;
-
-      // Since we add one property before loop, reduce max by 1.
-      // Target is around 1 meg; can have at most 2000 properties, and for
-      // big doc we don't want to exceed 1000 bytes per property.
-      // So let's make properties arrays of 4 Strings to get there.
-      final int ROOT_PROPS = 99;
-      final int LEAF_PROPS = 20; // so it's slightly under 2000 total properties, max
-      final String TEXT_1K = "abcd123 ".repeat(120); // 960 chars
-
-      // Use double loop to create a document with a lot of properties, 2-level nesting
-      for (int i = 0; i < ROOT_PROPS && !bigEnough; ++i) {
-        sb.append(",\n\"root").append(i).append("\":{");
-        // Add one short entry to simplify following loop
-        sb.append("\n \"subId\":").append(i);
-        for (int j = 0; j < LEAF_PROPS && !bigEnough; ++j) {
-          sb.append(",\n \"sub").append(j).append("\":");
-          sb.append('[');
-          sb.append('"').append(TEXT_1K).append("\",");
-          sb.append('"').append(TEXT_1K).append("\",");
-          sb.append('"').append(TEXT_1K).append("\",");
-          sb.append('"').append(TEXT_1K).append("\"");
-          sb.append(']');
-          bigEnough = sb.length() >= minDocSize;
-        }
-        sb.append("\n}");
-      }
-      sb.append("\n}");
-      if (!bigEnough) {
-        fail(
-            "Failed to create a document big enough, size: "
-                + sb.length()
-                + " bytes; needed "
-                + minDocSize);
-      }
-
-      return MAPPER.readTree(sb.toString());
     }
   }
 
@@ -1432,7 +1388,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
 
   @Nested
   @Order(4)
-  class InsertManyFailing {
+  class InsertManyLimitsChecking {
     @Test
     public void tryInsertTooLongNumber() {
       // Max number length: 100; use 110
@@ -1471,6 +1427,88 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
               startsWith("Document size limitation violated: Number value length"))
           .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"));
     }
+
+    @Test
+    public void insertBigButNotTooBigPayload() {
+      final int bigSize = DocumentLimitsConfig.DEFAULT_MAX_DOCUMENT_SIZE - 50_000;
+      // 5 x bit under 4 M should be just under limit
+      String json =
+          """
+                      {
+                        "insertMany": {
+                          "documents": [
+                            %s,
+                            %s,
+                            %s,
+                            %s,
+                            %s
+                          ]
+                        }
+                      }
+                      """
+              .formatted(
+                  createBigDoc("big1", bigSize).toString(),
+                  createBigDoc("big2", bigSize).toString(),
+                  createBigDoc("big3", bigSize).toString(),
+                  createBigDoc("big4", bigSize).toString(),
+                  createBigDoc("big5", bigSize).toString());
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200);
+    }
+
+    // Testing Quarkus max payload (20M); separate from Max Doc Size limit (4M)
+    // (so need 6 documents to exceed)
+    @Test
+    public void tryInsertTooBigPayload() {
+      final int bigSize = DocumentLimitsConfig.DEFAULT_MAX_DOCUMENT_SIZE - 50_000;
+      String json =
+          """
+                  {
+                    "insertMany": {
+                      "documents": [
+                        %s,
+                        %s,
+                        %s,
+                        %s,
+                        %s,
+                        %s
+                      ]
+                    }
+                  }
+                  """
+              .formatted(
+                  createBigDoc("toobig1", bigSize).toString(),
+                  createBigDoc("toobig2", bigSize).toString(),
+                  createBigDoc("toobig3", bigSize).toString(),
+                  createBigDoc("toobig4", bigSize).toString(),
+                  createBigDoc("toobig5", bigSize).toString(),
+                  createBigDoc("toobig6", bigSize).toString());
+      // Either we get 413 (Payload Too Large) due to Quarkus limit, or,
+      // java.net.SocketException: Broken Pipe
+      // in latter case, it's via "sneaky throw", unfortunately, so catch
+      // needs to be for Exception and only then verifying
+      try {
+        given()
+            .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+            .contentType(ContentType.JSON)
+            .body(json)
+            .when()
+            .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+            .then()
+            .statusCode(403);
+      } catch (Exception e) {
+        // Sneaky throw, must catch any Exception, verify type separately
+        assertThat(e)
+            .isInstanceOf(java.net.SocketException.class)
+            .hasMessageStartingWith("Broken pipe");
+      }
+    }
   }
 
   @Nested
@@ -1484,6 +1522,55 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
     @Test
     public void checkInsertManyMetrics() {
       InsertIntegrationTest.super.checkMetrics("InsertManyCommand");
+    }
+  }
+
+  private JsonNode createBigDoc(String docId, int minDocSize) {
+    // While it'd be cleaner to build JsonNode representation, checking for
+    // size much more expensive so go low-tech instead
+    StringBuilder sb = new StringBuilder(minDocSize + 1000);
+    sb.append("{\"_id\":\"").append(docId).append('"');
+
+    boolean bigEnough = false;
+
+    // Since we add one property before loop, reduce max by 1.
+    // Target is around 1 meg; can have at most 2000 properties, and for
+    // big doc we don't want to exceed 1000 bytes per property.
+    // So let's make properties arrays of 4 Strings to get there.
+    final int ROOT_PROPS = 99;
+    final int LEAF_PROPS = 20; // so it's slightly under 2000 total properties, max
+    final String TEXT_1K = "abcd123 ".repeat(120); // 960 chars
+
+    // Use double loop to create a document with a lot of properties, 2-level nesting
+    for (int i = 0; i < ROOT_PROPS && !bigEnough; ++i) {
+      sb.append(",\n\"root").append(i).append("\":{");
+      // Add one short entry to simplify following loop
+      sb.append("\n \"subId\":").append(i);
+      for (int j = 0; j < LEAF_PROPS && !bigEnough; ++j) {
+        sb.append(",\n \"sub").append(j).append("\":");
+        sb.append('[');
+        sb.append('"').append(TEXT_1K).append("\",");
+        sb.append('"').append(TEXT_1K).append("\",");
+        sb.append('"').append(TEXT_1K).append("\",");
+        sb.append('"').append(TEXT_1K).append("\"");
+        sb.append(']');
+        bigEnough = sb.length() >= minDocSize;
+      }
+      sb.append("\n}");
+    }
+    sb.append("\n}");
+    if (!bigEnough) {
+      fail(
+          "Failed to create a document big enough, size: "
+              + sb.length()
+              + " bytes; needed "
+              + minDocSize);
+    }
+
+    try {
+      return MAPPER.readTree(sb.toString());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateManyIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateManyIntegrationTest.java
@@ -689,6 +689,7 @@ public class UpdateManyIntegrationTest extends AbstractCollectionIntegrationTest
     @Test
     public void checkMetrics() {
       UpdateManyIntegrationTest.super.checkMetrics("UpdateManyCommand");
+      UpdateManyIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
@@ -2089,6 +2089,7 @@ public class UpdateOneIntegrationTest extends AbstractCollectionIntegrationTestB
     @Test
     public void checkMetrics() {
       UpdateOneIntegrationTest.super.checkMetrics("UpdateOneCommand");
+      UpdateOneIntegrationTest.super.checkDriverMetricsTenantId();
     }
   }
 }


### PR DESCRIPTION
Adding tenantId to driver metrics, by implementing our own MetricIdGenerator.

**Which issue(s) this PR fixes**:
Fixes #795

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
