### PR TITLE
Implement #922: allow ObjectId/UUID auto-generation

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSettings.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSettings.java
@@ -45,6 +45,11 @@ public record CollectionSettings(
     return EMPTY;
   }
 
+  public CollectionSettings withIdType(IdType idType) {
+    return new CollectionSettings(
+        collectionName, new IdConfig(idType), vectorConfig, indexingConfig);
+  }
+
   public record IdConfig(IdType idType) {
     public static IdConfig defaultIdConfig() {
       return new IdConfig(IdType.UNDEFINED);

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSettingsV1Reader.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/cqldriver/executor/CollectionSettingsV1Reader.java
@@ -29,13 +29,15 @@ public class CollectionSettingsV1Reader implements CollectionSettingsReader {
       indexingConfig = CollectionSettings.IndexingConfig.fromJson(indexing);
     }
     // construct collectionSettings idConfig, default idType as uuid
-    CollectionSettings.IdConfig idConfig = CollectionSettings.IdConfig.defaultIdConfig();
+    final CollectionSettings.IdConfig idConfig;
     JsonNode idConfigNode = collectionOptionsNode.path(TableCommentConstants.DEFAULT_ID_KEY);
     // should always have idConfigNode in table comment since schema v1
-    if (!idConfigNode.isMissingNode() && idConfigNode.has("type")) {
+    if (idConfigNode.has("type")) {
       idConfig =
           new CollectionSettings.IdConfig(
               CollectionSettings.IdType.fromString(idConfigNode.get("type").asText()));
+    } else {
+      idConfig = CollectionSettings.IdConfig.defaultIdConfig();
     }
 
     return new CollectionSettings(collectionName, idConfig, vectorConfig, indexingConfig);


### PR DESCRIPTION
**What this PR does**:

Adds support for configurable auto-generation of ids of type `ObjectId` and (various flavors of) `java.util.UUID`.

**Which issue(s) this PR fixes**:
Fixes #922

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
