### PR TITLE
Error out when `skip` is used with empty sort `sort: {}` in the `find` command

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/sort/SortClause.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/clause/sort/SortClause.java
@@ -55,4 +55,8 @@ public record SortClause(@Valid List<SortExpression> sortExpressions) {
       }
     }
   }
+
+  public boolean isEmpty() {
+    return sortExpressions.isEmpty();
+  }
 }

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/validation/FindOptionsValidation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/validation/FindOptionsValidation.java
@@ -31,6 +31,15 @@ public class FindOptionsValidation implements ConstraintValidator<CheckFindOptio
       return false;
     }
 
+    if (options.skip() != null && value.sortClause().isEmpty()) {
+      context
+          .buildConstraintViolationWithTemplate(
+              "skip options should be used with non empty sort clause")
+          .addPropertyNode("options.skip")
+          .addConstraintViolation();
+      return false;
+    }
+
     if (options.skip() != null
         && value.sortClause() != null
         && value.sortClause().hasVsearchClause()) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/validation/FindOptionsValidation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/validation/FindOptionsValidation.java
@@ -23,18 +23,9 @@ public class FindOptionsValidation implements ConstraintValidator<CheckFindOptio
     if (options == null) return true;
 
     context.disableDefaultConstraintViolation();
-    if (options.skip() != null && value.sortClause() == null) {
+    if (options.skip() != null && (value.sortClause() == null || value.sortClause().isEmpty())) {
       context
           .buildConstraintViolationWithTemplate("skip options should be used with sort clause")
-          .addPropertyNode("options.skip")
-          .addConstraintViolation();
-      return false;
-    }
-
-    if (options.skip() != null && value.sortClause().isEmpty()) {
-      context
-          .buildConstraintViolationWithTemplate(
-              "skip options should be used with non empty sort clause")
           .addPropertyNode("options.skip")
           .addConstraintViolation();
       return false;

--- a/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/validation/FindOptionsValidation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/api/model/command/validation/FindOptionsValidation.java
@@ -25,7 +25,7 @@ public class FindOptionsValidation implements ConstraintValidator<CheckFindOptio
     context.disableDefaultConstraintViolation();
     if (options.skip() != null && (value.sortClause() == null || value.sortClause().isEmpty())) {
       context
-          .buildConstraintViolationWithTemplate("skip options should be used with sort clause")
+          .buildConstraintViolationWithTemplate("skip option should be used with sort clause")
           .addPropertyNode("options.skip")
           .addConstraintViolation();
       return false;
@@ -35,8 +35,7 @@ public class FindOptionsValidation implements ConstraintValidator<CheckFindOptio
         && value.sortClause() != null
         && value.sortClause().hasVsearchClause()) {
       context
-          .buildConstraintViolationWithTemplate(
-              "skip options should not be used with vector search")
+          .buildConstraintViolationWithTemplate("skip option should not be used with vector search")
           .addPropertyNode("options.skip")
           .addConstraintViolation();
       return false;

--- a/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/exception/mappers/ConstraintViolationExceptionMapper.java
@@ -55,7 +55,7 @@ public class ConstraintViolationExceptionMapper {
     String propertyValueDesc = valueDescription(violation.getInvalidValue(), propertyPath);
     JsonApiException ex =
         ErrorCode.COMMAND_FIELD_INVALID.toApiException(
-            "field '%s' value '%s' not valid. Problem: %s.",
+            "field '%s' value %s not valid. Problem: %s.",
             propertyPath, propertyValueDesc, message);
     return ex.getCommandResultError(ex.getMessage(), Response.Status.OK);
   }
@@ -63,7 +63,7 @@ public class ConstraintViolationExceptionMapper {
   /** Helper method for construction description of value that caused the constraint violation. */
   private static String valueDescription(Object rawValue, String propertyPath) {
     if (rawValue == null) {
-      return "`null`";
+      return "'null'";
     }
     // Some value types never truncated: Numbers, Booleans.
     if (rawValue instanceof Number
@@ -78,23 +78,17 @@ public class ConstraintViolationExceptionMapper {
     }
 
     if (rawValue instanceof FindCommand) {
-      if (propertyPath.contains("options.skip")) {
-        return String.format("%s", ((FindCommand) rawValue).options().skip());
-      }
-      if (propertyPath.contains("options.limit")) {
-        return String.format("%s", ((FindCommand) rawValue).options().limit());
-      }
-      if (propertyPath.contains("options.pageState")) {
-        return String.format("%s", ((FindCommand) rawValue).options().pageState());
+      if (propertyPath.contains("options")) {
+        return String.format("'%s'", ((FindCommand) rawValue).options());
       }
     }
 
     String valueDesc = rawValue.toString();
     if (valueDesc.length() <= MAX_VALUE_LENGTH_TO_INCLUDE) {
-      return String.format("%s", valueDesc);
+      return String.format("'%s'", valueDesc);
     }
     return String.format(
-        "%s...[TRUNCATED from %d to %d characters]",
+        "'%s'...[TRUNCATED from %d to %d characters]",
         valueDesc, valueDesc.length(), MAX_VALUE_LENGTH_TO_INCLUDE);
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommandTest.java
@@ -163,6 +163,30 @@ public class FindCommandTest {
     }
 
     @Test
+    public void invalidOptionsSkipEmptySort() throws Exception {
+      String json =
+          """
+              {
+              "find": {
+                  "filter" : {"username" : "user1"},
+                  "sort": {},
+                  "options" : {
+                    "skip" : 10
+                  }
+                }
+              }
+              """;
+
+      FindCommand command = objectMapper.readValue(json, FindCommand.class);
+      Set<ConstraintViolation<FindCommand>> result = validator.validate(command);
+
+      assertThat(result)
+          .isNotEmpty()
+          .extracting(ConstraintViolation::getMessage)
+          .contains("skip options should be used with non empty sort clause");
+    }
+
+    @Test
     public void invalidOptionsPageStateWithSort() throws Exception {
       String json =
           """

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommandTest.java
@@ -183,7 +183,7 @@ public class FindCommandTest {
       assertThat(result)
           .isNotEmpty()
           .extracting(ConstraintViolation::getMessage)
-          .contains("skip options should be used with non empty sort clause");
+          .contains("skip options should be used with sort clause");
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommandTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/model/command/impl/FindCommandTest.java
@@ -159,7 +159,7 @@ public class FindCommandTest {
       assertThat(result)
           .isNotEmpty()
           .extracting(ConstraintViolation::getMessage)
-          .contains("skip options should be used with sort clause");
+          .contains("skip option should be used with sort clause");
     }
 
     @Test
@@ -183,7 +183,7 @@ public class FindCommandTest {
       assertThat(result)
           .isNotEmpty()
           .extracting(ConstraintViolation::getMessage)
-          .contains("skip options should be used with sort clause");
+          .contains("skip option should be used with sort clause");
     }
 
     @Test
@@ -230,7 +230,7 @@ public class FindCommandTest {
       assertThat(result)
           .isNotEmpty()
           .extracting(ConstraintViolation::getMessage)
-          .contains("skip options should not be used with vector search");
+          .contains("skip option should not be used with vector search");
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CollectionResourceIntegrationTest.java
@@ -99,7 +99,7 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .body(
               "errors[0].message",
               startsWith(
-                  "Request invalid: field 'namespace' value \"7_no_leading_number\" not valid. Problem: must match "));
+                  "Request invalid: field 'namespace' value '7_no_leading_number' not valid. Problem: must match "));
     }
 
     @Test
@@ -126,7 +126,7 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .body(
               "errors[0].message",
               startsWith(
-                  "Request invalid: field 'collection' value \"7_no_leading_number\" not valid. Problem: must match "));
+                  "Request invalid: field 'collection' value '7_no_leading_number' not valid. Problem: must match "));
     }
 
     @Test
@@ -142,7 +142,7 @@ class CollectionResourceIntegrationTest extends AbstractNamespaceIntegrationTest
           .body("errors[0].exceptionClass", is("JsonApiException"))
           .body(
               "errors[0].message",
-              startsWith("Request invalid: field 'command' value `null` not valid"));
+              startsWith("Request invalid: field 'command' value 'null' not valid"));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateNamespaceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/CreateNamespaceIntegrationTest.java
@@ -154,7 +154,7 @@ class CreateNamespaceIntegrationTest extends AbstractNamespaceIntegrationTestBas
           .body(
               "errors[0].message",
               is(
-                  "Request invalid: field 'command.name' value `null` not valid. Problem: must not be null."));
+                  "Request invalid: field 'command.name' value 'null' not valid. Problem: must not be null."));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteCollectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/DeleteCollectionIntegrationTest.java
@@ -121,7 +121,7 @@ class DeleteCollectionIntegrationTest extends AbstractNamespaceIntegrationTestBa
           .body(
               "errors[0].message",
               is(
-                  "Request invalid: field 'command.name' value `null` not valid. Problem: must not be null."));
+                  "Request invalid: field 'command.name' value 'null' not valid. Problem: must not be null."));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -1990,7 +1990,7 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .body(
               "errors[0].message",
               is(
-                  "Request invalid: field 'command.options.skip' value '10' not valid. Problem: skip options should be used with sort clause."));
+                  "Request invalid: field 'command.options.skip' value '10' not valid. Problem: skip option should be used with sort clause."));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindIntegrationTest.java
@@ -1962,6 +1962,36 @@ public class FindIntegrationTest extends AbstractCollectionIntegrationTestBase {
           .body("data.documents", hasSize(1))
           .body("data.documents", containsInAnyOrder(jsonEquals(expected)));
     }
+
+    @Test
+    public void invalidOptionsSkipNoSort() throws Exception {
+      String json =
+          """
+              {
+              "find": {
+                  "filter" : {"username" : "user1"},
+                  "options" : {
+                    "skip" : 10
+                  }
+                }
+              }
+              """;
+      given()
+          .header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, getAuthToken())
+          .contentType(ContentType.JSON)
+          .body(json)
+          .when()
+          .post(CollectionResource.BASE_PATH, namespaceName, collectionName)
+          .then()
+          .statusCode(200)
+          .body("errors", is(notNullValue()))
+          .body("errors", hasSize(1))
+          .body("errors[0].errorCode", is("COMMAND_FIELD_INVALID"))
+          .body(
+              "errors[0].message",
+              is(
+                  "Request invalid: field 'command.options.skip' value '10' not valid. Problem: skip options should be used with sort clause."));
+    }
   }
 
   @Nested

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneIntegrationTest.java
@@ -792,7 +792,7 @@ public class FindOneIntegrationTest extends AbstractCollectionIntegrationTestBas
           .body(
               "errors[0].message",
               startsWith(
-                  "Request invalid: field 'collection' value \"table,rate=100\" not valid. Problem:"))
+                  "Request invalid: field 'collection' value 'table,rate=100' not valid. Problem:"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
           .body("errors[0].errorCode", is("COMMAND_FIELD_INVALID"));
     }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/GeneralResourceIntegrationTest.java
@@ -93,7 +93,7 @@ class GeneralResourceIntegrationTest {
           .body(
               "errors[0].message",
               startsWith(
-                  "Request invalid: field 'command' value `null` not valid. Problem: must not be null"));
+                  "Request invalid: field 'command' value 'null' not valid. Problem: must not be null"));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/InsertIntegrationTest.java
@@ -512,7 +512,7 @@ public class InsertIntegrationTest extends AbstractCollectionIntegrationTestBase
           .body(
               "errors[0].message",
               startsWith(
-                  "Request invalid: field 'command.document' value `null` not valid. Problem: must not be null"));
+                  "Request invalid: field 'command.document' value 'null' not valid. Problem: must not be null"));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResourceIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/NamespaceResourceIntegrationTest.java
@@ -96,7 +96,7 @@ class NamespaceResourceIntegrationTest extends AbstractNamespaceIntegrationTestB
           .body(
               "errors[0].message",
               startsWith(
-                  "Request invalid: field 'namespace' value \"7_no_leading_number\" not valid. Problem: must match "));
+                  "Request invalid: field 'namespace' value '7_no_leading_number' not valid. Problem: must match "));
     }
 
     @Test
@@ -113,7 +113,7 @@ class NamespaceResourceIntegrationTest extends AbstractNamespaceIntegrationTestB
           .body(
               "errors[0].message",
               startsWith(
-                  "Request invalid: field 'command' value `null` not valid. Problem: must not be null"));
+                  "Request invalid: field 'command' value 'null' not valid. Problem: must not be null"));
     }
   }
 }

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateManyIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateManyIntegrationTest.java
@@ -675,7 +675,7 @@ public class UpdateManyIntegrationTest extends AbstractCollectionIntegrationTest
           .body(
               "errors[0].message",
               is(
-                  "Request invalid: field 'command.updateClause' value `null` not valid. Problem: must not be null."));
+                  "Request invalid: field 'command.updateClause' value 'null' not valid. Problem: must not be null."));
     }
   }
 

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/UpdateOneIntegrationTest.java
@@ -2043,7 +2043,7 @@ public class UpdateOneIntegrationTest extends AbstractCollectionIntegrationTestB
           .body(
               "errors[0].message",
               is(
-                  "Request invalid: field 'command.updateClause' value `null` not valid. Problem: must not be null."));
+                  "Request invalid: field 'command.updateClause' value 'null' not valid. Problem: must not be null."));
     }
 
     @Test

--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/VectorSearchIntegrationTest.java
@@ -793,7 +793,7 @@ public class VectorSearchIntegrationTest extends AbstractNamespaceIntegrationTes
           .body("errors[0].errorCode", is("COMMAND_FIELD_INVALID"))
           .body("errors[0].exceptionClass", is("JsonApiException"))
           .body(
-              "errors[0].message", endsWith("skip options should not be used with vector search."));
+              "errors[0].message", endsWith("skip option should not be used with vector search."));
     }
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Error out when `skip` is used with empty sort `sort={}` in the `find` command

**Which issue(s) this PR fixes**:
Fixes #917 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
