### PR TITLE
Fixes #895: truncate reported value that fails constraint violation if too long

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ConstraintViolationExceptionMapper.java
@@ -1,5 +1,6 @@
 package io.stargate.sgv2.jsonapi.exception.mappers;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.stargate.sgv2.jsonapi.api.model.command.CommandResult;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -13,6 +14,12 @@ import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 /** Simple exception mapper for the {@link ConstraintViolationException}. */
 public class ConstraintViolationExceptionMapper {
   private static final String PREFIX_POST_COMMAND = "postCommand.";
+
+  /**
+   * Maximum length of "value" to include without truncation: values longer than this will be
+   * truncated to this length (plus marker)
+   */
+  private static final int MAX_VALUE_LENGTH_TO_INCLUDE = 1000;
 
   // constant error fields
   public static final Map<String, Object> ERROR_FIELDS =
@@ -43,11 +50,35 @@ public class ConstraintViolationExceptionMapper {
     }
 
     Object propertyValue = violation.getInvalidValue();
-    String propertyValueDesc =
-        (propertyValue == null) ? "`null`" : String.format("\"%s\"", propertyValue);
+    String propertyValueDesc = valueDescription(propertyValue);
     String msg =
         "Request invalid: field '%s' value %s not valid. Problem: %s."
             .formatted(propertyPath, propertyValueDesc, message);
     return new CommandResult.Error(msg, ERROR_FIELDS, ERROR_FIELDS_METRICS_TAG, Response.Status.OK);
+  }
+
+  private static String valueDescription(Object rawValue) {
+    if (rawValue == null) {
+      return "`null`";
+    }
+    // Some value types never truncated: Numbers, Booleans.
+    if (rawValue instanceof Number
+        || rawValue instanceof Boolean
+        || rawValue.getClass().isPrimitive()) {
+      return rawValue.toString();
+    }
+
+    // JSON values: do not include the whole value, just description
+    if (rawValue instanceof JsonNode) {
+      return "<JSON value of " + rawValue.toString().length() + " characters>";
+    }
+
+    String valueDesc = rawValue.toString();
+    if (valueDesc.length() < MAX_VALUE_LENGTH_TO_INCLUDE) {
+      return String.format("\"%s\"", valueDesc);
+    }
+    return String.format(
+        "\"%s\"...[TRUNCATED from %d to %d characters]",
+        valueDesc, valueDesc.length(), MAX_VALUE_LENGTH_TO_INCLUDE);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Fail.fail;
 import static org.hamcrest.Matchers.blankString;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -1522,9 +1523,8 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
       final int MAX_DOCS = OperationsConfig.DEFAULT_MAX_DOCUMENT_INSERT_COUNT;
 
       // We need to both exceed doc count limit AND to create big enough payload to
-      // trigger message truncation (either by quarkus or client)
-      // Guessing that 20 x 1k == 20kB should be enough
-      final String TEXT_1K = "abcd 1234 ".repeat(1_000);
+      // trigger message truncation: 21 x 1k == 21kB should be enough
+      final String TEXT_1K = "abcd 1234 ".repeat(100);
 
       for (int i = 0; i < MAX_DOCS + 1; ++i) {
         ObjectNode doc =
@@ -1543,7 +1543,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
             }
           }
           """
-              .formatted(docs);
+              .formatted(docs.toString());
 
       given()
           .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
@@ -1562,7 +1562,8 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
                       + docs.size()
                       + " vs "
                       + MAX_DOCS
-                      + ")."));
+                      + ")."))
+          .body("errors[0].message", containsString("[TRUNCATED from "));
     }
   }
 


### PR DESCRIPTION
**What this PR does**:

Truncates reported failed value in ConstraintsViolation exception, if value length exceeds limit (1000 characters).

**Which issue(s) this PR fixes**:
Fixes #895

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
