### PR TITLE
Error if `$vectorize` is used on table for which the feature is not enabled.

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -96,7 +96,8 @@ public enum ErrorCode {
   UNSUPPORTED_UPDATE_DATA_TYPE("Unsupported update data type"),
 
   UNSUPPORTED_UPDATE_OPERATION("Unsupported update operation"),
-  UNAVAILABLE_EMBEDDING_SERVICE("Unable to vectorize data, embedding service not available"),
+  UNAVAILABLE_EMBEDDING_SERVICE(
+      "Unable to vectorize data, embedding service not configured for the collection"),
 
   UNSUPPORTED_UPDATE_OPERATION_MODIFIER("Unsupported update operation modifier"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/ErrorCode.java
@@ -96,8 +96,8 @@ public enum ErrorCode {
   UNSUPPORTED_UPDATE_DATA_TYPE("Unsupported update data type"),
 
   UNSUPPORTED_UPDATE_OPERATION("Unsupported update operation"),
-  UNAVAILABLE_EMBEDDING_SERVICE(
-      "Unable to vectorize data, embedding service not configured for the collection"),
+  EMBEDDING_SERVICE_NOT_CONFIGURED(
+      "Unable to vectorize data, embedding service not configured for the collection "),
 
   UNSUPPORTED_UPDATE_OPERATION_MODIFIER("Unsupported update operation modifier"),
 

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizer.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizer.java
@@ -28,6 +28,7 @@ public class DataVectorizer {
   private final EmbeddingService embeddingService;
   private final JsonNodeFactory nodeFactory;
   private final Optional<String> embeddingApiKey;
+  private final String collectionName;
 
   /**
    * Constructor
@@ -36,14 +37,17 @@ public class DataVectorizer {
    *     table
    * @param nodeFactory - Jackson node factory to create json nodes added to the document
    * @param embeddingApiKey - Optional override embedding api key came in request header
+   * @param collectionName - Collection name for which the vectorize is called
    */
   public DataVectorizer(
       EmbeddingService embeddingService,
       JsonNodeFactory nodeFactory,
-      Optional<String> embeddingApiKey) {
+      Optional<String> embeddingApiKey,
+      String collectionName) {
     this.embeddingService = embeddingService;
     this.nodeFactory = nodeFactory;
     this.embeddingApiKey = embeddingApiKey;
+    this.collectionName = collectionName;
   }
 
   /**
@@ -89,7 +93,7 @@ public class DataVectorizer {
 
       if (!vectorizeTexts.isEmpty()) {
         if (embeddingService == null) {
-          throw new JsonApiException(ErrorCode.UNAVAILABLE_EMBEDDING_SERVICE);
+          throw ErrorCode.EMBEDDING_SERVICE_NOT_CONFIGURED.toApiException(collectionName);
         }
         Uni<List<float[]>> vectors = embeddingService.vectorize(vectorizeTexts, embeddingApiKey);
         return vectors
@@ -132,7 +136,7 @@ public class DataVectorizer {
         SortExpression expression = sortExpressions.get(0);
         String text = expression.vectorize();
         if (embeddingService == null) {
-          throw new JsonApiException(ErrorCode.UNAVAILABLE_EMBEDDING_SERVICE);
+          throw ErrorCode.EMBEDDING_SERVICE_NOT_CONFIGURED.toApiException(collectionName);
         }
         Uni<List<float[]>> vectors = embeddingService.vectorize(List.of(text), embeddingApiKey);
         return vectors
@@ -198,7 +202,7 @@ public class DataVectorizer {
       } else if (jsonNode.isTextual()) {
         final String text = jsonNode.asText();
         if (embeddingService == null) {
-          throw new JsonApiException(ErrorCode.UNAVAILABLE_EMBEDDING_SERVICE);
+          throw ErrorCode.EMBEDDING_SERVICE_NOT_CONFIGURED.toApiException(collectionName);
         }
         final Uni<List<float[]>> vectors =
             embeddingService.vectorize(List.of(text), embeddingApiKey);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizerService.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizerService.java
@@ -39,7 +39,8 @@ public class DataVectorizerService {
         new DataVectorizer(
             commandContext.embeddingService(),
             objectMapper.getNodeFactory(),
-            dataApiRequestInfo.getEmbeddingApiKey());
+            dataApiRequestInfo.getEmbeddingApiKey(),
+            commandContext.collection());
     return vectorizeSortClause(dataVectorizer, commandContext, command)
         .onItem()
         .transformToUni(flag -> vectorizeUpdateClause(dataVectorizer, commandContext, command))

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizerService.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/embedding/DataVectorizerService.java
@@ -35,8 +35,6 @@ public class DataVectorizerService {
    * @return
    */
   public Uni<Command> vectorize(CommandContext commandContext, Command command) {
-    if (!commandContext.isVectorEnabled() || commandContext.embeddingService() == null)
-      return Uni.createFrom().item(command);
     final DataVectorizer dataVectorizer =
         new DataVectorizer(
             commandContext.embeddingService(),

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/DataVectorizerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/embedding/operation/DataVectorizerTest.java
@@ -43,7 +43,7 @@ public class DataVectorizerTest {
         documents.add(objectMapper.createObjectNode().put("$vectorize", "test data"));
       }
       DataVectorizer dataVectorizer =
-          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty());
+          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty(), "test");
       try {
         dataVectorizer.vectorize(documents).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -65,7 +65,7 @@ public class DataVectorizerTest {
       }
 
       DataVectorizer dataVectorizer =
-          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty());
+          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty(), "test");
       try {
         Throwable failure =
             dataVectorizer
@@ -93,7 +93,7 @@ public class DataVectorizerTest {
       }
 
       DataVectorizer dataVectorizer =
-          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty());
+          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty(), "test");
       try {
         dataVectorizer.vectorize(documents).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -115,7 +115,7 @@ public class DataVectorizerTest {
       arrayNode.add(objectMapper.getNodeFactory().numberNode(0.11f));
       documents.add(document);
       DataVectorizer dataVectorizer =
-          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty());
+          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty(), "test");
       try {
         Throwable failure =
             dataVectorizer
@@ -145,7 +145,7 @@ public class DataVectorizerTest {
       sortExpressions.add(sortExpression);
       SortClause sortClause = new SortClause(sortExpressions);
       DataVectorizer dataVectorizer =
-          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty());
+          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty(), "test");
       try {
         dataVectorizer.vectorize(sortClause).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -174,7 +174,7 @@ public class DataVectorizerTest {
       FindOneAndUpdateCommand command = objectMapper.readValue(json, FindOneAndUpdateCommand.class);
       UpdateClause updateClause = command.updateClause();
       DataVectorizer dataVectorizer =
-          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty());
+          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty(), "test");
       try {
         dataVectorizer.vectorizeUpdateClause(updateClause).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -201,7 +201,7 @@ public class DataVectorizerTest {
       FindOneAndUpdateCommand command = objectMapper.readValue(json, FindOneAndUpdateCommand.class);
       UpdateClause updateClause = command.updateClause();
       DataVectorizer dataVectorizer =
-          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty());
+          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty(), "test");
       Throwable t =
           dataVectorizer
               .vectorizeUpdateClause(updateClause)
@@ -231,7 +231,7 @@ public class DataVectorizerTest {
       FindOneAndUpdateCommand command = objectMapper.readValue(json, FindOneAndUpdateCommand.class);
       UpdateClause updateClause = command.updateClause();
       DataVectorizer dataVectorizer =
-          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty());
+          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty(), "test");
       try {
         dataVectorizer.vectorizeUpdateClause(updateClause).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -259,7 +259,7 @@ public class DataVectorizerTest {
       FindOneAndUpdateCommand command = objectMapper.readValue(json, FindOneAndUpdateCommand.class);
       UpdateClause updateClause = command.updateClause();
       DataVectorizer dataVectorizer =
-          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty());
+          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty(), "test");
       Throwable t =
           dataVectorizer
               .vectorizeUpdateClause(updateClause)
@@ -289,7 +289,7 @@ public class DataVectorizerTest {
       FindOneAndUpdateCommand command = objectMapper.readValue(json, FindOneAndUpdateCommand.class);
       UpdateClause updateClause = command.updateClause();
       DataVectorizer dataVectorizer =
-          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty());
+          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty(), "test");
       try {
         dataVectorizer.vectorizeUpdateClause(updateClause).subscribe().asCompletionStage().get();
       } catch (Exception e) {
@@ -315,7 +315,7 @@ public class DataVectorizerTest {
       FindOneAndUpdateCommand command = objectMapper.readValue(json, FindOneAndUpdateCommand.class);
       UpdateClause updateClause = command.updateClause();
       DataVectorizer dataVectorizer =
-          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty());
+          new DataVectorizer(testService, objectMapper.getNodeFactory(), Optional.empty(), "test");
       try {
         Throwable t =
             dataVectorizer

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CommandResolverWithVectorizerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CommandResolverWithVectorizerTest.java
@@ -165,9 +165,10 @@ public class CommandResolverWithVectorizerTest {
                 JsonApiException exception = (JsonApiException) e;
                 assertThat(exception.getMessage())
                     .isEqualTo(
-                        "Unable to vectorize data, embedding service not configured for the collection");
+                        "Unable to vectorize data, embedding service not configured for the collection : "
+                            + VECTOR_COMMAND_CONTEXT.collection());
                 assertThat(exception.getErrorCode())
-                    .isEqualTo(ErrorCode.UNAVAILABLE_EMBEDDING_SERVICE);
+                    .isEqualTo(ErrorCode.EMBEDDING_SERVICE_NOT_CONFIGURED);
               });
     }
 
