### PR TITLE
Fixes #893: add IT for InsertMany failure due to doc count exceeding limit

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/config/OperationsConfig.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/config/OperationsConfig.java
@@ -37,6 +37,12 @@ public interface OperationsConfig {
   /** Defines the default max size of filter fields. */
   int DEFAULT_MAX_FILTER_SIZE = 64;
 
+  /**
+   * Defines the default maximum documents to insert setting for {@code InsertMany} command;
+   * defaults to 20
+   */
+  public static final int DEFAULT_MAX_DOCUMENT_INSERT_COUNT = 20;
+
   /** @return Defines the default document page size, defaults to <code>20</code>. */
   @Max(500)
   @Positive
@@ -84,7 +90,7 @@ public interface OperationsConfig {
    */
   @Max(100)
   @Positive
-  @WithDefault("20")
+  @WithDefault("" + DEFAULT_MAX_DOCUMENT_INSERT_COUNT)
   int maxDocumentInsertCount();
 
   /**

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -24,6 +24,7 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 import io.stargate.sgv2.jsonapi.config.DocumentLimitsConfig;
+import io.stargate.sgv2.jsonapi.config.OperationsConfig;
 import io.stargate.sgv2.jsonapi.config.constants.DocumentConstants;
 import io.stargate.sgv2.jsonapi.config.constants.HttpConstants;
 import io.stargate.sgv2.jsonapi.testresource.DseTestResource;
@@ -1388,7 +1389,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
   }
 
   @Nested
-  @Order(4)
+  @Order(5)
   class InsertManyLimitsChecking {
     @Test
     public void tryInsertTooLongNumber() {
@@ -1509,6 +1510,59 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
             .isInstanceOf(java.net.SocketException.class)
             .hasMessageStartingWith("Broken pipe");
       }
+    }
+  }
+
+  @Nested
+  @Order(6)
+  class InsertManyFails {
+    @Test
+    public void insertManyWithTooManyDocuments() {
+      ArrayNode docs = MAPPER.createArrayNode();
+      final int MAX_DOCS = OperationsConfig.DEFAULT_MAX_DOCUMENT_INSERT_COUNT;
+
+      // We need to both exceed doc count limit AND to create big enough payload to
+      // trigger message truncation (either by quarkus or client)
+      // Guessing that 20 x 1k == 20kB should be enough
+      final String TEXT_1K = "abcd 1234 ".repeat(1_000);
+
+      for (int i = 0; i < MAX_DOCS + 1; ++i) {
+        ObjectNode doc =
+            MAPPER
+                .createObjectNode()
+                .put("_id", "doc" + i)
+                .put("username", "user" + i)
+                .put("text", TEXT_1K);
+        docs.add(doc);
+      }
+      String json =
+          """
+          {
+            "insertMany": {
+              "documents": %s
+            }
+          }
+          """
+              .formatted(docs);
+
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("data", is(nullValue()))
+          .body("errors[0].exceptionClass", is("ConstraintViolationException"))
+          .body(
+              "errors[0].message",
+              endsWith(
+                  "not valid. Problem: amount of documents to insert is over the max limit ("
+                      + docs.size()
+                      + " vs "
+                      + MAX_DOCS
+                      + ")."));
     }
   }
 


### PR DESCRIPTION
**What this PR does**:

Adds an integration test to verify that error message for attempts to insert more documents than allowed results in proper exception message

**Which issue(s) this PR fixes**:
Fixes #893

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
