### PR TITLE
Fixes #884: unify JSON Object member reference to "property" (from "field" etc)

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -61,9 +61,9 @@ public enum ErrorCode {
 
   SHRED_BAD_EJSON_VALUE("Bad EJSON value"),
 
-  SHRED_BAD_VECTOR_SIZE("$vector property can't be empty"),
+  SHRED_BAD_VECTOR_SIZE("$vector value can't be empty"),
 
-  SHRED_BAD_VECTOR_VALUE("$vector search needs to be array of numbers"),
+  SHRED_BAD_VECTOR_VALUE("$vector value needs to be array of numbers"),
   SHRED_BAD_VECTORIZE_VALUE("$vectorize search needs to be text value"),
 
   INVALID_FILTER_EXPRESSION("Invalid filter expression"),

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -61,7 +61,7 @@ public enum ErrorCode {
 
   SHRED_BAD_EJSON_VALUE("Bad EJSON value"),
 
-  SHRED_BAD_VECTOR_SIZE("$vector field can't be empty"),
+  SHRED_BAD_VECTOR_SIZE("$vector property can't be empty"),
 
   SHRED_BAD_VECTOR_VALUE("$vector search needs to be array of numbers"),
   SHRED_BAD_VECTORIZE_VALUE("$vectorize search needs to be text value"),
@@ -108,10 +108,10 @@ public enum ErrorCode {
 
   UNSUPPORTED_UPDATE_OPERATION_TARGET("Unsupported target JSON value for update operation"),
 
-  UNSUPPORTED_UPDATE_FOR_DOC_ID("Cannot use operator with '_id' field"),
+  UNSUPPORTED_UPDATE_FOR_DOC_ID("Cannot use operator with '_id' property"),
 
-  UNSUPPORTED_UPDATE_FOR_VECTOR("Cannot use operator with '$vector' field"),
-  UNSUPPORTED_UPDATE_FOR_VECTORIZE("Cannot use operator with '$vectorize' field"),
+  UNSUPPORTED_UPDATE_FOR_VECTOR("Cannot use operator with '$vector' property"),
+  UNSUPPORTED_UPDATE_FOR_VECTORIZE("Cannot use operator with '$vectorize' property"),
 
   VECTOR_SEARCH_NOT_AVAILABLE("Vector search functionality is not available in the backend"),
 
@@ -121,7 +121,7 @@ public enum ErrorCode {
 
   VECTOR_SEARCH_INVALID_FUNCTION_NAME("Invalid vector search function name: "),
 
-  VECTOR_SEARCH_FIELD_TOO_BIG("Vector embedding field '$vector' length too big"),
+  VECTOR_SEARCH_TOO_BIG_VALUE("Vector embedding property '$vector' length too big"),
   VECTORIZE_SERVICE_NOT_REGISTERED("Vectorize service name provided is not registered : "),
 
   VECTORIZE_SERVICE_TYPE_NOT_ENABLED("Vectorize service type not enabled : "),

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CreateCollectionCommandResolver.java
@@ -83,10 +83,10 @@ public class CreateCollectionCommandResolver implements CommandResolver<CreateCo
         vectorSize = command.options().vector().dimension();
         if (vectorSize > documentLimitsConfig.maxVectorEmbeddingLength()) {
           throw new JsonApiException(
-              ErrorCode.VECTOR_SEARCH_FIELD_TOO_BIG,
+              ErrorCode.VECTOR_SEARCH_TOO_BIG_VALUE,
               String.format(
                   "%s: %d (max %d)",
-                  ErrorCode.VECTOR_SEARCH_FIELD_TOO_BIG.getMessage(),
+                  ErrorCode.VECTOR_SEARCH_TOO_BIG_VALUE.getMessage(),
                   vectorSize,
                   documentLimitsConfig.maxVectorEmbeddingLength()));
         }

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -234,9 +234,9 @@ public class Shredder {
   }
 
   /**
-   * Validator applied to the full document, before removing non-indexable properties. Used to ensure
-   * that the full document does not violate overall structural limits such as total length or
-   * maximum nesting depth, or invalid property names. Most checks are done at a later point with
+   * Validator applied to the full document, before removing non-indexable properties. Used to
+   * ensure that the full document does not violate overall structural limits such as total length
+   * or maximum nesting depth, or invalid property names. Most checks are done at a later point with
    * {@link IndexableValueValidator}.
    */
   static class FullDocValidator {
@@ -325,8 +325,8 @@ public class Shredder {
   }
 
   /**
-   * Secondary validator applied to the storable document after non-indexable properties (and branches)
-   * have been pruned.
+   * Secondary validator applied to the storable document after non-indexable properties (and
+   * branches) have been pruned.
    */
   static class IndexableValueValidator {
     final DocumentLimitsConfig limits;

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/shredding/Shredder.java
@@ -90,7 +90,7 @@ public class Shredder {
     final WritableShreddedDocument.Builder b =
         WritableShreddedDocument.builder(docId, txId, docJson, docWithId);
 
-    // Before value validation, indexing, may need to drop "non-indexed" fields. But if so,
+    // Before value validation, indexing, may need to drop "non-indexed" properties. But if so,
     // need to ensure we do not modify original document, so let's create a copy (may need
     // to be returned as "after" Document)
     ObjectNode indexableDocument;
@@ -106,18 +106,18 @@ public class Shredder {
     // and now we can finally validate (String) value lengths
     new IndexableValueValidator(documentLimits).validate(indexableDocument);
 
-    // And finally let's traverse the document to actually "shred" (build index fields)
+    // And finally let's traverse the document to actually "shred" (build index properties)
     traverse(indexableDocument, b, JsonPath.rootBuilder());
     return b.build();
   }
 
   /**
    * Method called to ensure that Document has Document Id (generating id if necessary), and that it
-   * is the very first field in the document (reordering as needed). Note that a new document is
+   * is the very first property in the document (reordering as needed). Note that a new document is
    * created and returned; input document is never modified.
    *
    * @param doc Document to use as the base
-   * @return Document that has _id as its first field
+   * @return Document that has _id as its first property
    */
   private ObjectNode normalizeDocumentId(ObjectNode doc) {
     // First: see if we have Object Id present or not
@@ -127,13 +127,13 @@ public class Shredder {
     if (idNode == null) {
       idNode = generateDocumentId();
     }
-    // Either way we need to construct actual document with _id as the first field;
-    // unfortunately there is no way to reorder fields in-place.
-    final ObjectNode docWithIdAsFirstField = objectMapper.createObjectNode();
-    docWithIdAsFirstField.set(DocumentConstants.Fields.DOC_ID, idNode);
-    // Ok to add all fields, possibly including doc id since order won't change
-    docWithIdAsFirstField.setAll(doc);
-    return docWithIdAsFirstField;
+    // Either way we need to construct actual document with _id as the first property;
+    // unfortunately there is no way to reorder properties in-place.
+    final ObjectNode docWithIdAsFirstProperty = objectMapper.createObjectNode();
+    docWithIdAsFirstProperty.set(DocumentConstants.Fields.DOC_ID, idNode);
+    // Ok to add all properties, possibly including doc id since order won't change
+    docWithIdAsFirstProperty.setAll(doc);
+    return docWithIdAsFirstProperty;
   }
 
   private JsonNode generateDocumentId() {
@@ -185,7 +185,7 @@ public class Shredder {
     if (pathAsString.equals(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD)) {
       traverseVector(path, value, callback);
     } else if (pathAsString.equals(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD)) {
-      // Do nothing, vectorize field will just sit in doc json
+      // Do nothing, vectorize property will just sit in doc json
     } else {
       if (value.isObject()) {
         ObjectNode ob = (ObjectNode) value;
@@ -234,7 +234,7 @@ public class Shredder {
   }
 
   /**
-   * Validator applied to the full document, before removing non-indexable fields. Used to ensure
+   * Validator applied to the full document, before removing non-indexable properties. Used to ensure
    * that the full document does not violate overall structural limits such as total length or
    * maximum nesting depth, or invalid property names. Most checks are done at a later point with
    * {@link IndexableValueValidator}.
@@ -300,9 +300,9 @@ public class Shredder {
         if (JsonUtil.EJSON_VALUE_KEY_DATE.equals(key) && value.isValueNode()) {
           ; // Fine, looks like legit Date value
         } else if (key.equals(DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD) && depth == 1) {
-          ; // Fine, looks like legit vector field
+          ; // Fine, looks like legit vector property
         } else if (key.equals(DocumentConstants.Fields.VECTOR_EMBEDDING_TEXT_FIELD) && depth == 1) {
-          ; // Fine, looks like legit vectorize field
+          ; // Fine, looks like legit vectorize property
         } else {
           throw ErrorCode.SHRED_DOC_KEY_NAME_VIOLATION.toApiException(
               "property name ('%s') contains character(s) not allowed", key);
@@ -325,7 +325,7 @@ public class Shredder {
   }
 
   /**
-   * Secondary validator applied to the storable document after non-indexable fields (and branches)
+   * Secondary validator applied to the storable document after non-indexable properties (and branches)
    * have been pruned.
    */
   static class IndexableValueValidator {
@@ -363,12 +363,12 @@ public class Shredder {
         if (DocumentConstants.Fields.VECTOR_EMBEDDING_FIELD.equals(referringPropertyName)) {
           if (arrayValue.size() > limits.maxVectorEmbeddingLength()) {
             throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-                "number of elements Vector embedding (field '%s') has (%d) exceeds maximum allowed (%d)",
+                "number of elements Vector embedding (property '%s') has (%d) exceeds maximum allowed (%d)",
                 referringPropertyName, arrayValue.size(), limits.maxVectorEmbeddingLength());
           }
         } else {
           throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-              "number of elements an indexable Array (field '%s') has (%d) exceeds maximum allowed (%d)",
+              "number of elements an indexable Array (property '%s') has (%d) exceeds maximum allowed (%d)",
               referringPropertyName, arrayValue.size(), limits.maxArrayLength());
         }
       }
@@ -382,7 +382,7 @@ public class Shredder {
       final int propCount = objectValue.size();
       if (propCount > limits.maxObjectProperties()) {
         throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-            "number of properties an indexable Object (field '%s') has (%d) exceeds maximum allowed (%s)",
+            "number of properties an indexable Object (property '%s') has (%d) exceeds maximum allowed (%s)",
             referringPropertyName, objectValue.size(), limits.maxObjectProperties());
       }
       totalProperties.addAndGet(propCount);
@@ -397,7 +397,7 @@ public class Shredder {
           JsonUtil.lengthInBytesIfAbove(value, limits.maxStringLengthInBytes());
       if (encodedLength.isPresent()) {
         throw ErrorCode.SHRED_DOC_LIMIT_VIOLATION.toApiException(
-            "indexed String value (field '%s') length (%d bytes) exceeds maximum allowed (%d bytes)",
+            "indexed String value (property '%s') length (%d bytes) exceeds maximum allowed (%d bytes)",
             referringPropertyName, encodedLength.getAsInt(), limits.maxStringLengthInBytes());
       }
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/SortClauseDeserializerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/deserializers/SortClauseDeserializerTest.java
@@ -71,7 +71,7 @@ class SortClauseDeserializerTest {
       Throwable throwable = catchThrowable(() -> objectMapper.readValue(json, SortClause.class));
 
       assertThat(throwable).isInstanceOf(JsonApiException.class);
-      assertThat(throwable.getMessage()).contains("$vector field can't be empty");
+      assertThat(throwable.getMessage()).contains("$vector value can't be empty");
     }
 
     @Test
@@ -85,7 +85,7 @@ class SortClauseDeserializerTest {
       Throwable throwable = catchThrowable(() -> objectMapper.readValue(json, SortClause.class));
 
       assertThat(throwable).isInstanceOf(JsonApiException.class);
-      assertThat(throwable.getMessage()).contains("$vector search needs to be array of numbers");
+      assertThat(throwable.getMessage()).contains("$vector value needs to be array of numbers");
     }
 
     @Test
@@ -99,7 +99,7 @@ class SortClauseDeserializerTest {
       Throwable throwable = catchThrowable(() -> objectMapper.readValue(json, SortClause.class));
 
       assertThat(throwable).isInstanceOf(JsonApiException.class);
-      assertThat(throwable.getMessage()).contains("$vector search needs to be array of numbers");
+      assertThat(throwable.getMessage()).contains("$vector value needs to be array of numbers");
     }
 
     public void vectorSearchInvalidData() {

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateIntegrationTest.java
@@ -727,7 +727,7 @@ public class FindOneAndUpdateIntegrationTest extends AbstractCollectionIntegrati
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
           .body("errors[0].errorCode", is("UNSUPPORTED_UPDATE_FOR_DOC_ID"))
-          .body("errors[0].message", is("Cannot use operator with '_id' field: $unset"));
+          .body("errors[0].message", is("Cannot use operator with '_id' property: $unset"));
 
       // And finally verify also that nothing was changed:
       json =
@@ -780,7 +780,7 @@ public class FindOneAndUpdateIntegrationTest extends AbstractCollectionIntegrati
           .body("data", is(nullValue()))
           .body("status", is(nullValue()))
           .body("errors[0].errorCode", is("UNSUPPORTED_UPDATE_FOR_DOC_ID"))
-          .body("errors[0].message", is("Cannot use operator with '_id' field: $set"));
+          .body("errors[0].message", is("Cannot use operator with '_id' property: $set"));
 
       // And finally verify also that nothing was changed:
       json =

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneAndUpdateNoIndexIntegrationTest.java
@@ -263,7 +263,7 @@ public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractNamespaceInt
           .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
           .body(
               "errors[0].message",
-              containsString("number of elements an indexable Array (field 'bigArray')"))
+              containsString("number of elements an indexable Array (property 'bigArray')"))
           .body("errors[0].message", containsString("exceeds maximum allowed"));
     }
 
@@ -335,7 +335,7 @@ public class FindOneAndUpdateNoIndexIntegrationTest extends AbstractNamespaceInt
             .body("errors[0].errorCode", is("SHRED_DOC_LIMIT_VIOLATION"))
             .body(
                 "errors[0].message",
-                containsString("number of properties an indexable Object (field 'bigObject')"))
+                containsString("number of properties an indexable Object (property 'bigObject')"))
             .body("errors[0].message", containsString("exceeds maximum allowed"));
       }
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -560,7 +560,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               is(
-                  "Document size limitation violated: number of elements an indexable Array (field 'arr') has ("
+                  "Document size limitation violated: number of elements an indexable Array (property 'arr') has ("
                       + ARRAY_LEN
                       + ") exceeds maximum allowed ("
                       + MAX_ARRAY_LENGTH
@@ -715,7 +715,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith(
-                  "Document size limitation violated: indexed String value (field 'bigString') length (8056 bytes) exceeds maximum allowed"));
+                  "Document size limitation violated: indexed String value (property 'bigString') length (8056 bytes) exceeds maximum allowed"));
     }
 
     private String createBigString(int minLen) {
@@ -820,7 +820,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               endsWith(
-                  "indexable Object (field 'subdoc') has (1001) exceeds maximum allowed (1000)"));
+                  "indexable Object (property 'subdoc') has (1001) exceeds maximum allowed (1000)"));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -122,11 +122,11 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .statusCode(200)
           .body("status.ok", is(nullValue()))
           .body("errors[0].exceptionClass", is("JsonApiException"))
-          .body("errors[0].errorCode", is("VECTOR_SEARCH_FIELD_TOO_BIG"))
+          .body("errors[0].errorCode", is("VECTOR_SEARCH_TOO_BIG_VALUE"))
           .body(
               "errors[0].message",
               startsWith(
-                  "Vector embedding field '$vector' length too big: "
+                  "Vector embedding property '$vector' length too big: "
                       + tooHighDimension
                       + " (max "
                       + maxDimension
@@ -336,7 +336,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .body("status", is(nullValue()))
           .body("errors", is(notNullValue()))
           .body("errors", hasSize(1))
-          .body("errors[0].message", startsWith("$vector field can't be empty"))
+          .body("errors[0].message", startsWith("$vector value can't be empty"))
           .body("errors[0].errorCode", is("SHRED_BAD_VECTOR_SIZE"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
     }
@@ -369,7 +369,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .body("status", is(nullValue()))
           .body("errors", is(notNullValue()))
           .body("errors", hasSize(1))
-          .body("errors[0].message", startsWith("$vector search needs to be array of numbers"))
+          .body("errors[0].message", startsWith("$vector value needs to be array of numbers"))
           .body("errors[0].errorCode", is("SHRED_BAD_VECTOR_VALUE"))
           .body("errors[0].exceptionClass", is("JsonApiException"));
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderDocLimitsTest.java
@@ -147,7 +147,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " number of properties an indexable Object (field 'subdoc') has ("
+              " number of properties an indexable Object (property 'subdoc') has ("
                   + tooManyProps
                   + ") exceeds maximum allowed ("
                   + maxObProps
@@ -201,7 +201,7 @@ public class ShredderDocLimitsTest {
       assertThat(shredder.shred(doc)).isNotNull();
     }
 
-    // Test to verify that max-array-size limit only imposed on indexable fields
+    // Test to verify that max-array-size limit only imposed on indexable properties
     @Test
     public void allowDocWithHugeArrayNoIndex() {
       // Max allowed 1000 normally, but if array not-indexed, not limited
@@ -222,7 +222,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " number of elements an indexable Array (field 'arr') has ("
+              " number of elements an indexable Array (property 'arr') has ("
                   + arraySizeAboveMax
                   + ") exceeds maximum allowed ("
                   + docLimits.maxArrayLength()
@@ -312,7 +312,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " String value (field 'arr') length ("
+              " String value (property 'arr') length ("
                   + tooLongLength
                   + " bytes) exceeds maximum allowed ("
                   + docLimits.maxStringLengthInBytes()
@@ -344,7 +344,7 @@ public class ShredderDocLimitsTest {
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_DOC_LIMIT_VIOLATION)
           .hasMessageStartingWith(ErrorCode.SHRED_DOC_LIMIT_VIOLATION.getMessage())
           .hasMessageEndingWith(
-              " String value (field 'text') length ("
+              " String value (property 'text') length ("
                   + (tooLongCharLength * 3)
                   + " bytes) exceeds maximum allowed ("
                   + docLimits.maxStringLengthInBytes()
@@ -394,7 +394,7 @@ public class ShredderDocLimitsTest {
   class ValidationDocNameViolations {
     @ParameterizedTest
     @ValueSource(strings = {"name", "a123", "snake_case", "camelCase", "ab-cd-ef"})
-    public void allowRegularFieldNames(String validName) {
+    public void allowRegularPropertyNames(String validName) {
       final ObjectNode doc = objectMapper.createObjectNode();
       doc.put("_id", 123);
       doc.put(validName, 123456);
@@ -404,7 +404,7 @@ public class ShredderDocLimitsTest {
     }
 
     @Test
-    public void catchEmptyFieldName() {
+    public void catchEmptyPropertyName() {
       final ObjectNode doc = objectMapper.createObjectNode();
       doc.put("", 123456);
 
@@ -419,7 +419,7 @@ public class ShredderDocLimitsTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"$function", "dot.ted", "index[1]", "a/b", "a\\b"})
-    public void catchInvalidFieldName(String invalidName) {
+    public void catchInvalidPropertyName(String invalidName) {
       final ObjectNode doc = objectMapper.createObjectNode();
       doc.put("_id", 123);
       doc.put(invalidName, 123456);

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
@@ -271,7 +271,7 @@ public class ShredderTest {
 
       assertThat(t)
           .isNotNull()
-          .hasMessage("$vector property can't be empty")
+          .hasMessage("$vector value can't be empty")
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_VECTOR_SIZE);
     }
 
@@ -283,7 +283,7 @@ public class ShredderTest {
 
       assertThat(t)
           .isNotNull()
-          .hasMessage("$vector search needs to be array of numbers")
+          .hasMessage("$vector value needs to be array of numbers")
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_VECTOR_VALUE);
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/shredding/ShredderTest.java
@@ -271,7 +271,7 @@ public class ShredderTest {
 
       assertThat(t)
           .isNotNull()
-          .hasMessage("$vector field can't be empty")
+          .hasMessage("$vector property can't be empty")
           .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SHRED_BAD_VECTOR_SIZE);
     }
 


### PR DESCRIPTION
**What this PR does**:

Unifies terms used to refer to key/value pairs in JSON Document by using "property", over alternate names like "field"

**Which issue(s) this PR fixes**:
Fixes #884

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