@@ -340,9 +341,10 @@ public class CommandResolverWithVectorizerTest {
                 JsonApiException exception = (JsonApiException) e;
                 assertThat(exception.getMessage())
                     .isEqualTo(
-                        "Unable to vectorize data, embedding service not configured for the collection");
+                        "Unable to vectorize data, embedding service not configured for the collection : "
+                            + VECTOR_COMMAND_CONTEXT.collection());
                 assertThat(exception.getErrorCode())
-                    .isEqualTo(ErrorCode.UNAVAILABLE_EMBEDDING_SERVICE);
+                    .isEqualTo(ErrorCode.EMBEDDING_SERVICE_NOT_CONFIGURED);
               });
     }
 
@@ -523,13 +525,13 @@ public class CommandResolverWithVectorizerTest {
       new DataVectorizer(
               TestEmbeddingService.commandContextWithVectorize.embeddingService(),
               objectMapper.getNodeFactory(),
-              Optional.empty())
+              Optional.empty(),
+              TestEmbeddingService.commandContextWithVectorize.collection())
           .vectorizeUpdateClause(updateClause)
           .subscribe()
           .withSubscriber(UniAssertSubscriber.create())
           .awaitItem()
           .getItem();
-      ;
       assertThat(operation)
           .isInstanceOfSatisfying(
               ReadAndUpdateOperation.class,
@@ -718,9 +720,10 @@ public class CommandResolverWithVectorizerTest {
                 JsonApiException exception = (JsonApiException) e;
                 assertThat(exception.getMessage())
                     .isEqualTo(
-                        "Unable to vectorize data, embedding service not configured for the collection");
+                        "Unable to vectorize data, embedding service not configured for the collection : "
+                            + VECTOR_COMMAND_CONTEXT.collection());
                 assertThat(exception.getErrorCode())
-                    .isEqualTo(ErrorCode.UNAVAILABLE_EMBEDDING_SERVICE);
+                    .isEqualTo(ErrorCode.EMBEDDING_SERVICE_NOT_CONFIGURED);
               });
     }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CommandResolverWithVectorizerTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/resolver/model/impl/CommandResolverWithVectorizerTest.java
