### PR TITLE
Fix #956: add tests to ensure $objectId/$uuid work with projections

### DIFF
--- a/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneWithProjectionIntegrationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/api/v1/FindOneWithProjectionIntegrationTest.java
@@ -287,9 +287,11 @@ public class FindOneWithProjectionIntegrationTest extends AbstractCollectionInte
               "data.document",
               jsonEquals(
                   """
+                      {
                         "_id": "ext1",
                         "username": "user1",
                         "enabled": true
+                      }
                                         """));
     }
 


### PR DESCRIPTION
**What this PR does**:

Adds ITs to verify that Projections can refer to `$uuid` / `$objectId` valued properties

**Which issue(s) this PR fixes**:
Fixes #956

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