@@ -10,6 +10,7 @@ import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.stargate.sgv2.common.testprofiles.NoGlobalResourcesTestProfile;
+import io.stargate.sgv2.jsonapi.api.model.command.CommandContext;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateClause;
 import io.stargate.sgv2.jsonapi.api.model.command.clause.update.UpdateOperator;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.DeleteOneCommand;
@@ -23,6 +24,9 @@ import io.stargate.sgv2.jsonapi.api.model.command.impl.InsertOneCommand;
 import io.stargate.sgv2.jsonapi.api.model.command.impl.UpdateOneCommand;
 import io.stargate.sgv2.jsonapi.api.request.DataApiRequestInfo;
 import io.stargate.sgv2.jsonapi.config.OperationsConfig;
+import io.stargate.sgv2.jsonapi.exception.ErrorCode;
+import io.stargate.sgv2.jsonapi.exception.JsonApiException;
+import io.stargate.sgv2.jsonapi.service.cqldriver.executor.CollectionSettings;
 import io.stargate.sgv2.jsonapi.service.embedding.DataVectorizer;
 import io.stargate.sgv2.jsonapi.service.embedding.DataVectorizerService;
 import io.stargate.sgv2.jsonapi.service.embedding.operation.TestEmbeddingService;
@@ -40,6 +44,7 @@ import io.stargate.sgv2.jsonapi.service.testutil.DocumentUpdaterUtils;
 import io.stargate.sgv2.jsonapi.service.updater.DocumentUpdater;
 import jakarta.inject.Inject;
 import java.util.Optional;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -72,6 +77,21 @@ public class CommandResolverWithVectorizerTest {
 
   @Nested
   class Resolve {
+    protected final String KEYSPACE_NAME = RandomStringUtils.randomAlphanumeric(16);
+    protected final String COLLECTION_NAME = RandomStringUtils.randomAlphanumeric(16);
+    private final CommandContext VECTOR_COMMAND_CONTEXT =
+        new CommandContext(
+            KEYSPACE_NAME,
+            COLLECTION_NAME,
+            new CollectionSettings(
+                COLLECTION_NAME,
+                true,
+                -1,
+                CollectionSettings.SimilarityFunction.COSINE,
+                null,
+                null,
+                null),
+            null);
 
     @Test
     public void find() throws Exception {
@@ -115,6 +135,39 @@ public class CommandResolverWithVectorizerTest {
                 assertThat(find.singleResponse()).isFalse();
                 assertThat(find.vector()).containsExactly(vector);
                 assertThat(find.logicalExpression().comparisonExpressions).isEmpty();
+              });
+    }
+
+    @Test
+    public void findNonVectorize() throws Exception {
+      String json =
+          """
+          {
+            "find": {
+              "sort" : {"$vectorize" : "test data"}
+            }
+          }
+          """;
+
+      FindCommand findOneCommand = objectMapper.readValue(json, FindCommand.class);
+
+      Throwable throwable =
+          dataVectorizerService
+              .vectorize(VECTOR_COMMAND_CONTEXT, findOneCommand)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .getFailure();
+
+      assertThat(throwable)
+          .isInstanceOf(JsonApiException.class)
+          .satisfies(
+              e -> {
+                JsonApiException exception = (JsonApiException) e;
+                assertThat(exception.getMessage())
+                    .isEqualTo(
+                        "Unable to vectorize data, embedding service not configured for the collection");
+                assertThat(exception.getErrorCode())
+                    .isEqualTo(ErrorCode.UNAVAILABLE_EMBEDDING_SERVICE);
               });
     }
 
@@ -257,6 +310,39 @@ public class CommandResolverWithVectorizerTest {
                           assertThat(find.vector()).containsExactly(0.25f, 0.25f, 0.25f);
                           assertThat(find.singleResponse()).isTrue();
                         });
+              });
+    }
+
+    @Test
+    public void updateNonVectorize() throws Exception {
+      String json =
+          """
+                    {
+                      "updateOne": {
+                        "filter" : {"col" : "val"},
+                        "update" : {"$set" : {"location" : "New York"}},
+                        "sort" : {"$vectorize" : "test data"}
+                      }
+                    }
+                    """;
+
+      UpdateOneCommand command = objectMapper.readValue(json, UpdateOneCommand.class);
+      Throwable throwable =
+          dataVectorizerService
+              .vectorize(VECTOR_COMMAND_CONTEXT, command)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .getFailure();
+      assertThat(throwable)
+          .isInstanceOf(JsonApiException.class)
+          .satisfies(
+              e -> {
+                JsonApiException exception = (JsonApiException) e;
+                assertThat(exception.getMessage())
+                    .isEqualTo(
+                        "Unable to vectorize data, embedding service not configured for the collection");
+                assertThat(exception.getErrorCode())
+                    .isEqualTo(ErrorCode.UNAVAILABLE_EMBEDDING_SERVICE);
               });
     }
 
@@ -592,6 +678,49 @@ public class CommandResolverWithVectorizerTest {
                     .isEqualTo(TestEmbeddingService.commandContextWithVectorize);
                 assertThat(op.ordered()).isFalse();
                 assertThat(op.documents()).containsExactly(first, second);
+              });
+    }
+
+    @Test
+    public void insertManyNonVectorize() throws Exception {
+      String json =
+          """
+                  {
+                    "insertMany": {
+                      "documents": [
+                        {
+                          "_id": "1",
+                          "location": "London",
+                          "$vectorize" : "test data"
+                        },
+                        {
+                          "_id": "2",
+                          "location": "New York",
+                          "$vectorize" : "test data"
+                        }
+                      ]
+                    }
+                  }
+                  """;
+
+      InsertManyCommand command = objectMapper.readValue(json, InsertManyCommand.class);
+      final Throwable throwable =
+          dataVectorizerService
+              .vectorize(VECTOR_COMMAND_CONTEXT, command)
+              .subscribe()
+              .withSubscriber(UniAssertSubscriber.create())
+              .getFailure();
+
+      assertThat(throwable)
+          .isInstanceOf(JsonApiException.class)
+          .satisfies(
+              e -> {
+                JsonApiException exception = (JsonApiException) e;
+                assertThat(exception.getMessage())
+                    .isEqualTo(
+                        "Unable to vectorize data, embedding service not configured for the collection");
+                assertThat(exception.getErrorCode())
+                    .isEqualTo(ErrorCode.UNAVAILABLE_EMBEDDING_SERVICE);
               });
     }
 


### PR DESCRIPTION
**What this PR does**:
Error if `$vectorize` is used on table for which the feature is not enabled.

**Which issue(s) this PR fixes**:
Fixes #901 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
